### PR TITLE
replace pixelmatch with blazediff

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Testaro uses:
 - [Playwright](https://playwright.dev/) to launch browsers, perform user actions in them, and perform tests
 - [playwright-extra](https://www.npmjs.com/package/playwright-extra) and [puppeteer-extra-plugin-stealth](https://www.npmjs.com/package/puppeteer-extra-plugin-stealth) to make a Playwright-controlled browser more indistinguishable from a human-operated browser and thus make their requests more likely to succeed
 - [playwright-dompath](https://www.npmjs.com/package/playwright-dompath) to retrieve XPaths of elements
-- [pixelmatch](https://www.npmjs.com/package/pixelmatch) to measure motion
+- [BlazeDiff](https://blazediff.dev/) to measure motion
 
 Testaro performs tests of these _tools_:
 

--- a/UPGRADES.md
+++ b/UPGRADES.md
@@ -54,7 +54,7 @@ I'll quickly scan for module patterns and JSON imports across the repo to tailor
   - Strategy for optional properties and progressive enrichment during execution.
 
 - **3rd‑party types and augmentations**
-  - Verify/choose type packages for `playwright`, `@siteimprove/alfa-*`, `axe-playwright`, `@qualweb/*`, `accessibility-checker`, `playwright-dompath`, `pixelmatch`. Plan fallbacks if defs are missing.
+  - Verify/choose type packages for `playwright`, `@siteimprove/alfa-*`, `axe-playwright`, `@qualweb/*`, `accessibility-checker`, `playwright-dompath`. Plan fallbacks if defs are missing.
   - Decide on module augmentation vs casting for custom fields (e.g., `page.browserID` assignment requires augmenting `playwright.Page` or casting).
 
 - **Dynamic loading patterns**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "testaro",
-  "version": "65.1.1",
+  "version": "66.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "testaro",
-      "version": "65.1.1",
+      "version": "66.0.0",
       "license": "MIT",
       "dependencies": {
+        "@blazediff/core": "*",
         "@qualweb/act-rules": "*",
         "@qualweb/best-practices": "*",
         "@qualweb/core": "*",
@@ -22,11 +23,11 @@
         "aslint-testaro": "*",
         "axe-playwright": "*",
         "dotenv": "*",
-        "pixelmatch": "*",
         "playwright": "*",
         "playwright-dompath": "*",
         "playwright-extra": "*",
         "playwright-extra-plugin-stealth": "*",
+        "pngjs": "*",
         "puppeteer-extra-plugin-stealth": "*",
         "vnu-jar": "*"
       },
@@ -58,6 +59,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@blazediff/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
+      "license": "MIT"
     },
     "node_modules/@cliqz/adblocker": {
       "version": "1.34.0",
@@ -5274,18 +5281,6 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
-    },
-    "node_modules/pixelmatch": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.1.0.tgz",
-      "integrity": "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==",
-      "license": "ISC",
-      "dependencies": {
-        "pngjs": "^7.0.0"
-      },
-      "bin": {
-        "pixelmatch": "bin/pixelmatch"
-      }
     },
     "node_modules/playwright": {
       "version": "1.58.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/jrpool/testaro#readme",
   "dependencies": {
+    "@blazediff/core": "*",
     "@qualweb/core": "*",
     "@qualweb/act-rules": "*",
     "@qualweb/wcag-techniques": "*",
@@ -43,7 +44,6 @@
     "aslint-testaro": "*",
     "axe-playwright": "*",
     "dotenv": "*",
-    "pixelmatch": "*",
     "playwright": "*",
     "playwright-dompath": "*",
     "playwright-extra": "*",

--- a/testaro/motion.js
+++ b/testaro/motion.js
@@ -19,7 +19,7 @@ const fs = require('fs/promises');
 // Module to get operating-system properties.
 const os = require('os');
 // Module to compare screenshots.
-const blazediff = require('blazediff/core').diff;
+const blazediff = require('@blazediff/core').diff;
 // Module to parse PNGs.
 const {PNG} = require('pngjs');
 

--- a/testaro/motion.js
+++ b/testaro/motion.js
@@ -19,7 +19,7 @@ const fs = require('fs/promises');
 // Module to get operating-system properties.
 const os = require('os');
 // Module to compare screenshots.
-const pixelmatch = require('pixelmatch').default;
+const blazediff = require('blazediff/core').diff;
 // Module to parse PNGs.
 const {PNG} = require('pngjs');
 
@@ -60,7 +60,7 @@ exports.reporter = async page => {
       // Otherwise, i.e. if their dimensions are identical:
       else {
         // Get the count of differing pixels between the shots.
-        const pixelChanges = pixelmatch(shoot0PNG.data, shoot1PNG.data, null, width, height);
+        const pixelChanges = blazediff(shoot0PNG.data, shoot1PNG.data, null, width, height);
         // Get the ratio of differing to all pixels as a percentage.
         const changePercent = Math.round(100 * pixelChanges / (width * height));
         // Free the memory used by screenshots.


### PR DESCRIPTION
This PR implements PR 54 by Teimur Gasanov against `cvs-health/testaro`. The PR is adapted to this fork, where `pixelmatch` was used in `testaro/motion` instead of in `procs/visChange`.