### PR TITLE
Add explicit time limits for aslint, htmlcs, nuVal, and qualWeb

### DIFF
--- a/run.js
+++ b/run.js
@@ -81,8 +81,12 @@ const errorWords = [
 // Time limits on tools, accounting for page reloads by 6 Testaro tests.
 const timeLimits = {
   alfa: 20,
+  aslint: 45,
   ed11y: 30,
+  htmlcs: 30,
   ibm: 30,
+  nuVal: 30,
+  qualWeb: 45,
   testaro: 150 + Math.round(6 * waits / 1000)
 };
 // Timeout multiplier.


### PR DESCRIPTION
## Summary
- Adds explicit time limits for tools that currently default to 15 seconds
- Prevents premature timeouts on complex pages

## Changes
| Tool | New Timeout | Rationale |
|------|-------------|-----------|
| aslint | 45s | Runs many rules, needs time for complex DOMs |
| htmlcs | 30s | Similar complexity to ibm |
| nuVal | 30s | Makes external HTTP validation calls |
| qualWeb | 45s | Comprehensive ruleset |

## Problem
When scanning complex pages (e.g., https://pope.tech/), aslint consistently times out at 15 seconds while other tools with explicit time limits complete successfully. This results in 0 aslint instances being collected and an error message:

```
>>>> test aslint
ERROR: Timed out at 15 seconds
```

## Backwards Compatibility
- The `TIMEOUT_MULTIPLIER` environment variable still applies to these values
- Users who relied on the 15-second default can set `TIMEOUT_MULTIPLIER=0.33` to restore similar behavior

## Testing
Tested against https://pope.tech/ - aslint now completes successfully and returns results.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)