### PR TITLE
Add shoot action for inline full-page screenshots

### DIFF
--- a/actSpecs.js
+++ b/actSpecs.js
@@ -121,6 +121,14 @@ exports.actSpecs = {
         what: [true, 'string', 'hasLength', 'substring of option text content']
       }
     ],
+    shoot: [
+      'Save a full-page screenshot to <tmpdir>/testaro-shoot-<which>.png',
+      {
+        which: [true, 'string', 'hasLength', 'screenshot label, used in the filename'],
+        exclusion: [false, 'string', 'hasLength', 'CSS selector for an element to mask'],
+        what: [false, 'string', 'hasLength', 'comment']
+      }
+    ],
     state: [
       'Wait until the page reaches a load state',
       {

--- a/procs/doActs.js
+++ b/procs/doActs.js
@@ -25,6 +25,8 @@ const {fork} = require('child_process');
 const os = require('os');
 // Function to prune a catalog.
 const {pruneCatalog} = require('./catalog');
+// Function to take a full-page screenshot.
+const {shoot} = require('./shoot');
 // Module to handle file system operations.
 const fs = require('fs/promises');
 const httpClient = require('http');
@@ -701,6 +703,14 @@ exports.doActs = async (report, opts = {}) => {
               console.log(`ERROR making all elements visible (${error.message})`);
               act.result.success = false;
             });
+          }
+          // Otherwise, if the act is a screenshot:
+          else if (type === 'shoot') {
+            const exclusion = act.exclusion ? page.locator(act.exclusion) : null;
+            const pngPath = await shoot(page, act.which, {exclusion});
+            act.result = pngPath
+              ? {success: true, path: pngPath}
+              : {success: false, prevented: true};
           }
           // Otherwise, if the act is a move:
           else if (moves[type]) {

--- a/procs/shoot.js
+++ b/procs/shoot.js
@@ -6,6 +6,13 @@
 /*
   shoot
   Makes and saves as a PNG buffer file a full-page screenshot and returns the file path.
+
+  Call shape:
+    shoot(page, label, options?)
+      label:   string|number used in the saved filename (testaro-shoot-<label>.png).
+      options: optional object:
+        exclusion: a Playwright Locator to mask in the screenshot.
+        dir:       output directory (defaults to the OS temp dir).
 */
 
 // IMPORTS
@@ -40,9 +47,11 @@ const screenShot = async (page, exclusion = null) => {
     return '';
   });
 };
-exports.shoot = async (page, index) => {
+exports.shoot = async (page, label, options = {}) => {
+  const exclusion = options.exclusion || null;
+  const dir = options.dir || tmpDir;
   // Make and get a screenshot as a buffer.
-  let shot = await screenShot(page);
+  let shot = await screenShot(page, exclusion);
   // If it succeeded:
   if (shot.length) {
     // Get the screenshot as an object representation of a PNG image.
@@ -54,8 +63,8 @@ exports.shoot = async (page, index) => {
     if (global.gc) {
       global.gc();
     }
-    const fileName = `testaro-shoot-${index}.png`;
-    const pngPath = path.join(tmpDir, fileName);
+    const fileName = `testaro-shoot-${label}.png`;
+    const pngPath = path.join(dir, fileName);
     // Save the PNG buffer.
     await fs.writeFile(pngPath, pngBuffer);
     // Return the result.

--- a/procs/shoot.js
+++ b/procs/shoot.js
@@ -9,7 +9,11 @@
 
   Call shape:
     shoot(page, label, options?)
-      label:   string|number used in the saved filename (testaro-shoot-<label>.png).
+      label:   string|number used in the saved filename. Sanitized to
+               testaro-shoot-<safe>.png — characters outside [A-Za-z0-9._-]
+               collapse to '_', leading/trailing dots and underscores are
+               stripped, length is capped at 100, and an empty result becomes
+               'unnamed'.
       options: optional object:
         exclusion: a Playwright Locator to mask in the screenshot.
         dir:       output directory (defaults to the OS temp dir).
@@ -29,6 +33,22 @@ const {PNG} = require('pngjs');
 const tmpDir = os.tmpdir();
 
 // FUNCTIONS
+
+// Coerces a label into a filesystem-safe string. Runs of any character outside
+// [A-Za-z0-9._-] collapse to one underscore; leading and trailing dots and
+// underscores are stripped (no hidden files, no traversal); capped at 100
+// characters; falls back to 'unnamed' if nothing usable remains.
+const sanitizeLabel = (label) => {
+  const raw = String(label);
+  const cleaned = raw
+    .replace(/[^A-Za-z0-9._-]+/g, '_')
+    .replace(/^[._]+|[._]+$/g, '')
+    .slice(0, 100) || 'unnamed';
+  if (cleaned !== raw) {
+    console.log(`>> shoot: label sanitized from "${raw}" to "${cleaned}"`);
+  }
+  return cleaned;
+};
 
 // Creates and returns a screenshot.
 const screenShot = async (page, exclusion = null) => {
@@ -63,7 +83,7 @@ exports.shoot = async (page, label, options = {}) => {
     if (global.gc) {
       global.gc();
     }
-    const fileName = `testaro-shoot-${label}.png`;
+    const fileName = `testaro-shoot-${sanitizeLabel(label)}.png`;
     const pngPath = path.join(dir, fileName);
     // Save the PNG buffer.
     await fs.writeFile(pngPath, pngBuffer);

--- a/validation/jobs/todo/240101T1300-shoot-example.json
+++ b/validation/jobs/todo/240101T1300-shoot-example.json
@@ -1,0 +1,46 @@
+{
+  "id": "240101T1300-shoot-example",
+  "what": "Demonstrate the shoot action: full-page screenshots interleaved with scripted steps",
+  "strict": true,
+  "timeLimit": 30,
+  "acts": [
+    {
+      "type": "launch",
+      "which": "chromium",
+      "url": "https://example.edu/",
+      "what": "Chromium browser"
+    },
+    {
+      "type": "shoot",
+      "which": "before",
+      "what": "Snapshot the landing page before any interaction"
+    },
+    {
+      "type": "shoot",
+      "which": "before-masked",
+      "exclusion": "header",
+      "what": "Same view with the page header masked out"
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "rules": [
+        "y",
+        "bulk"
+      ]
+    },
+    {
+      "type": "shoot",
+      "which": "after-tests",
+      "what": "Snapshot the page after Testaro tests have run"
+    }
+  ],
+  "sources": {},
+  "standard": "only",
+  "observe": false,
+  "sendReportTo": "http://localhost:3007/api",
+  "timeStamp": "240101T1300",
+  "creationTimeStamp": "240101T1300"
+}


### PR DESCRIPTION
## Summary

Adds a top-level `shoot` action so a job script can take full-page screenshots **interleaved** with other acts, without piggy-backing on the Testaro tool's `shoot0` / `shoot1` rules.

Today, capturing a screenshot mid-script requires inserting a `test` act with `which: "testaro"` and `rules: ["shoot0"]` (or `shoot1`). That has three limitations:

- Hard cap of two screenshots per job (filenames are hard-coded by index 0/1).
- Each capture forks a child process via `doTestAct`, adding latency between scripted steps.
- It's an undocumented use of the testaro tool rather than a first-class scripting capability.

This PR keeps `shoot0`/`shoot1` working unchanged and adds a `shoot` etc-action that runs in the parent process on the live `page`.

## Usage

```json
{ "type": "url",   "which": "https://example.edu/" },
{ "type": "shoot", "which": "before",        "what": "before any interaction" },
{ "type": "shoot", "which": "before-masked", "exclusion": "header" },
{ "type": "click", "which": "Sign in" },
{ "type": "shoot", "which": "after-click" }
```

Files are saved to `<os.tmpdir()>/testaro-shoot-<which>.png`. The optional `exclusion` field is a CSS selector that becomes a Playwright `Locator` and is passed through as a screenshot `mask`.

The act result is `{success: true, path: "<absolute-path>"}` on success, or `{success: false, prevented: true}` if Playwright's `page.screenshot()` rejected.

## Changes

- **`procs/shoot.js`** — signature is now `shoot(page, label, options?)` with `options.exclusion` (a Playwright `Locator`) and `options.dir`. Existing callers (`shoot0`, `shoot1`) pass an integer index, which still produces `testaro-shoot-0.png` / `testaro-shoot-1.png` in `tmpdir` exactly as before — full backward compatibility.
- **`actSpecs.js`** — registers the new `etc` action with required `which` (label used in the filename), optional `exclusion` (CSS selector for a mask), and optional `what`.
- **`procs/doActs.js`** — dispatches `type === 'shoot'` alongside `reveal`, building a `Locator` from `act.exclusion` when provided.
- **`validation/jobs/todo/240101T1300-shoot-example.json`** — sample job exercising before/masked/after captures around a `test` act.

## Why a top-level action vs. expanding `shoot0`/`shoot1`

A `test` act is forked into `doTestAct`, which serializes the local report and round-trips it through a child process. For a pure-Playwright operation like `page.screenshot()`, that boundary is unnecessary and forces the screenshot to run on a separately-launched page rather than the live one the script just manipulated. An `etc` action runs directly on the same `page` object that handled the previous `click` / `reveal` / `wait`, which is the right semantic for "capture what's on screen *now*".

## Test plan

- [ ] `node --check` passes on the three edited files (verified locally).
- [ ] Sample job runs end-to-end against a real target and produces three PNGs in tmpdir.
- [ ] Existing `shoot0` / `shoot1` test rules continue to produce `testaro-shoot-0.png` / `testaro-shoot-1.png` (signature is backward-compatible).
- [ ] Validation suite (`npm test`) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)