### PR TITLE
Skip launches against URLs a prior act proved unreachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ As Testaro performs a job, information about the job as a whole is inserted into
 
 Testaro inserts the `jobData` property into every job, but inserts the `catalog` property only into jobs that instruct Testaro to produce standard results.
 
+The `jobData.unreachableURLs` property is an object keyed by URL. When a test act exhausts its launch retries against a URL (browser launch failure, navigation timeout, etc.), Testaro records the URL there. Subsequent test acts in the same job that target the same URL are marked prevented without forking a new child process, so an unreachable target costs one act's retries rather than one set of retries per engine.
+
 #### Catalog
 
 Whenever a job requires any testing and requires the production of standard results, Testaro inserts a _catalog_ into the report before calling any of the testing tools. The catalog is an inventory of HTML elements in the DOM of the target.

--- a/procs/doActs.js
+++ b/procs/doActs.js
@@ -382,6 +382,33 @@ exports.doActs = async (report, opts = {}) => {
       else if (type === 'test') {
         // Add a description of the tool to the act.
         act.what = tools[act.which];
+        // Determine the URL this test act will visit. Same precedence the
+        // forked child (procs/doTestAct.js) applies: act-level override
+        // first, then the job-level target.
+        const actTargetURL = (act.launch && act.launch.target && act.launch.target.url)
+          || localReport.target.url;
+        // If a prior test act in this job already exhausted launch.js's
+        // retry loop against this URL, the URL is unreachable for the
+        // job's lifetime. Mark this act prevented inline and skip the
+        // child fork — re-running the same retry loop just burns time
+        // (3 retries with backoff × N remaining engines).
+        const priorFailure = localReport.jobData.unreachableURLs
+          && localReport.jobData.unreachableURLs[actTargetURL];
+        if (priorFailure) {
+          const skipMessage = `Target URL previously unreachable; skipped (${priorFailure})`;
+          console.log(`>>>> test ${act.which} skipped: ${skipMessage}`);
+          act.startTime = Date.now();
+          act.data ??= {};
+          act.data.prevented = true;
+          act.data.error = skipMessage;
+          act.result ??= {};
+          act.result.success = false;
+          act.result.error = skipMessage;
+          localReport.jobData.preventions[act.which] = skipMessage;
+          localReport.jobData.toolTimes[act.which] ??= 0;
+          actCount++;
+          continue;
+        }
         // Get the start time of the act.
         const startTime = Date.now();
         // Add it to the act.
@@ -505,6 +532,23 @@ exports.doActs = async (report, opts = {}) => {
         }
         // Get the (usually revised) act.
         act = acts[actIndex];
+        // If this act was prevented because launch.js exhausted its
+        // retries against actTargetURL, remember the URL so subsequent
+        // test acts targeting it can skip the fork. Recognize the two
+        // canonical launch-failure error strings:
+        //   - 'No page' — set by doTestAct.js when launch() returned null
+        //   - starts with 'ERROR: No retries left' — set by launch.js
+        // Tool-internal preventions (e.g. axe choking on bad markup) use
+        // different error strings, so they don't poison this set.
+        if (act.data && act.data.prevented) {
+          const e = act.data.error || '';
+          const isLaunchFailure = e === 'No page'
+            || e.startsWith('ERROR: No retries left');
+          if (isLaunchFailure) {
+            localReport.jobData.unreachableURLs ??= {};
+            localReport.jobData.unreachableURLs[actTargetURL] ??= e;
+          }
+        }
         // Add the elapsed time of the tool to the local report.
         const time = Math.round((Date.now() - startTime) / 1000);
         const {toolTimes} = localReport.jobData;

--- a/run.js
+++ b/run.js
@@ -72,7 +72,13 @@ exports.doJob = async (job, opts = {}) => {
       presses: 0,
       amountRead: 0,
       toolTimes: {},
-      preventions: {}
+      preventions: {},
+      // URLs that a launch attempt has already proved unreachable for this
+      // job. Populated by doActs after a test act exhausts launch.js's retry
+      // loop. Subsequent test acts targeting the same URL skip the fork
+      // instead of re-running the same retry loop. Keyed by URL → error
+      // message captured at first failure.
+      unreachableURLs: {}
     };
     process.on('message', message => {
       if (message === 'interrupt') {


### PR DESCRIPTION
Fixes #8.

## Problem

When a test act's launch + navigation fails, `procs/launch.js` retries up to 3 times with backoff. If all 3 retries fail, the act exits with `data.prevented: true, data.error: 'No page'`. **The job is not aborted**, so the next test act in the same job forks a fresh child process and runs the same 3-retry loop against the same URL.

For an 8-engine job against an unreachable target, that's up to 24 launch attempts when 3 would have been enough to establish unreachability. The log of a real run looks like:

```
ERROR launching or navigating (...)
WARNING: Waiting 1 sec. before retrying (retries left: 2)
ERROR launching or navigating (...)
WARNING: Waiting 1 sec. before retrying (retries left: 1)
ERROR launching or navigating (...)
[next act spawns its own child; same retry triplet repeats]
[and again, and again, …]
```

See #8 for the full diagnosis.

## Fix

Track failed URLs at the job level. Subsequent acts targeting the same URL skip the fork and report the prior failure.

### Changes

- **`run.js`**: initialize `jobData.unreachableURLs = {}` (object keyed by URL → error message).
- **`procs/doActs.js`**:
  - After a test act ends with `data.prevented` and one of two canonical launch-failure error strings (`'No page'` set by `doTestAct.js`, or `'ERROR: No retries left…'` set by `launch.js`'s `addError`), record the act's effective target URL in `unreachableURLs`.
  - Before forking a child for a test act, check whether its effective target URL (`act.launch?.target?.url || report.target.url` — same precedence the child uses) is already in the set. If so, mark the act `prevented: true` inline with a descriptive error message that carries through the original failure reason, increment `actCount`, and `continue` — no child fork, no fresh retry loop.
- **`README.md`**: document the new `jobData.unreachableURLs` field.

### Tool-prevention vs launch-failure

The skip set is populated only when `act.data.error` is `'No page'` or starts with `'ERROR: No retries left'`. Tool-internal preventions (axe choking on malformed markup, qualWeb rejecting unsupported content, etc.) use different error strings, so they don't poison the set — a later engine that handles the page differently still gets its turn.

### Per-URL granularity

Acts with an explicit `act.launch.target.url` override pointing somewhere reachable still launch normally. The skip set is keyed by the exact URL that failed; mixed-URL jobs are unaffected.

## Backwards compatibility

- New field `jobData.unreachableURLs`. Empty `{}` when no launches fail.
- Job-input fields unchanged.
- Per-act semantics (3 retries with backoff) unchanged for the *first* act to encounter a given URL.

## Test notes

`node --check` clean on the three modified files. End-to-end verification against the same scenario that motivated #7 (WebKit launches failing because of the stealth-arg incompatibility): with #7 applied, WebKit launches succeed; with #8/this PR applied on top, an intentionally-unreachable target shows one act's worth of retries plus 7 fast-skip messages, instead of 8 × 3 launch attempts.

Happy to adjust the error-string heuristic if you'd prefer a more specific signal (e.g. a structured `act.data.cause: 'launch'` field) or a more conservative one.