### PR TITLE
tests/testaro: fix exclude-list ruleSpec dispatch (silently ran zero rules)

### DIFF
--- a/tests/testaro.js
+++ b/tests/testaro.js
@@ -504,9 +504,14 @@ exports.reporter = async (page, report, actIndex) => {
     // Wait 1 second to prevent out-of-order logging with granular reporting.
     await wait(1000);
     // Get the rules to be tested for and their execution order.
+    // 'y' = include-list: run exactly the rules in ruleSpec.slice(1).
+    // 'n' = exclude-list: run all defaultOn rules EXCEPT those in ruleSpec.slice(1).
+    const excludeIDs = ruleSpec.slice(1);
     const jobRuleIDs = ruleSpec[0] === 'y'
-    ? ruleSpec.slice(1)
-    : allRules.filter(rule => rule.defaultOn && ! allRuleIDs.includes(rule.id));
+    ? excludeIDs
+    : allRules
+      .filter(rule => rule.defaultOn && ! excludeIDs.includes(rule.id))
+      .map(rule => rule.id);
     const jobRules = allRules.filter(rule => jobRuleIDs.includes(rule.id));
     let justPrevented = false;
     // For each rule to be tested for:


### PR DESCRIPTION
Closes [jrpool/testaro#11](https://github.com/jrpool/testaro/issues/11).

The `ruleSpec` validator at `tests/testaro.js:499-503` accepts both `['y', ...includeIDs]` and `['n', ...excludeIDs]` shapes, but the dispatch a few lines below only works for the include case. The exclude branch has two compounding bugs that combine to a silent no-op:

```js
const jobRuleIDs = ruleSpec[0] === 'y'
  ? ruleSpec.slice(1)
  : allRules.filter(rule => rule.defaultOn && ! allRuleIDs.includes(rule.id));
// …
const jobRules = allRules.filter(rule => jobRuleIDs.includes(rule.id));
```

1. **Wrong set in the predicate.** `allRuleIDs` is constructed two lines earlier as the full ID list across every rule. `! allRuleIDs.includes(rule.id)` is therefore always `false` for any real rule, so the filter returns `[]`. The variable the author meant to reference is `ruleSpec.slice(1)` — the user's exclude list.
2. **Wrong element type.** The `'y'` branch produces IDs (`ruleSpec.slice(1)`), but the `'n'` branch produces rule *objects* (`allRules.filter(...)`). The next line, `allRules.filter(rule => jobRuleIDs.includes(rule.id))`, compares IDs against either IDs or objects depending on which branch ran — for the `'n'` branch every comparison is `false`.

Net effect: any job passing `rules: ['n', ...]` silently runs zero rules and returns `totals: [0, 0, 0, 0]`. The validator's acceptance of the shape gives no hint that the dispatch is broken.

The fix names the exclude set explicitly and produces IDs from both branches.

**Real-world motivation:** the rules `shoot0` / `shoot1` (full-page screenshot captures to `/tmp`) have a 4 s per-rule screenshot timeout and a 5 s rule timeout. On lazy-loading pages they routinely time out and produce noisy `ERROR: Test of testaro rule shoot0 timed out` lines while consuming seconds per URL per browser configuration. Callers that don't consume the screenshots want to write `rules: ['n', 'shoot0', 'shoot1']` to exclude them — that was the use case that surfaced this bug.

No new test fixtures touched; the existing validator continues to accept both shapes, only the dispatch changes.