### PR TITLE
procs/nu: guard result.messages so curate() survives empty W3C responses

### DIFF
--- a/procs/nu.js
+++ b/procs/nu.js
@@ -58,6 +58,14 @@ exports.curate = async (data, nuData, rules) => {
     const nuDataClean = JSON.parse(nuDataValid);
     result = nuDataClean;
   }
+  // Guarantee result.messages is always an iterable. The W3C API returns
+  // {messages: [...]} on success, but on HTTP errors (e.g. 502 for bodies
+  // >~80 kB) or fetch failures nuVal leaves nuData={}, so result becomes {}
+  // and `result.messages.filter(...)` below throws
+  // "Cannot read properties of undefined (reading 'filter')".
+  if (result && ! Array.isArray(result.messages)) {
+    result.messages = [];
+  }
   // If there is a result and rules were specified:
   if (result && rules && Array.isArray(rules) && rules.length) {
     // Remove all messages except those specified.


### PR DESCRIPTION
Closes [jrpool/testaro#12](https://github.com/jrpool/testaro/issues/12).

When the W3C validator returns non-2xx (HTTP 502 for bodies >~80 kB) or `fetch` throws, `tests/nuVal.js` leaves `nuData = {}` and still calls `curate(data, nuData, rules)`. `curate` assigns `result = {}` and the unconditional `result.messages.filter(...)` at the end throws `Cannot read properties of undefined (reading 'filter')`. The act gets logged as `Test act nuVal failed (Cannot read…)` with the real cause (HTTP 502, network error, etc.) discarded.

Normalizing `result.messages` to `[]` when missing lets `data.prevented` / `data.error` propagate as the existing contract intends. `tests/nuVnu.js` shares the same `curate` and is fixed by the same patch.