### PR TITLE
tests/nuVal: allow overriding validator URL via TESTARO_NU_URL

### DIFF
--- a/tests/nuVal.js
+++ b/tests/nuVal.js
@@ -55,7 +55,11 @@ exports.reporter = async (page, report, actIndex) => {
       },
       body: testTarget
     };
-    const nuURL = 'https://validator.w3.org/nu/?parser=html&out=json';
+    // Override target for self-hosted Nu Html Checker instances (Docker
+    // image ghcr.io/validator/validator or equivalent). Defaults to the
+    // public W3C service, which 502s on bodies >~80 kB.
+    const nuURL = process.env.TESTARO_NU_URL
+      || 'https://validator.w3.org/nu/?parser=html&out=json';
     let nuData = {};
     let nuResponse = new Response();
     try {


### PR DESCRIPTION
Closes [jrpool/testaro#13](https://github.com/jrpool/testaro/issues/13).

The public W3C validator at `validator.w3.org/nu/` 502s on POST bodies larger than ~80 kB and isn't reachable from hosts inside private networks. Both cases are already called out in the file header comments. The official `ghcr.io/validator/validator` Docker image hosts the same checker with no body-size cap; teams running Testaro in CI / behind a corporate proxy / against large pages can deploy it once and point Testaro at it.

This change keeps the public W3C endpoint as the default so existing users see no behavior change, and adds a single env-var hook (`TESTARO_NU_URL`) to redirect. No new dependency, no per-act config plumbing.

**Env-var name** — `TESTARO_NU_URL` matches the existing `const nuURL` in the file. If you'd prefer `TESTARO_NUVAL_URL`, `NU_VALIDATOR_URL`, or something else, it's a one-line rename — flag it on review and I'll push.