### PR TITLE
htmlcs: hide UMD loader globals during HTMLCS.js injection so HTMLCS_RUNNER reaches window (fixes #47)

### DIFF
--- a/tests/htmlcs.js
+++ b/tests/htmlcs.js
@@ -62,8 +62,19 @@ exports.reporter = async (page, report, actIndex) => {
       const script = document.createElement('script');
       script.nonce = scriptNonce;
       script.textContent = scriptText;
+      // HTMLCS.js is a UMD bundle. If the page exposes an AMD loader (define.amd, e.g. Wix or RequireJS) or leaked CommonJS globals (exports, module), the UMD wrapper registers HTMLCS as a module and never attaches HTMLCS_RUNNER to window, so the run() call below throws and the tool is reported prevented. Hide those loader globals for the duration of the synchronous script execution, so the wrapper falls through to its browser-global branch.
+      const umdDefine = window.define;
+      const umdExports = window.exports;
+      const umdModule = window.module;
+      window.define = undefined;
+      window.exports = undefined;
+      window.module = undefined;
       // Add the HTMLCS script to the page.
       document.head.insertAdjacentElement('beforeend', script);
+      // Restore the loader globals.
+      window.define = umdDefine;
+      window.exports = umdExports;
+      window.module = umdModule;
       // If only some rules are to be employed:
       if (rules && Array.isArray(rules) && rules.length) {
         // Redefine WCAG 2 AAA as including only them.


### PR DESCRIPTION
Fixes #47.

## What

`tests/htmlcs.js` now hides `window.define` / `window.exports` / `window.module` for the duration of the (synchronous) HTMLCS.js script insertion, then restores them.

## Why

HTMLCS.js is a UMD bundle. On pages that expose an AMD loader (`define.amd` — Wix/Thunderbolt, RequireJS) or leaked CommonJS globals, the UMD wrapper registers HTMLCS as a module instead of taking its browser-global branch, so `window.HTMLCS_RUNNER` is never defined. `window.HTMLCS_RUNNER.run(actStandard)` then throws, and the whole act is reported prevented (`ERROR executing HTMLCS_RUNNER in the page`) — htmlcs silently returns zero results on a broad class of real-world sites. Full analysis in #47.

Hiding the loader globals makes the wrapper fall through to the browser-global branch; because the injected script executes synchronously, the globals are restored before any page code can observe their absence. The script-element injection is kept as-is, so CSP compatibility (no `eval` / `new Function`) is unchanged.

## Verification

Live run against a hydrated Wix page (`https://www.thesagemages.com`), htmlcs act only, testaro 75.2.1:

| | prevented | standard instances | error |
|---|---|---|---|
| before | **true** | 0 | `ERROR executing HTMLCS_RUNNER in the page` |
| after (this branch) | false | **61** | — |

The page's AMD loader works normally after the run. We have been running this change in production as a patch-package patch across daily multi-site scans since June with no htmlcs regressions.
