### PR TITLE
Containerized deployment: TESTARO_CHROMIUM_NO_SANDBOX option and reference image (#32)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+node_modules
+temp
+tmp
+watch
+.env
+.npmrc
+.DS_Store
+.vscode
+validation/tests/old
+Dockerfile
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ temp/
 tmp/
 validation/tests/old
 
+# Default job and report directories of the reference container image
+watch/
+
 # Secrets
 .env
 .npmrc

--- a/CONTAINERS.md
+++ b/CONTAINERS.md
@@ -1,0 +1,88 @@
+# Containerized deployment
+
+## Introduction
+
+This document describes how to deploy Testaro in a container, using the reference `Dockerfile` and `docker-compose.yml` at the project root. It accompanies the evaluation requested in [issue 32](https://github.com/jrpool/testaro/issues/32).
+
+Containerization is practical. The reference image runs every Testaro tool:
+
+- The image is based on the official Playwright image (`mcr.microsoft.com/playwright`), which contains the Chromium, Firefox, and WebKit browsers and their system libraries, plus standard fonts, which keep page rendering consistent across hosts.
+- QualWeb's own (Puppeteer) Chromium is downloaded at image build time, pinned by `package-lock.json`.
+- A headless Java runtime is installed for the `nuVnu` test, so `vnu-jar` does not download one over the network on first use.
+- The `nuVal` test is pure HTTP; the reference Compose stack pairs Testaro with a self-hosted Nu Html Checker sidecar (`ghcr.io/validator/validator`) via the `TESTARO_NU_URL` environment variable, so it does not depend on the public W3C service (which is rate-limited and rejects large documents).
+- The `wave` test calls an external API and needs only a `WAVE_KEY`.
+
+## Version coupling
+
+The tag of the base image in the `Dockerfile` (`mcr.microsoft.com/playwright:v1.60.0-noble`) must match the version of the `playwright` package in `package-lock.json`, so that the browsers baked into the image are the ones the installed Playwright expects. When upgrading Playwright, change both together.
+
+## The Chromium sandbox
+
+Chromium's sandbox requires unprivileged user-namespace cloning, which the default Docker seccomp policy blocks (and which some hardened hosts prohibit even outside containers). There are two ways to run:
+
+1. **Without the sandbox** (the image default): the `TESTARO_CHROMIUM_NO_SANDBOX=true` environment variable makes Testaro launch Playwright's Chromium with `chromiumSandbox: false` and QualWeb's Chromium with `--no-sandbox`. This is the usual choice when the container itself is the isolation boundary and only untrusted web content is being visited.
+2. **With the sandbox**: set `TESTARO_CHROMIUM_NO_SANDBOX=false` and run the container with a seccomp profile that permits user-namespace cloning, such as [the profile published by Playwright](https://github.com/microsoft/playwright/blob/main/utils/docker/seccomp_profile.json):
+
+    ```bash
+    docker run --security-opt seccomp=seccomp_profile.json …
+    ```
+
+WebKit and Firefox are unaffected either way.
+
+## Quick start with Compose
+
+```bash
+mkdir -p watch/jobs/todo watch/jobs/done watch/reports/raw
+chmod -R a+w watch
+docker compose up --build
+```
+
+This builds the image, starts the Nu Html Checker sidecar, and starts Testaro watching `watch/jobs/todo` (checking every 300 seconds, per the default command `node call dirWatch true 300`). Drop a job file into `watch/jobs/todo` on the host; the report appears in `watch/reports/raw`, and the job file moves to `watch/jobs/done`.
+
+The container runs as the unprivileged `pwuser` from the Playwright base image, so the mounted host directories must be writable by that user (the `chmod` above, or `chown` to the matching UID).
+
+## One-shot job
+
+To perform a single job and exit:
+
+```bash
+docker compose run --rm testaro node call run
+```
+
+Or without Compose (no Nu sidecar; `nuVal` then uses the public W3C service):
+
+```bash
+docker build -t testaro .
+docker run --rm --init \
+  -v "$PWD/watch/jobs:/home/pwuser/testaro/watch/jobs" \
+  -v "$PWD/watch/reports:/home/pwuser/testaro/watch/reports" \
+  testaro node call run
+```
+
+## Server polling
+
+To poll a server for jobs instead of watching a directory, override the command and provide the `netWatch` variables:
+
+```bash
+docker run --rm --init \
+  -e AGENT=agent1 \
+  -e NETWATCH_URL_JOB=https://example.com/api/testaro-agent/job \
+  -e NETWATCH_URL_REPORT=https://example.com/api/testaro-agent/report \
+  -e NETWATCH_URL_AUTH=password \
+  testaro node call netWatch true 300 true
+```
+
+## Operational notes
+
+- **Init process**: Testaro forks a child process per test act, and some tools relaunch browsers repeatedly, so zombie reaping matters more than for typical browser-automation applications. Always run with an init process (`docker run --init`; in Compose, `init: true`).
+- **Memory**: allow headroom for browser relaunch spikes; multiple tools' browsers can briefly coexist with the catalog pass. The reference Compose stack allows 4 GB.
+- **`/dev/shm`**: Testaro launches Chromium with `--disable-dev-shm-usage`, so the small default `/dev/shm` of containers is not a problem and no `--shm-size` option is needed.
+- **Environment variables**: all variables in `env.example` work as usual; pass them with `-e`/`--env-file` or the Compose `environment` key rather than baking an `.env` file into the image.
+
+## License
+
+© 2026 Jeff Witt.
+
+Licensed under the [MIT License](https://opensource.org/license/mit/). See [LICENSE](LICENSE) file at the project root for details.
+
+SPDX-License-Identifier: MIT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# © 2026 Jeff Witt.
+#
+# Licensed under the MIT License. See LICENSE file at the project root or
+# https://opensource.org/license/mit/ for details.
+#
+# SPDX-License-Identifier: MIT
+
+# Reference container image for Testaro. See CONTAINERS.md for usage.
+#
+# The base-image tag must match the version of the playwright package in
+# package-lock.json, so that the browsers baked into the image are the ones
+# the installed Playwright expects.
+FROM mcr.microsoft.com/playwright:v1.60.0-noble
+
+# Install a headless Java runtime for the nuVnu test (vnu-jar); baking it in
+# prevents vnu-jar from downloading a Temurin runtime over the network on
+# first use. Also install unzip, which Puppeteer's browser downloader needs
+# during `npm ci` and which the base image lacks.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openjdk-17-jre-headless unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+# Run as the unprivileged user provided by the Playwright base image.
+USER pwuser
+WORKDIR /home/pwuser/testaro
+
+# Install the dependencies first, for build-layer caching. QualWeb's
+# Puppeteer downloads its own Chromium during this step (into
+# ~/.cache/puppeteer), so that browser is also baked into the image, pinned
+# by package-lock.json. Playwright's browsers are already in the base image.
+COPY --chown=pwuser:pwuser package.json package-lock.json ./
+RUN npm ci
+
+# Copy the application.
+COPY --chown=pwuser:pwuser . .
+
+# Directories for jobs and reports when watching a directory; mount volumes
+# here (see CONTAINERS.md and docker-compose.yml).
+ENV JOBDIR=/home/pwuser/testaro/watch/jobs \
+    REPORTDIR=/home/pwuser/testaro/watch/reports
+RUN mkdir -p watch/jobs/todo watch/jobs/done watch/reports/raw
+
+# Chromium's sandbox requires unprivileged user-namespace cloning, which the
+# default Docker seccomp policy blocks. This default disables the sandbox
+# (for Playwright's Chromium and QualWeb's). To keep the sandbox instead,
+# run the container with a seccomp profile that permits user-namespace
+# cloning and set this variable to false. See CONTAINERS.md.
+ENV TESTARO_CHROMIUM_NO_SANDBOX=true
+
+# Testaro forks a child process per test act, and some tools relaunch
+# browsers repeatedly, so zombie reaping matters: run the container with an
+# init process (`docker run --init`; in Compose, `init: true`).
+CMD ["node", "call", "dirWatch", "true", "300"]

--- a/README.md
+++ b/README.md
@@ -577,6 +577,8 @@ The behavior of Testaro as a dependency of an application deployed on a virtual 
 
 Experimental deployments of Testaro as a dependency in a containerized application has sometimes resulted in thrown errors that are not thrown when the same application is deployed without containerization.
 
+A reference container image for stand-alone deployment, in which all tools run, is defined by the `Dockerfile` and `docker-compose.yml` files at the project root and documented in [CONTAINERS.md](CONTAINERS.md).
+
 ### Headless browser fidelity
 
 Testaro normally performs tests with headless browsers. Some experiments appear to have shown that some test results are inaccurate with headless browsers, but this has not been replicated. The `launch` function in the `run` module accepts a `headEmulation` argument with `'high'` and `'low'` values. Its purpose is to permit optimizations of headless browsers to be turned off, so browsers behave and appear more similar to headed browsers. Observation has failed to show any performance cost, so `'high'` is the default value.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+# © 2026 Jeff Witt.
+#
+# Licensed under the MIT License. See LICENSE file at the project root or
+# https://opensource.org/license/mit/ for details.
+#
+# SPDX-License-Identifier: MIT
+
+# Reference Compose stack for Testaro: the Testaro image watching a job
+# directory, plus a self-hosted Nu Html Checker as a sidecar so the nuVal
+# test does not depend on the public W3C service (which is rate-limited and
+# rejects large documents). See CONTAINERS.md for usage.
+services:
+  testaro:
+    build: .
+    # Reap zombie processes from forked test acts and browser relaunches.
+    init: true
+    environment:
+      # Disable the Chromium sandbox (default seccomp blocks the user
+      # namespaces it needs). Alternative: set this to "false" and run with
+      # a seccomp profile that permits user-namespace cloning, e.g.
+      #   security_opt:
+      #     - seccomp:seccomp_profile.json
+      # using the profile published by Playwright:
+      # https://github.com/microsoft/playwright/blob/main/utils/docker/seccomp_profile.json
+      TESTARO_CHROMIUM_NO_SANDBOX: "true"
+      # Send nuVal requests to the sidecar instead of the W3C service.
+      TESTARO_NU_URL: "http://nu:8888/?parser=html&out=json"
+      AGENT: docker-example
+    volumes:
+      # Host directories for jobs and reports. The container runs as the
+      # unprivileged pwuser; the host directories must be writable by it
+      # (see CONTAINERS.md).
+      - ./watch/jobs:/home/pwuser/testaro/watch/jobs
+      - ./watch/reports:/home/pwuser/testaro/watch/reports
+    depends_on:
+      - nu
+    # Headroom for browser relaunch spikes: multiple tools' browsers can
+    # briefly coexist with the catalog pass.
+    mem_limit: 4g
+
+  nu:
+    image: ghcr.io/validator/validator:latest
+    # Uncomment to also reach the checker from the host:
+    # ports:
+    #   - "8888:8888"

--- a/env.example
+++ b/env.example
@@ -31,6 +31,11 @@ TIMEOUT_MULTIPLIER=1
 ABORT_ASSERTIVELY=false
 # URL of any non-default (e.g., self-hosted) Nu Html Checker API (see ghcr.io/validator/validator).
 TESTARO_NU_URL=__placeholder__
+# Whether to launch Chromium (Playwright's and QualWeb's) without its sandbox (normally false).
+# The sandbox requires unprivileged user-namespace cloning, which default container
+# seccomp policies and some hardened hosts prohibit. Set this to true in containers,
+# or run the container with a seccomp profile that permits user-namespace cloning.
+TESTARO_CHROMIUM_NO_SANDBOX=false
 
 ## License
 

--- a/netWatch.js
+++ b/netWatch.js
@@ -29,10 +29,21 @@ const {nowString} = require('./procs/dateTime');
 
 // CONSTANTS
 
-const jobURL = new URL(process.env.NETWATCH_URL_JOB);
-const jobHost = jobURL.host;
-const reportURL = new URL(process.env.NETWATCH_URL_REPORT);
-const reportHost = reportURL.host;
+// The netWatch environment variables are required only for network watching,
+// but call.js loads this module for every command, so their absence or
+// invalidity must not throw here; netWatch reports it if netWatch is used.
+const toURL = urlString => {
+  try {
+    return new URL(urlString);
+  }
+  catch(error) {
+    return null;
+  }
+};
+const jobURL = toURL(process.env.NETWATCH_URL_JOB);
+const jobHost = jobURL && jobURL.host;
+const reportURL = toURL(process.env.NETWATCH_URL_REPORT);
+const reportHost = reportURL && reportURL.host;
 const agentPW = process.env.NETWATCH_URL_AUTH;
 
 // FUNCTIONS

--- a/procs/launch.js
+++ b/procs/launch.js
@@ -18,6 +18,14 @@
 
 const {addError} = require('./error');
 const headedBrowser = process.env.HEADED_BROWSER === 'true';
+// Whether to launch Chromium without its sandbox. The sandbox requires
+// unprivileged user-namespace cloning, which the default container seccomp
+// policies and some hardened hosts prohibit. Setting
+// TESTARO_CHROMIUM_NO_SANDBOX=true permits Chromium to run in such
+// environments; the alternative is to run the container with a seccomp
+// profile that permits user-namespace cloning. Applies only to Chromium;
+// WebKit and Firefox have no equivalent option.
+const chromiumNoSandbox = process.env.TESTARO_CHROMIUM_NO_SANDBOX === 'true';
 // Two flavors of Playwright:
 // - `playwrightCore`: the upstream Playwright SDK with no plugins attached.
 // - `playwrightExtra`: the playwright-extra wrapper. `run.js` registers
@@ -320,6 +328,11 @@ const launchOnce = async opts => {
       slowMo: waits || 0,
       args: browserOptionArgs
     };
+    // If launching Chromium without its sandbox was specified:
+    if (browserID === 'chromium' && chromiumNoSandbox) {
+      // Disable the sandbox.
+      browserOptions.chromiumSandbox = false;
+    }
     let browser, browserContext;
     try {
       // Create a browser of the specified type.

--- a/tests/qualWeb.js
+++ b/tests/qualWeb.js
@@ -72,11 +72,19 @@ exports.reporter = async (page, report, actIndex, timeLimit) => {
       instances: []
     };
   }
+  // Specify the options for the Puppeteer browser launched by QualWeb.
+  const puppeteerOptions = {
+    headless: true
+  };
+  // If launching Chromium without its sandbox was specified (e.g., in a
+  // container or on a host that restricts unprivileged user namespaces):
+  if (process.env.TESTARO_CHROMIUM_NO_SANDBOX === 'true') {
+    // Disable the sandbox of the QualWeb browser, too.
+    puppeteerOptions.args = ['--no-sandbox'];
+  }
   try {
     // Start the QualWeb core engine.
-    await qualWeb.start(clusterOptions, {
-      headless: true
-    });
+    await qualWeb.start(clusterOptions, puppeteerOptions);
   }
   // If the start fails:
   catch(error) {


### PR DESCRIPTION
Delivers the reference container image and env-gated revisions offered in #32, in three commits:

1. **`tolerate absent netWatch environment variables in call commands`** — fixes #55, which the container verification surfaced: `netWatch.js` parsed `NETWATCH_URL_JOB`/`NETWATCH_URL_REPORT` with `new URL()` at module scope, and `call.js` loads that module for every command, so `node call run` and `node call dirWatch` crashed whenever those variables were unset (as in a container watching a directory) or still had the `env.example` placeholders. The URLs are now parsed tolerantly, preserving the existing `if (jobURL && reportURL)` guard in `netWatch`.

2. **`add TESTARO_CHROMIUM_NO_SANDBOX option for sandboxless Chromium`** — the two env-gated revisions from the first #32 comment, under one variable (default `false`; nothing changes for existing deployments). When `true`: `procs/launch.js` launches Playwright's Chromium with `chromiumSandbox: false`, and `tests/qualWeb.js` starts QualWeb's Puppeteer Chromium with `--no-sandbox`. Needed wherever unprivileged user-namespace cloning is unavailable: containers under the default Docker seccomp policy, and hosts with `kernel.apparmor_restrict_unprivileged_userns=1` (Ubuntu 24.04+ default). The alternative — keeping the sandbox with a seccomp profile — is documented. Documented in `env.example`. (Once `tests/qualWeb.js` moves to QualWeb's new official Playwright driver — see the update in #32 — the qualWeb half of this gate becomes redundant and can be deleted.)

3. **`add reference container image and documentation`** —
   - `Dockerfile` on the official Playwright base image (`mcr.microsoft.com/playwright:v1.60.0-noble`, tag pinned to the `playwright` version in `package-lock.json`), running as the unprivileged `pwuser`. QualWeb's Puppeteer Chromium is downloaded at build time (pinned by the lockfile), a headless JRE is installed so `nuVnu`/`vnu-jar` doesn't download a Temurin runtime at first use, and `unzip` is added (Puppeteer's browser downloader needs it; the base image lacks it). Default command: `node call dirWatch true 300`.
   - `docker-compose.yml` pairing Testaro with a self-hosted Nu Html Checker sidecar (`ghcr.io/validator/validator`) through the existing `TESTARO_NU_URL`, with `init: true` for zombie reaping (Testaro forks a child per test act and relaunches browsers).
   - `CONTAINERS.md` documenting usage: quick start, one-shot jobs, netWatch mode, the two Chromium-sandbox strategies, version coupling of the base-image tag, and operational notes (init process, memory headroom, `/dev/shm`).
   - README pointer from the existing “Containerized deployment” section; `watch/` gitignored.

## Verification

Built the image and ran two jobs fully inside the container (Compose stack with the Nu sidecar, default seccomp, no host accommodations), against `https://alphagov.github.io/accessibility-tool-audit/test-cases.html`:

| tool | result |
|---|---|
| axe | ran (axe-core 4.12.0): 26 rules violated, 117 violations, 55 warnings |
| qualWeb | ran on its bundled Puppeteer Chromium, sandboxless: standard totals `[254, 405, 96, 24]`, 779 instances |
| nuVal | ran through the sidecar (`TESTARO_NU_URL=http://nu:8888/?parser=html&out=json`): 29 instances |
| nuVnu | ran on the baked-in JRE: 29 instances, totals identical to nuVal (`[8, 0, 0, 21]`) — a nice cross-check of the two Nu paths |
| testaro (native) | ran (`bulk`, `focInd`): 11 findings in standard totals |

Both jobs: `aborted: false`, `preventions: {}`; the catalog passes (browser relaunches) completed normally; reports written to the bind-mounted `watch/reports/raw`.

With `TESTARO_CHROMIUM_NO_SANDBOX` unset, behavior is byte-identical to `main` except the netWatch crash fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
