### PR TITLE
Honor caller-supplied device User-Agent in launch context

### DIFF
--- a/procs/launch.js
+++ b/procs/launch.js
@@ -340,7 +340,12 @@ const launchOnce = async opts => {
       // Create a context (i.e. window) for it.
       const contextOptions = {
         ...device.windowOptions,
-        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+        // Honor a caller-supplied device User-Agent (device.windowOptions.userAgent,
+        // spread above); fall back to the default only when the job provides none.
+        // Assigning unconditionally here overrode device emulation and per-job
+        // browser selection, so Firefox/WebKit launches announced Chrome-on-macOS.
+        userAgent: device.windowOptions.userAgent
+          || 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
         viewport: device.windowOptions.viewport || {width: 1920, height: 1080},
         locale: 'en-US',
         timezoneId: 'America/Los_Angeles',


### PR DESCRIPTION
## What

Honor a caller-supplied device User-Agent in `procs/launch.js` instead of unconditionally overriding it.

`device.windowOptions` is spread into the `newContext` options, but `userAgent` was then reassigned to a fixed string on the next line — so any UA a job specified (for device emulation, or per-job browser selection) was discarded. Firefox and WebKit launches announced a Chrome-on-macOS UA, inconsistent with the engine actually rendering the page.

The fix falls back to the existing default only when the job supplies no `userAgent`:

```js
userAgent: device.windowOptions.userAgent
  || 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) … Chrome/131.0.0.0 Safari/537.36',
```

## Why

`viewport`, `isMobile`, `hasTouch`, and `deviceScaleFactor` already survive the spread and are honored; only the UA was being clobbered, which is the signal most sites use to branch mobile/desktop layout. This restores device emulation and per-job browser UA.

## Verified

Loaded `https://httpbin.org/anything` per engine with a device UA passed through the same `newContext` path; each engine now reports its configured UA (Android/Chromium, Firefox, iOS-Safari/WebKit) instead of the hardcoded string.

## Notes / follow-ups (not in this PR)

- `locale` / `timezoneId` are hardcoded the same way; could get the same caller-wins treatment if desired.
- Playwright's `userAgent` option doesn't set matching UA Client Hints (`Sec-CH-UA*`); full mobile emulation on Chromium additionally needs `Emulation.setUserAgentOverride` with `userAgentMetadata` via CDP. Happy to follow up separately if useful.

Fixes #57
