### PR TITLE
Fail fast on 4xx navigation status (fixes testaro-tool hang on blocked pages)

### DIFF
--- a/procs/launch.js
+++ b/procs/launch.js
@@ -601,6 +601,18 @@ exports.launch = async (opts = {}) => {
       let unusedBrowserIDs = ['chromium', 'webkit', 'firefox'].filter(id => id !== tempBrowserID);
       let retriesLeft = retries;
       let {error} = launchResult;
+      // A 4xx client-error navigation status is a definitive server refusal (a
+      // WAF block or auth wall); retrying it — and switching browser type for a
+      // full extra round of retries — cannot change the outcome. Under the
+      // testaro tool's per-rule relaunch this compounds into a multi-minute (up
+      // to job-timeout) stall on a single target. Fail fast on 4xx, except 408
+      // (Request Timeout) and 429 (Rate Limited), which are legitimately
+      // transient (429 is handled below).
+      const navStatus = Number((/status(\d{3})/.exec(error) || [])[1]);
+      if (navStatus >= 400 && navStatus < 500 && navStatus !== 408 && navStatus !== 429) {
+        retriesLeft = 0;
+        unusedBrowserIDs = [];
+      }
       // As long as retries remain, decrement the allowed retry count and:
       while (retriesLeft) {
         // Prepare to wait 1 second before a retry.


### PR DESCRIPTION
## What
`launch()` fails fast on a **4xx** navigation status instead of retrying it and switching browser types.

## Why (diagnosis for #48)
Investigating pages that hang testing (from #48 and our own corpus), I isolated the stall to a single tool. On `https://www.salesforce.com/`, running each tool separately:

| tool | result |
|---|---|
| axe / alfa / qualWeb / ibm / aslint / htmlcs / ed11y | complete in 14–42 s |
| **testaro** | **hangs** (killed at 110 s; would run to job timeout) |

The site returns **403** to the automated browser. In `launch()`, a failed navigation retries, and when retries are exhausted for the current browser it **switches browser type (chromium → webkit → firefox) and resets the retry counter**. For a persistent 403 that's ~11 launch+navigate attempts, most on the slow-to-launch WebKit/Firefox — and because the `testaro` tool relaunches per rule, it compounds into a multi-minute (up to job-timeout) stall on one target. No other tool does per-rule relaunch, so only `testaro` hangs.

A 4xx is the server *refusing* — retrying and browser-switching can't change it. This change skips the retry loop for 4xx, except **408** (Request Timeout) and **429** (Rate Limited), which are legitimately transient (429 already has dedicated handling below). 5xx / timeouts / other transient failures are unchanged.

## Verified
With the change, `salesforce.com` for the `testaro` tool returns in **~1 s** (definitive block) instead of hanging. Not a full close of #48 — the 403 itself is a WAF-block question — but it removes the "prevent jobs from being completed" hang, which is one of #48's stated symptoms.
