### PR TITLE
Restore granular observability as a structured event set (#44)

### DIFF
--- a/procs/doActs.js
+++ b/procs/doActs.js
@@ -227,7 +227,20 @@ const waitError = (page, act, error, what) => {
   return false;
 };
 // Performs the acts in a report and adds the results to the report.
-exports.doActs = async report => {
+exports.doActs = async (report, opts = {}) => {
+  // Fire-and-forget progress emitter (see #44), mirroring run.js: a handler
+  // exception is logged, never propagated, so a faulty consumer can never abort
+  // the job.
+  const emitProgress = event => {
+    if (opts && typeof opts.onProgress === 'function') {
+      try {
+        opts.onProgress(event);
+      }
+      catch (error) {
+        console.log(`ERROR in onProgress callback: ${error.message}`);
+      }
+    }
+  };
   // Make a temporary copy of the report. Precondition: report is valid.
   let tempReport = JSON.parse(JSON.stringify(report));
   let page = null;
@@ -247,6 +260,9 @@ exports.doActs = async report => {
     if (tempReport?.jobData && ! tempReport.jobData.aborted) {
       let act = acts[actIndex];
       const {type, which} = act;
+      // #44: signal act start so a consumer can heartbeat and advance a live
+      // per-act (per-tool, for test acts) view while the act runs.
+      emitProgress({event: 'actStart', index: Number(actIndex), type, which});
       const actSuffix = type === 'test' ? ` ${which}` : '';
       const message = `>>>> ${type}${actSuffix}`;
       // Log the act.
@@ -477,6 +493,19 @@ exports.doActs = async report => {
             act.expectationFailures = failureCount;
           }
         }
+        // #44: signal test-act completion with its outcome — timedOut is the
+        // most useful, since doActs already SIGKILLs a timed-out child — and its
+        // elapsed time, so consumers need not re-derive them from the report.
+        emitProgress({
+          event: 'actEnd',
+          index: Number(actIndex),
+          type,
+          which,
+          outcome: timedOut
+            ? 'timedOut'
+            : act.data && act.data.prevented ? 'prevented' : 'success',
+          elapsedMs: Date.now() - startTime
+        });
       }
       // Otherwise, if a current page exists:
       else if (page) {

--- a/run.js
+++ b/run.js
@@ -76,6 +76,20 @@ const getTmpDirPath = async jobName => {
 };
 // Runs a job and returns a report.
 exports.doJob = async (job, opts = {}) => {
+  // Fire-and-forget progress emitter (see #44). A handler exception is logged,
+  // never propagated, so a faulty consumer can never abort the job. Payloads
+  // carry identifiers and timing only — no report content — and are delivered
+  // via the existing opts param, so doJob's signature is unchanged.
+  const emitProgress = event => {
+    if (opts && typeof opts.onProgress === 'function') {
+      try {
+        opts.onProgress(event);
+      }
+      catch (error) {
+        console.log(`ERROR in onProgress callback: ${error.message}`);
+      }
+    }
+  };
   // Initialize a report as a copy of the job.
   let report = JSON.parse(JSON.stringify(job));
   report.jobData ??= {};
@@ -94,6 +108,7 @@ exports.doJob = async (job, opts = {}) => {
   else {
     // Report this.
     console.log(`Starting job ${job.id} (${job.target.what})`);
+    emitProgress({event: 'jobStart', id: job.id});
     const tmpDir = await getTmpDirPath(job.id);
     // Add initialized job data to the report.
     const startTime = new Date();
@@ -128,8 +143,15 @@ exports.doJob = async (job, opts = {}) => {
     if (job.browserID && job.target && job.standard !== 'no') {
       // Initialize a catalog so it precedes any page images in the report.
       report.catalog = {};
+      // getCatalog() navigates to the target (procs/catalog.js) — which, on a
+      // slow, blocked, or dead target, can retry across browser types — before
+      // any act runs. Bracket it with events so a consumer can heartbeat through
+      // this phase instead of seeing the job fall silent until the first act.
+      emitProgress({event: 'catalogStart'});
+      const catalogStartMs = Date.now();
       // Add a catalog of the target, and a page image if required, to the report.
       report.catalog = await getCatalog(report);
+      emitProgress({event: 'catalogEnd', elapsedMs: Date.now() - catalogStartMs});
     }
     // Perform the acts and revise the report.
     report = await doActs(report, opts);
@@ -152,6 +174,9 @@ exports.doJob = async (job, opts = {}) => {
       report.jobData.toolTimes[item[0]] = item[1];
     });
   }
+  // Signal job completion (also fires for an invalid job, after its abort data
+  // is set) so a consumer can finalize regardless of outcome.
+  emitProgress({event: 'jobEnd', id: job.id, aborted: !! report.jobData.aborted});
   // Return the report.
   return report;
 };


### PR DESCRIPTION
Restores granular observability (removed 2025-10-30) as a structured, fire-and-forget event set, per the direction in #44. Generalizes the minimal per-act callback I described there into the fuller set.

## Events
Delivered via the existing `opts.onProgress` — `doJob`'s signature is unchanged, and an absent handler is a complete no-op.

| source | event | payload |
|---|---|---|
| `run.js` | `jobStart` | `{id}` |
| `run.js` | `catalogStart` | `{}` |
| `run.js` | `catalogEnd` | `{elapsedMs}` |
| `run.js` | `jobEnd` | `{id, aborted}` |
| `doActs.js` | `actStart` | `{index, type, which}` |
| `doActs.js` | `actEnd` | `{index, type, which, outcome, elapsedMs}` (test acts) |

`outcome` ∈ `timedOut` \| `prevented` \| `success`. `timedOut` surfaces the SIGKILL `doActs` already performs on a timed-out child — the most valuable outcome, and one every consumer otherwise re-derives.

## Why `catalogStart`/`catalogEnd` specifically
`getCatalog()` navigates to the target **before any act runs**, and on a slow / blocked / dead target its `launch()` retries across browser types with no progress signal at all. A consumer watching only per-act events sees the job fall silent for that entire phase and cannot distinguish a slow catalog from a hung one — which is exactly the failure mode behind the hang in #48 (a production job that appears dead during catalog navigation and gets killed by the orchestrator's no-heartbeat timeout). Bracketing the catalog phase lets a consumer heartbeat through it.

## Contract (per the discussion here)
- **Parent-only** emission — the fork boundary stays invisible; no IPC changes.
- Payloads carry **identifiers and timing only**, no report content.
- **Fire-and-forget**: handler exceptions are caught and logged, never propagated, so a faulty callback can never abort a job.

`actEnd` is currently emitted for test acts (the ones that can time out); happy to extend to every act type, add a per-rule tier for the native `testaro` tool via child→parent messages, or adjust names/shape to your preference.

Refs #44.
