### PR TITLE
Fix catalog crash on pages that extend Array.prototype

### DIFF
--- a/procs/catalog.js
+++ b/procs/catalog.js
@@ -65,8 +65,17 @@ exports.getCatalog = async report => {
         // Initialize the index of the current heading.
         let headingIndex = '';
         // For each element in the page:
-        for (const index in elements) {
-          const element = elements[index];
+        // Iterate by numeric index rather than `for...in`. `for...in` over this
+        // array also enumerates any enumerable members added to Array.prototype
+        // by the TARGET page's own scripts (e.g. legacy MooTools/Prototype-style
+        // extensions); `element` then becomes that injected value and the
+        // element.closest(...) call below throws "closest is not a function",
+        // aborting the entire catalog and the job. The indexed loop sees only
+        // real elements. `index` is kept as a string so the catalog keys
+        // (cat[index], texts[...].push(index)) are unchanged.
+        for (let i = 0; i < elements.length; i++) {
+          const index = String(i);
+          const element = elements[i];
           // Get its ID and tag name.
           const {id, tagName} = element;
           // Get its start tag.


### PR DESCRIPTION
Fixes #61.

`getCatalog()`'s element loop used `for...in` over `Array.from(document.querySelectorAll('*'))`. `for...in` also enumerates enumerable members added to `Array.prototype` by the target page's own scripts (legacy MooTools/Prototype-style libraries still do this), so `element` becomes that injected value and `element.closest('body')` throws `"closest is not a function"` inside `page.evaluate`, aborting the whole catalog and failing the job.

This switches to an indexed loop, which visits only the array's real elements. `index` is kept as a string so the catalog keys (`cat[index]`, `texts[...].push(index)`) are byte-for-byte unchanged — no behavior change on well-behaved pages.

Verified against the mechanism:

```js
Object.defineProperty(Array.prototype, 'each', { value() {}, enumerable: true });
const els = [{closest: () => true}];
// for...in  -> TypeError: els[i].closest is not a function
// indexed   -> OK
```

A live site that failed 100% of scans on this now scans cleanly.
