### PR TITLE
autocomplete: fix label-array splice so name/given/family/email heuristics fire (fixes #53)

### DIFF
--- a/testaro/autocomplete.js
+++ b/testaro/autocomplete.js
@@ -79,8 +79,12 @@ exports.reporter = async (
   };
   const selector = 'body input[type=text], body input[type=email], body input:not([type])';
   const whats = 'Inputs are missing required autocomplete attributes';
-  const placeHolders = Object.keys(labels).map(key => `__${key}Labels__`);
-  const replacers = Object.values(labels).map(value => JSON.stringify(value));
+  // Each placeholder sits inside single quotes in getBadWhat (e.g. name: ['__nameLabels__']).
+  // Replace the quoted placeholder with the bracket-stripped JSON so the result is a proper
+  // element list (name: ["your name", ...]) rather than a one-element array holding the JSON
+  // text of the array (name: ['["your name", ...]']), which never matches an accessible name.
+  const placeHolders = Object.keys(labels).map(key => `'__${key}Labels__'`);
+  const replacers = Object.values(labels).map(value => JSON.stringify(value).slice(1, -1));
   // Create a stringified getBadWhat, with placeholders replaced with the specified label arrays.
   let getBadWhatString = getBadWhat.toString();
   [0, 1, 2, 3].forEach(index => {

--- a/validation/tests/jobProperties/autocomplete.json
+++ b/validation/tests/jobProperties/autocomplete.json
@@ -67,7 +67,7 @@
         [
           "standardResult.totals.2",
           "=",
-          4
+          3
         ],
         [
           "standardResult.instances.1.what",
@@ -120,7 +120,7 @@
         [
           "standardResult.totals.2",
           "=",
-          4
+          3
         ],
         [
           "standardResult.instances.0.what",
@@ -135,7 +135,7 @@
         [
           "standardResult.instances.0.count",
           "=",
-          4
+          3
         ]
       ],
       "rules": [


### PR DESCRIPTION
Fixes #53.

## Problem

`autocomplete` stringifies `getBadWhat` and splices the caller's label arrays into placeholders. Each placeholder sits **inside single quotes** in the source:

```js
const labels = {
  name: ['__nameLabels__'],
  ...
};
```

Replacing the bare token with `JSON.stringify(value)` leaves the quotes in place, so the splice produces a one-element array whose only member is the JSON *text* of the intended array:

```js
name: ['["your name","full name","first and last name"]']
```

`labels.name.some(label => accessibleName.includes(label))` can therefore never match a real accessible name. The `name`, `given-name`, `family-name`, and `email` **label** heuristics are all dead — only the hard `type === 'email'` branch can set a required value.

## Fix

Include the surrounding quotes in each placeholder and strip the JSON array brackets from the replacement, so the splice yields a proper element list:

```js
const placeHolders = Object.keys(labels).map(key => `'__${key}Labels__'`);
const replacers = Object.values(labels).map(value => JSON.stringify(value).slice(1, -1));
```

Result: `name: ["your name","full name","first and last name"]`. This also removes the secondary hazard noted in #53 (a quote-normalizing toolchain turning the splice into a syntax error), since the emitted literal no longer depends on the source quote style.

## Verification

Ran the `autocomplete` validation job before and after the rule change and read the actual `standardResult`:

| target | before fix | after fix |
| --- | --- | --- |
| `bad.html` | `totals [0,0,0,0]`, `instances: []` | `totals [0,0,3,0]` — given-name, family-name, email |
| `good.html` | `totals [0,0,0,0]` | `totals [0,0,0,0]` |

The three violations on `bad.html` are all label-only (input 4 already passes via its `type="email"` branch), so before the fix the rule reported nothing.

## Validation fixture

The committed job (`validation/tests/jobProperties/autocomplete.json`) could not pass under the bug and carried a stale `totals.2 = 4` that disagreed with its own per-instance assertions (which reference only instances 1 = family-name and 2 = "Your email address" — a three-violation result). Corrected `totals.2` to `3` on both `bad.html` test acts and the `withItems: false` summary `count` to `3`, to match the verified output. `good.html` (0 violations) is unchanged.

## Out of scope (noticed while validating)

To run the validation job locally I had to work around three unrelated, pre-existing issues in `main` (all on the strict `file://` validation path): `deSlash` is referenced but never defined in `procs/launch.js`; `normalizeURL` doesn't collapse the `procs/..//` segment the harness prepends, so strict mode reports a false `badRedirection`; and the expectation resolver in `validateTest.js` reads `standardResult.*` as `null` (the value is nested under `result.standardResult`), so every assertion "fails" regardless. Happy to file these separately if useful — flagging here since they're why `npm test <ruleID>` can't currently self-verify this (or any) rule.

---

Not urgent, and no rush to merge — happy to adjust the approach (there were a couple of directions in #53). 🤖 Generated with [Claude Code](https://claude.com/claude-code)
