### PR TITLE
Define deSlash so strict jobs don't abort with ReferenceError (fixes #65)

### DIFF
--- a/procs/launch.js
+++ b/procs/launch.js
@@ -77,6 +77,8 @@ const wait = exports.wait = ms => {
     }, ms);
   });
 };
+// Removes any trailing slashes from a URL, for redirection comparison.
+const deSlash = url => (url || '').replace(/\/+$/, '');
 // Close a browser context and/or its browser, if they exist.
 const browserClose = exports.browserClose = async page => {
   if (page) {


### PR DESCRIPTION
Fixes #65.

`goTo` uses `deSlash()` to allow a trailing-slash difference before flagging a bad redirection, but `deSlash` is undefined, so every strict navigation throws `ReferenceError: deSlash is not defined` and the job aborts (this is why the validation harness, which runs strict jobs, can't validate any rule).

Adds `deSlash` as a trailing-slash trimmer next to the other launch helpers. One-line, no behavior change beyond making the existing comparison run.

One of three independent fixes for the strict-`file://` validation path (see also #66, #67); order-independent, no conflicts between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)