### PR TITLE
normalizeURL: resolve ../ so strict file:// visits don't false-positive (fixes #66)

### DIFF
--- a/procs/launch.js
+++ b/procs/launch.js
@@ -17,6 +17,7 @@
 // IMPORTS
 
 const {addError} = require('./error');
+const {posix: posixPath} = require('path');
 const headedBrowser = process.env.HEADED_BROWSER === 'true';
 // Whether to launch Chromium without its sandbox. The sandbox requires
 // unprivileged user-namespace cloning, which the default container seccomp
@@ -104,8 +105,12 @@ const normalizeURL = url => {
     if (url.toLowerCase().startsWith('file:')) {
       let path = url.replace(/^file:\/+/i, '');
       path = path.replace(/\\/g, '/');
+      // Collapse redundant slashes and resolve . and .. segments, so a URL built
+      // with a relative prefix (e.g. .../procs/../target) compares equal to the
+      // absolute URL the browser reports.
+      path = posixPath.normalize('/' + path).replace(/^\//, '');
       // Return the URL normalized.
-      return 'file:///' + path.replace(/^\//, '');
+      return 'file:///' + path;
     }
     // Otherwise, i.e. if it is not that of a local file:
     else {


### PR DESCRIPTION
Fixes #66.

`goTo` splices `${__dirname}/../` into project-relative `file://` targets, leaving an unresolved `procs/..` segment; the browser reports the canonicalized URL, so under `report.strict` the comparison sees a mismatch and returns a spurious `badRedirection`. `normalizeURL` (whose job is to make the two comparable) doesn't collapse redundant slashes or resolve `.`/`..`.

Runs the path through `path.posix.normalize` before rebuilding the URL. Verified in isolation that `deSlash(normalizeURL(requested)) === deSlash(normalizeURL(actual))` for the `.../procs/../target` case.

Surfaces only after #65 (otherwise `deSlash` throws first). One of three independent fixes for the strict-`file://` validation path (see also #65, #67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)