### PR TITLE
Resolve test-act expectations against act.result so standardResult.* works (fixes #67)

### DIFF
--- a/procs/doActs.js
+++ b/procs/doActs.js
@@ -69,7 +69,18 @@ const errorStart = error => error.message.replace(/\n.+/s, '');
 const isTrue = (object, specs) => {
   const property = specs[0];
   const propertyTree = property.split('.');
-  let actual = property.length ? object[propertyTree[0]] : object;
+  // Test-act expectations reference results by property path. Most fixtures use the
+  // bare standardResult.* path, whose value lives at act.result.standardResult; a few
+  // use result.* directly on the act. Resolve against act.result when the first segment
+  // is absent on the act but present on act.result, so both conventions work.
+  let base = object;
+  if (
+    property.length && object && object[propertyTree[0]] === undefined
+    && object.result && object.result[propertyTree[0]] !== undefined
+  ) {
+    base = object.result;
+  }
+  let actual = property.length ? base[propertyTree[0]] : base;
   // Identify the actual value of the specified property.
   while (propertyTree.length > 1 && actual !== undefined) {
     propertyTree.shift();


### PR DESCRIPTION
Fixes #67.

`isTrue(act, spec)` walks the expectation's property path from the act, but a test act's result is stored under `act.result`. The fixtures overwhelmingly use the bare `standardResult.*` path (51 files, ~970 specs), so `act['standardResult']` is `undefined` and every such expectation resolves to `null`/`false` regardless of the real result; a few `result.*` fixtures happen to work.

Resolves against `act.result` when the first path segment is absent on the act but present on `act.result` — unbreaks the dominant `standardResult.*` convention while leaving the `result.*` fixtures working, with no fixture edits.

Verified in isolation: `standardResult.totals.2` and `standardResult.instances.length` resolve to the real values, and `result.elements.data.items.0.code` still resolves. Alternative (normalize all fixtures to one convention) noted in #67 if you'd rather go that way.

One of three independent fixes for the strict-`file://` validation path (see also #65, #66). With all three, `npm test <ruleID>` navigates and evaluates expectations against real values again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)