### PR TITLE
Move the job-time path ID map from the catalog to the report; fix always-pruned appended entries (fixes #54)

### DIFF
--- a/procs/catalog.js
+++ b/procs/catalog.js
@@ -54,12 +54,14 @@ exports.getCatalog = async report => {
           action: 'report'
         });
       }
-      // Get a catalog of the elements in the page.
+      // Get a catalog of the elements in the page and a map of path IDs to catalog indexes.
       console.log('Creating catalog');
-      const catalog = await page.evaluate(() => {
+      const {cat: catalog, pathIDs} = await page.evaluate(() => {
         const elements = Array.from(document.querySelectorAll('*'));
         // Initialize a catalog.
         const cat = {};
+        // Initialize a map of path IDs to catalog indexes.
+        const pathIDs = {};
         // Initialize a directory of text fragments.
         const texts = {};
         // Initialize the index of the current heading.
@@ -132,9 +134,8 @@ exports.getCatalog = async report => {
             // Assign its index to the current heading index.
             headingIndex = index;
           }
-          // Add the path ID to the temporary path ID property of the catalog.
-          cat.pathID ??= {};
-          cat.pathID[pathID] = index;
+          // Add the path ID to the map of path IDs.
+          pathIDs[pathID] = index;
         }
         // For each text in the catalog:
         Object.keys(texts).forEach(text => {
@@ -160,8 +161,10 @@ exports.getCatalog = async report => {
             });
           }
         });
-        return cat;
+        return {cat, pathIDs};
       });
+      // Add the map of path IDs to the report as a temporary job-time property.
+      report.pathIDs = pathIDs;
       // Close the browser and its context.
       await browserClose(page);
       // Return the catalog.
@@ -188,22 +191,23 @@ exports.pruneCatalog = report => {
       // For each instance of the standard result:
       instances.forEach(instance => {
         const catalogIndex = instance?.catalogIndex;
-        // If the instance has a catalog index:
-        if (catalogIndex) {
-          // Ensure the index is classified as cited.
-          citedElementIndexes.add(catalogIndex);
-          const {headingIndex} = catalog[catalogIndex];
+        // If the instance has a catalog index (an index of '0' counts, so test for presence):
+        if (catalogIndex !== undefined && catalogIndex !== '') {
+          // Ensure the index is classified as cited, as a string so it matches the
+          // catalog keys tested below (Object.keys() yields strings).
+          citedElementIndexes.add(String(catalogIndex));
+          const {headingIndex} = catalog[catalogIndex] ?? {};
           // If the catalog item has a heading index:
           if (headingIndex) {
             // Ensure it, too, is classified as cited.
-            citedElementIndexes.add(headingIndex);
+            citedElementIndexes.add(String(headingIndex));
           }
         }
       });
     }
   });
-  // Delete the temporary path ID property.
-  delete catalog.pathID;
+  // Delete the temporary path ID map of the report.
+  delete report.pathIDs;
   // For each element in the catalog:
   Object.keys(catalog).forEach(elementIndex => {
     // If it is not cited by any instance or by any cited element:

--- a/procs/testaro.js
+++ b/procs/testaro.js
@@ -22,7 +22,7 @@ const {getXPathCatalogIndex} = require('./xPath');
 // Tests for a testaro rule.
 exports.doTest = async (
   page,
-  catalog,
+  report,
   withItems,
   ruleID,
   candidateSelector,
@@ -122,7 +122,7 @@ exports.doTest = async (
       // If the proto-instance includes an XPath:
       if (xPath) {
         // Add the catalog index to the standard instance.
-        standardInstance.catalogIndex = getXPathCatalogIndex(catalog, xPath);
+        standardInstance.catalogIndex = getXPathCatalogIndex(report, xPath);
       }
       // Add the standard instance to the standard instances.
       standardInstances.push(standardInstance);
@@ -152,17 +152,17 @@ exports.doTest = async (
   };
 };
 // Adds a catalog index or, if necessary, an XPath to a proto-instance.
-const addCatalogIndex = async (protoInstance, locator, catalog) => {
+const addCatalogIndex = async (protoInstance, locator, report) => {
   // Get the XPath of the element referenced by the locator.
   const xPath = await locator.evaluate(element => window.getXPath(element) ?? '/html');
   // Add a catalog index to the proto-instance.
-  protoInstance.catalogIndex = getXPathCatalogIndex(catalog, xPath);
+  protoInstance.catalogIndex = getXPathCatalogIndex(report, xPath);
   // Return the proto-instance with any modification.
   return protoInstance;
 };
 // Tests for a doTest-ineligible Testaro rule.
 exports.getBasicResult = async (
-  catalog, withItems, ruleID, ordinalSeverity, whats, data, violations
+  report, withItems, ruleID, ordinalSeverity, whats, data, violations
 ) => {
   // If the test was prevented:
   if (data.prevented) {
@@ -190,7 +190,7 @@ exports.getBasicResult = async (
         count: 1
       };
       // Add a catalog index to it.
-      addCatalogIndex(protoInstance, loc, catalog);
+      addCatalogIndex(protoInstance, loc, report);
       // Add the standard instance to the standard instances.
       standardInstances.push(protoInstance);
     }

--- a/procs/xPath.js
+++ b/procs/xPath.js
@@ -65,18 +65,20 @@ const getXPathTagName = xPath => {
   return xPath.split('/').pop().replace(/\[.+/, '').toUpperCase();
 };
 // Gets a catalog index as a string from an XPath.
-exports.getXPathCatalogIndex = (catalog, xPath) => {
+exports.getXPathCatalogIndex = (report, xPath) => {
+  const {catalog} = report;
+  report.pathIDs ??= {};
   // Get the index of the catalog item with the XPath.
-  const index = catalog.pathID[xPath];
-  // If no such item exists:
-  if (! index) {
-    // Add an item to the catalog.
-    const newIndex = Object.keys(catalog).length;
+  const index = report.pathIDs[xPath];
+  // If no such item exists (an index of '0' is a match, so test for absence, not falsity):
+  if (index === undefined) {
+    // Add an item to the catalog, keyed by the count of items already in it.
+    const newIndex = `${Object.keys(catalog).length}`;
     catalog[newIndex] = {
       pathID: xPath,
       tagName: getXPathTagName(xPath)
     };
-    catalog.pathID[xPath] = `${newIndex}`;
+    report.pathIDs[xPath] = newIndex;
     return newIndex;
   }
   return index;

--- a/testaro/adbID.js
+++ b/testaro/adbID.js
@@ -57,6 +57,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'Elements have aria-describedby attributes with missing or invalid id values';
   return await doTest(
-    page, report.catalog, withItems, 'adbID', 'body [aria-describedby]', whats, 3, getBadWhat.toString()
+    page, report, withItems, 'adbID', 'body [aria-describedby]', whats, 3, getBadWhat.toString()
   );
 };

--- a/testaro/allCapStyle.js
+++ b/testaro/allCapStyle.js
@@ -46,6 +46,6 @@ exports.reporter = async (page, report, _, withItems) => {
   const selector = 'body, body *:not(style, script, svg)';
   const whats = 'Elements have an all-capital text transformation style';
   return await doTest(
-    page, report.catalog, withItems, 'allCapStyle', selector, whats, 0, getBadWhat.toString()
+    page, report, withItems, 'allCapStyle', selector, whats, 0, getBadWhat.toString()
   );
 };

--- a/testaro/allHidden.js
+++ b/testaro/allHidden.js
@@ -33,7 +33,7 @@ exports.reporter = async (page, report) => {
         what: 'The entire page body is hidden or empty',
         ordinalSeverity: 3,
         count: 1,
-        catalogIndex: getXPathCatalogIndex(report.catalog, '/html/body')
+        catalogIndex: getXPathCatalogIndex(report, '/html/body')
       }]
     };
   }

--- a/testaro/allSlanted.js
+++ b/testaro/allSlanted.js
@@ -45,6 +45,6 @@ exports.reporter = async (page, report, _, withItems) => {
   const selector = 'body, body *:not(style, script, svg)';
   const whats = 'Elements contain all-slanted text';
   return await doTest(
-    page, report.catalog, withItems, 'allSlanted', selector, whats, 0, getBadWhat.toString()
+    page, report, withItems, 'allSlanted', selector, whats, 0, getBadWhat.toString()
   );
 };

--- a/testaro/altScheme.js
+++ b/testaro/altScheme.js
@@ -41,6 +41,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'img elements have alt attributes with URL or filename values';
   return await doTest(
-    page, report.catalog, withItems, 'altScheme', 'body img[alt]', whats, 1, getBadWhat.toString()
+    page, report, withItems, 'altScheme', 'body img[alt]', whats, 1, getBadWhat.toString()
   );
 };

--- a/testaro/attVal.js
+++ b/testaro/attVal.js
@@ -31,6 +31,6 @@ exports.reporter = async (page, report, _0, withItems, attributeName, areLicit, 
   };
   const whats = `Elements have attribute ${attributeName} with illicit values`;
   return await doTest(
-    page, report.catalog, withItems, 'attVal', `body [${attributeName}]`, whats, 2, getBadWhat.toString()
+    page, report, withItems, 'attVal', `body [${attributeName}]`, whats, 2, getBadWhat.toString()
   );
 };

--- a/testaro/autocomplete.js
+++ b/testaro/autocomplete.js
@@ -91,6 +91,6 @@ exports.reporter = async (
     getBadWhatString = getBadWhatString.replace(placeHolders[index], replacers[index]);
   });
   return doTest(
-    page, report.catalog, withItems, 'autocomplete', selector, whats, 2, getBadWhatString
+    page, report, withItems, 'autocomplete', selector, whats, 2, getBadWhatString
   );
 };

--- a/testaro/bulk.js
+++ b/testaro/bulk.js
@@ -38,7 +38,7 @@ exports.reporter = async (page, report) => {
         what: `Page contains ${visibleElementCount} visible elements`,
         ordinalSeverity: severity,
         count: 1,
-        catalogIndex: getXPathCatalogIndex(report.catalog, '/html')
+        catalogIndex: getXPathCatalogIndex(report, '/html')
       }]
     };
   }

--- a/testaro/buttonMenu.js
+++ b/testaro/buttonMenu.js
@@ -15,7 +15,7 @@
 
 // IMPORTS
 
-const {addCatalogIndex} = require('../procs/catalog');
+const {getXPathCatalogIndex} = require('../procs/xPath');
 
 // ########## FUNCTIONS
 
@@ -304,7 +304,7 @@ exports.reporter = async (page, report, _0, withItems, trialKeySpecs = []) => {
                     what: `Menu responds nonstandardly to the ${key} key`,
                     ordinalSeverity: 2,
                     count: 1,
-                    catalogIndex: getXPathCatalogIndex(report.catalog, mbXPath)
+                    catalogIndex: getXPathCatalogIndex(report, mbXPath)
                   });
                 }
                 // Stop testing the menu button.
@@ -339,7 +339,7 @@ exports.reporter = async (page, report, _0, withItems, trialKeySpecs = []) => {
           what: 'Menu button does not control exactly 1 menu',
           ordinalSeverity: 2,
           count: 1,
-          catalogIndex: getXPathCatalogIndex(report.catalog, mbXPath)
+          catalogIndex: getXPathCatalogIndex(report, mbXPath)
         });
       }
     }

--- a/testaro/captionLoc.js
+++ b/testaro/captionLoc.js
@@ -31,6 +31,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'caption elements are not the first children of table elements';
   return await doTest(
-    page, report.catalog, withItems, 'captionLoc', 'body caption', whats, 3, getBadWhat.toString()
+    page, report, withItems, 'captionLoc', 'body caption', whats, 3, getBadWhat.toString()
   );
 };

--- a/testaro/datalistRef.js
+++ b/testaro/datalistRef.js
@@ -46,6 +46,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'list attributes of input elements are empty or IDs of no or non-datalist elements';
   return await doTest(
-    page, report.catalog, withItems, 'datalistRef', 'body input[list]', whats, 3, getBadWhat.toString()
+    page, report, withItems, 'datalistRef', 'body input[list]', whats, 3, getBadWhat.toString()
   );
 };

--- a/testaro/distortion.js
+++ b/testaro/distortion.js
@@ -38,6 +38,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'Elements distort their texts';
   return await doTest(
-    page, report.catalog, withItems, 'distortion', 'body, body *', whats, 0, getBadWhat.toString()
+    page, report, withItems, 'distortion', 'body, body *', whats, 0, getBadWhat.toString()
   );
 };

--- a/testaro/docType.js
+++ b/testaro/docType.js
@@ -14,6 +14,10 @@
   This test reports a failure to equip the page document with a W3C-recommended HTML doctype.
 */
 
+// IMPORTS
+
+const {getXPathCatalogIndex} = require('../procs/xPath');
+
 // Runs the test and returns the result.
 exports.reporter = async (page, report) => {
   // Returns whether the page declares a document type.
@@ -31,7 +35,7 @@ exports.reporter = async (page, report) => {
       what: 'Document has no standard HTML doctype preamble',
       ordinalSeverity: 3,
       count: 1,
-      catalogIndex: getXPathCatalogIndex('/html')
+      catalogIndex: getXPathCatalogIndex(report, '/html')
     }]
   };
 };

--- a/testaro/dupAtt.js
+++ b/testaro/dupAtt.js
@@ -96,7 +96,7 @@ exports.reporter = async (page, report, _, withItems) => {
           what: `${item.tagName} element has 2 attributes named ${item.duplicatedAttribute}`,
           ordinalSeverity: 2,
           count: 1,
-          catalogIndex: getXPathCatalogIndex(report.catalog, '/html/body')
+          catalogIndex: getXPathCatalogIndex(report, '/html/body')
         });
       });
     }

--- a/testaro/embAc.js
+++ b/testaro/embAc.js
@@ -32,5 +32,5 @@ exports.reporter = async (page, report, _, withItems) => {
   .map(tag => `a ${tag}, button ${tag}`)
   .join(', ');
   const whats = 'interactive elements are embedded in links or buttons';
-  return await doTest(page, report.catalog, withItems, 'embAc', selector, whats, 2, getBadWhat.toString());
+  return await doTest(page, report, withItems, 'embAc', selector, whats, 2, getBadWhat.toString());
 };

--- a/testaro/focAll.js
+++ b/testaro/focAll.js
@@ -74,7 +74,7 @@ exports.reporter = async (page, report) => {
       what: 'Some focusable elements are not Tab-focusable or vice versa',
       ordinalSeverity: 2,
       count,
-      catalogIndex: getXPathCatalogIndex(report.catalog, '/html/body')
+      catalogIndex: getXPathCatalogIndex(report, '/html/body')
     }] : []
   };
 };

--- a/testaro/focAndOp.js
+++ b/testaro/focAndOp.js
@@ -118,6 +118,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'Elements are Tab-focusable but not operable or vice versa';
   return await doTest(
-    page, report.catalog, withItems, 'focAndOp', 'body, body *', whats, 2, getBadWhat.toString()
+    page, report, withItems, 'focAndOp', 'body, body *', whats, 2, getBadWhat.toString()
   );
 };

--- a/testaro/focInd.js
+++ b/testaro/focInd.js
@@ -86,6 +86,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'Elements fail to have standard focus indicators';
   return await doTest(
-    page, report.catalog, withItems, 'focInd', 'body, body *', whats, 1, getBadWhat.toString()
+    page, report, withItems, 'focInd', 'body, body *', whats, 1, getBadWhat.toString()
   );
 };

--- a/testaro/focVis.js
+++ b/testaro/focVis.js
@@ -42,6 +42,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'Visible links are above or to the left of the display';
   return await doTest(
-    page, report.catalog, withItems, 'focVis', 'body a', whats, 2, getBadWhat.toString()
+    page, report, withItems, 'focVis', 'body a', whats, 2, getBadWhat.toString()
   );
 };

--- a/testaro/headEl.js
+++ b/testaro/headEl.js
@@ -65,7 +65,7 @@ exports.reporter = async (page, report) => {
       what: `Invalid elements within the head: ${data.badTagNames.join(', ')}`,
       ordinalSeverity: 2,
       count: data.total,
-      catalogIndex: getXPathCatalogIndex(report.catalog, '/html/head')
+      catalogIndex: getXPathCatalogIndex(report, '/html/head')
     });
   }
   totals = [0, 0, data.total, 0];

--- a/testaro/headingAmb.js
+++ b/testaro/headingAmb.js
@@ -70,6 +70,6 @@ exports.reporter = async (page, report, _, withItems) => {
   const selector = headingLevels.map(level => `body h${level}`).join(', ');
   const whats = 'Adjacent sibling same-level headings have the same text';
   return await doTest(
-    page, report.catalog, withItems, 'headingAmb', selector, whats, 1, getBadWhat.toString()
+    page, report, withItems, 'headingAmb', selector, whats, 1, getBadWhat.toString()
   );
 };

--- a/testaro/hovInd.js
+++ b/testaro/hovInd.js
@@ -140,5 +140,5 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const selector = 'body a, body button, body input, body [onmouseenter], body [onmouseover]';
   const whats = 'elements have confusing hover indicators';
-  return await doTest(page, report.catalog, withItems, 'hovInd', selector, whats, 1, getBadWhat.toString());
+  return await doTest(page, report, withItems, 'hovInd', selector, whats, 1, getBadWhat.toString());
 };

--- a/testaro/hover.js
+++ b/testaro/hover.js
@@ -141,5 +141,5 @@ exports.reporter = async (page, report, _, withItems) => {
   }
   // Get and return a result.
   const whats = 'Hovering over elements changes the number of related visible elements';
-  return await getBasicResult(report.catalog, withItems, 'hover', 0, whats, data, violations);
+  return await getBasicResult(report, withItems, 'hover', 0, whats, data, violations);
 };

--- a/testaro/hr.js
+++ b/testaro/hr.js
@@ -27,6 +27,6 @@ exports.reporter = async (page, report, _, withItems) => {
   }
   const whats = 'HR elements are used for vertical segmentation';
   return await doTest(
-    page, report.catalog, withItems, 'hr', 'body hr', whats, 0, getBadWhat.toString()
+    page, report, withItems, 'hr', 'body hr', whats, 0, getBadWhat.toString()
   );
 };

--- a/testaro/imageLink.js
+++ b/testaro/imageLink.js
@@ -33,6 +33,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'Links have image files as their destinations';
   return await doTest(
-    page, report.catalog, withItems, 'imageLink', 'body  a[href]', whats, 0, getBadWhat.toString()
+    page, report, withItems, 'imageLink', 'body  a[href]', whats, 0, getBadWhat.toString()
   );
 };

--- a/testaro/labClash.js
+++ b/testaro/labClash.js
@@ -44,6 +44,6 @@ exports.reporter = async (page, report, _, withItems) => {
   const selector = 'body button, body input:not([type=hidden]), body select, body textarea';
   const whats = 'Elements have inconsistent label types';
   return await doTest(
-    page, report.catalog, withItems, 'labClash', selector, whats, 2, getBadWhat.toString()
+    page, report, withItems, 'labClash', selector, whats, 2, getBadWhat.toString()
   );
 };

--- a/testaro/legendLoc.js
+++ b/testaro/legendLoc.js
@@ -33,6 +33,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'Legend elements are not the first children of fieldset elements';
   return await doTest(
-    page, report.catalog, withItems, 'legendLoc', 'body legend', whats, 3, getBadWhat.toString()
+    page, report, withItems, 'legendLoc', 'body legend', whats, 3, getBadWhat.toString()
   );
 };

--- a/testaro/lineHeight.js
+++ b/testaro/lineHeight.js
@@ -61,6 +61,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'Element line heights are less than 1.5 times their font sizes';
   return await doTest(
-    page, report.catalog, withItems, 'lineHeight', 'body, body *', whats, 1, getBadWhat.toString()
+    page, report, withItems, 'lineHeight', 'body, body *', whats, 1, getBadWhat.toString()
   );
 };

--- a/testaro/linkAmb.js
+++ b/testaro/linkAmb.js
@@ -22,7 +22,7 @@ const {getXPathCatalogIndex} = require('../procs/xPath');
 
 // Runs the test and returns the result.
 exports.reporter = async (page, report, _, withItems) => {
-  const catalogIndex = getXPathCatalogIndex(report.catalog, '/html/body');
+  const catalogIndex = getXPathCatalogIndex(report, '/html/body');
   return await page.evaluate(args => {
     const [withItems, catalogIndex] = args;
     // Get all links.

--- a/testaro/linkExt.js
+++ b/testaro/linkExt.js
@@ -26,6 +26,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'Links have target=_blank attributes';
   return await doTest(
-    page, report.catalog, withItems, 'linkExt', 'body a[target=_blank]', whats, 0, getBadWhat.toString()
+    page, report, withItems, 'linkExt', 'body a[target=_blank]', whats, 0, getBadWhat.toString()
   );
 };

--- a/testaro/linkOldAtt.js
+++ b/testaro/linkOldAtt.js
@@ -39,6 +39,6 @@ exports.reporter = async (page, report, _, withItems) => {
   const selector = 'body a[charset], body a[coords], body a[name], body a[rev], body a[shape]';
   const whats = 'Links have deprecated attributes';
   return await doTest(
-    page, report.catalog, withItems, 'linkOldAtt', selector, whats, 1, getBadWhat.toString()
+    page, report, withItems, 'linkOldAtt', selector, whats, 1, getBadWhat.toString()
   );
 };

--- a/testaro/linkTo.js
+++ b/testaro/linkTo.js
@@ -33,6 +33,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'Links are missing href attributes';
   return await doTest(
-    page, report.catalog, withItems, 'linkTo', 'body a:not([href]', whats, 2, getBadWhat.toString()
+    page, report, withItems, 'linkTo', 'body a:not([href]', whats, 2, getBadWhat.toString()
   );
 };

--- a/testaro/linkUl.js
+++ b/testaro/linkUl.js
@@ -44,6 +44,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'Links with adjacent text are not underlined';
   return await doTest(
-    page, report.catalog, withItems, 'linkUl', 'body a', whats, 1, getBadWhat.toString()
+    page, report, withItems, 'linkUl', 'body a', whats, 1, getBadWhat.toString()
   );
 };

--- a/testaro/miniText.js
+++ b/testaro/miniText.js
@@ -59,6 +59,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'Visible elements have font sizes smaller than 11 pixels';
   return await doTest(
-    page, report.catalog, withItems, 'miniText', 'body, body *:not(script, style)', whats, 2, getBadWhat.toString()
+    page, report, withItems, 'miniText', 'body, body *:not(script, style)', whats, 2, getBadWhat.toString()
   );
 };

--- a/testaro/motion.js
+++ b/testaro/motion.js
@@ -90,7 +90,7 @@ exports.reporter = async (page, report) => {
           what: violationWhat,
           ordinalSeverity,
           count: 1,
-          catalogIndex: getXPathCatalogIndex(report.catalog, '/html/body')
+          catalogIndex: getXPathCatalogIndex(report, '/html/body')
         });
       }
     }

--- a/testaro/nonTable.js
+++ b/testaro/nonTable.js
@@ -56,6 +56,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'table elements are misused for non-table content';
   return await doTest(
-    page, report.catalog, withItems, 'nonTable', 'body table', whats, 2, getBadWhat.toString()
+    page, report, withItems, 'nonTable', 'body table', whats, 2, getBadWhat.toString()
   );
 };

--- a/testaro/optRoleSel.js
+++ b/testaro/optRoleSel.js
@@ -32,6 +32,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'Elements with role=option have no aria-selected attributes';
   return await doTest(
-    page, report.catalog, withItems, 'optRoleSel', 'body [role="option"]', whats, 1, getBadWhat.toString()
+    page, report, withItems, 'optRoleSel', 'body [role="option"]', whats, 1, getBadWhat.toString()
   );
 };

--- a/testaro/phOnly.js
+++ b/testaro/phOnly.js
@@ -34,6 +34,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'input elements have placeholders but no accessible names';
   return await doTest(
-    page, report.catalog, withItems, 'phOnly', 'body input[placeholder]', whats, 2, getBadWhat.toString()
+    page, report, withItems, 'phOnly', 'body input[placeholder]', whats, 2, getBadWhat.toString()
   );
 };

--- a/testaro/pseudoP.js
+++ b/testaro/pseudoP.js
@@ -49,6 +49,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'br elements follow other br elements, possibly constituting pseudo-paragraphs';
   return await doTest(
-    page, report.catalog, withItems, 'pseudoP', 'body br', whats, 0, getBadWhat.toString()
+    page, report, withItems, 'pseudoP', 'body br', whats, 0, getBadWhat.toString()
   );
 };

--- a/testaro/radioSet.js
+++ b/testaro/radioSet.js
@@ -69,6 +69,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'Radio buttons are not validly grouped in fieldsets with legends';
   return await doTest(
-    page, report.catalog, withItems, 'radioSet', 'body input[type=radio]', whats, 2, getBadWhat.toString()
+    page, report, withItems, 'radioSet', 'body input[type=radio]', whats, 2, getBadWhat.toString()
   );
 };

--- a/testaro/role.js
+++ b/testaro/role.js
@@ -44,5 +44,5 @@ exports.reporter = async (page, report, _, withItems) => {
   }
   // Get and return a result.
   const whats = 'Elements have roles assigned that are also implicit HTML element roles';
-  return await getBasicResult(report.catalog, withItems, 'role', 0, whats, {}, violations);
+  return await getBasicResult(report, withItems, 'role', 0, whats, {}, violations);
 };

--- a/testaro/secHeading.js
+++ b/testaro/secHeading.js
@@ -44,6 +44,6 @@ exports.reporter = async (page, report, _, withItems) => {
   const selector = 'body section, body article, body nav, body aside, body main';
   const whats = 'First child headings of sectioning containers are deeper than others';
   return await doTest(
-    page, report.catalog, withItems, 'secHeading', selector, whats, 0, getBadWhat.toString()
+    page, report, withItems, 'secHeading', selector, whats, 0, getBadWhat.toString()
   );
 };

--- a/testaro/styleDiff.js
+++ b/testaro/styleDiff.js
@@ -84,7 +84,7 @@ const linksByType = async page => await page.evaluateHandle(() => {
 exports.reporter = async (page, report, _, withItems) => {
   // Get an object with arrays of list links and adjacent links as properties.
   const linkTypes = await linksByType(page);
-  const catalogIndex = getXPathCatalogIndex(report.catalog, '/html/body');
+  const catalogIndex = getXPathCatalogIndex(report, '/html/body');
   return await page.evaluate(args => {
     const [linkTypes, withItems, catalogIndex] = args;
     const {body} = document;

--- a/testaro/tabNav.js
+++ b/testaro/tabNav.js
@@ -374,7 +374,7 @@ exports.reporter = async (page, report, _, withItems) => {
         what: `Tab responds nonstandardly to ${item.navigationErrors.join(', ')}`,
         ordinalSeverity: 1,
         count: 1,
-        catalogIndex: getXPathCatalogIndex(report.catalog, item.xPath)
+        catalogIndex: getXPathCatalogIndex(report, item.xPath)
       });
     });
   }

--- a/testaro/targetsNear.js
+++ b/testaro/targetsNear.js
@@ -142,7 +142,7 @@ exports.reporter = async (page, report, _, withItems) => {
   }, withItems);
   // Convert the XPaths of the proto-instances to catalog indexes.
   protoResult.standardInstances = protoResult.standardInstances.map(instance => {
-    instance.catalogIndex = getXPathCatalogIndex(report.catalog, instance.xPath);
+    instance.catalogIndex = getXPathCatalogIndex(report, instance.xPath);
     delete instance.xPath;
     return instance;
   });

--- a/testaro/textSem.js
+++ b/testaro/textSem.js
@@ -38,6 +38,6 @@ exports.reporter = async (page, report, _, withItems) => {
   const selector = 'body i, body b, body small';
   const whats = 'Semantically vague elements i, b, and/or small are used';
   return await doTest(
-    page, report.catalog, withItems, 'textSem', selector, whats, 0, getBadWhat.toString()
+    page, report, withItems, 'textSem', selector, whats, 0, getBadWhat.toString()
   );
 };

--- a/testaro/titledEl.js
+++ b/testaro/titledEl.js
@@ -29,6 +29,6 @@ exports.reporter = async (page, report, _, withItems) => {
   const selector = 'body [title]:not(iframe, link, style)';
   const whats = 'title attributes are used on elements they are likely ineffective on';
   return await doTest(
-    page, report.catalog, withItems, 'titledEl', selector, whats, 0, getBadWhat.toString()
+    page, report, withItems, 'titledEl', selector, whats, 0, getBadWhat.toString()
   );
 };

--- a/testaro/zIndex.js
+++ b/testaro/zIndex.js
@@ -33,6 +33,6 @@ exports.reporter = async (page, report, _, withItems) => {
   };
   const whats = 'Elements have non-default Z indexes';
   return await doTest(
-    page, report.catalog, withItems, 'zIndex', 'body, body *', whats, 0, getBadWhat.toString()
+    page, report, withItems, 'zIndex', 'body, body *', whats, 0, getBadWhat.toString()
   );
 };

--- a/tests/alfa.js
+++ b/tests/alfa.js
@@ -71,7 +71,6 @@ exports.reporter = async (page, report, actIndex) => {
     // Get the evaluations.
     const evaluations = Array.from(await audit.evaluate());
     const {nativeResult, standardResult} = result;
-    const {catalog} = report;
     // For each of them:
     for (const index in evaluations) {
       const evaluation = evaluations[index];
@@ -139,7 +138,7 @@ exports.reporter = async (page, report, actIndex) => {
               what,
               ordinalSeverity,
               count: 1,
-              catalogIndex: getXPathCatalogIndex(catalog, xPath)
+              catalogIndex: getXPathCatalogIndex(report, xPath)
             });
           }
         }

--- a/tests/aslint.js
+++ b/tests/aslint.js
@@ -224,7 +224,6 @@ exports.reporter = async (page, report, actIndex) => {
         }
         // If standard results are to be reported:
         if (standard) {
-          const {catalog} = report;
           const ruleIDs = Object.keys(rules);
           // For each violated rule:
           for (let ruleID of ruleIDs) {
@@ -249,7 +248,7 @@ exports.reporter = async (page, report, actIndex) => {
               const {xpath} = element;
               const pathID = getNormalizedXPath(xpath);
               // Use it to get the index of the element in the catalog.
-              const catalogIndex = getXPathCatalogIndex(catalog, pathID);
+              const catalogIndex = getXPathCatalogIndex(report, pathID);
               // Add an instance to the standard result.
               standardResult.instances.push({
                 ruleID,

--- a/tests/axe.js
+++ b/tests/axe.js
@@ -203,7 +203,7 @@ exports.reporter = async (page, report, actIndex) => {
                   what: Array.from(whatSet.values()).join('; '),
                   ordinalSeverity,
                   count: 1,
-                  catalogIndex: getXPathCatalogIndex(report.catalog, xPath)
+                  catalogIndex: getXPathCatalogIndex(report, xPath)
                 };
                 standardResult.instances.push(instance);
               });

--- a/tests/ed11y.js
+++ b/tests/ed11y.js
@@ -109,7 +109,7 @@ exports.reporter = async (page, report, actIndex) => {
       instance.what = content;
       instance.ordinalSeverity = dismissalKey ? 0 : 2;
       instance.count = 1;
-      instance.catalogIndex = getXPathCatalogIndex(report.catalog, xPath);
+      instance.catalogIndex = getXPathCatalogIndex(report, xPath);
       standardResult.instances.push(instance);
     });
   }

--- a/tests/htmlcs.js
+++ b/tests/htmlcs.js
@@ -134,7 +134,7 @@ exports.reporter = async (page, report, actIndex) => {
           what: parts[4],
           ordinalSeverity: parts[0] === 'Warning' ? 0 : 2,
           count: 1,
-          catalogIndex: getXPathCatalogIndex(report.catalog, xPath)
+          catalogIndex: getXPathCatalogIndex(report, xPath)
         };
         standardResult.instances.push(instance);
       }

--- a/tests/ibm.js
+++ b/tests/ibm.js
@@ -174,7 +174,7 @@ exports.reporter = async (page, report, actIndex) => {
           // If the XPath was obtained:
           if (xPath) {
             // Add the catalog index to the standard instance.
-            standardItem.catalogIndex = getXPathCatalogIndex(report.catalog, xPath);
+            standardItem.catalogIndex = getXPathCatalogIndex(report, xPath);
           }
           // Add the standard instance to the standard result.
           standardResult.instances.push(standardItem);

--- a/tests/nuVal.js
+++ b/tests/nuVal.js
@@ -111,7 +111,7 @@ exports.reporter = async (page, report, actIndex) => {
         // If the acquisition succeeded:
         if (xPath) {
           // Add the catalog index to the standard instance.
-          standardInstance.catalogIndex = getXPathCatalogIndex(report.catalog, xPath);
+          standardInstance.catalogIndex = getXPathCatalogIndex(report, xPath);
         }
         // Add the standard instance to the standard result.
         standardResult.instances.push(standardInstance);

--- a/tests/nuVnu.js
+++ b/tests/nuVnu.js
@@ -99,7 +99,7 @@ exports.reporter = async (page, report, actIndex) => {
           // If the acquisition succeeded:
           if (xPath) {
             // Add the catalog index to the standard instance.
-            standardInstance.catalogIndex = getXPathCatalogIndex(report.catalog, xPath);
+            standardInstance.catalogIndex = getXPathCatalogIndex(report, xPath);
           }
           // Add the standard instance to the standard result.
           standardResult.instances.push(standardInstance);

--- a/tests/qualWeb.js
+++ b/tests/qualWeb.js
@@ -236,7 +236,7 @@ exports.reporter = async (page, report, actIndex, timeLimit) => {
                               what,
                               ordinalSeverity: ordinalSeverities[section][verdict],
                               count: 1,
-                              catalogIndex: getXPathCatalogIndex(report.catalog, xPath)
+                              catalogIndex: getXPathCatalogIndex(report, xPath)
                             };
                             // Add the instance to the standard result.
                             standardResult.instances.push(instance);

--- a/tests/wave.js
+++ b/tests/wave.js
@@ -161,7 +161,7 @@ exports.reporter = async (page, report, actIndex) => {
                       };
                       const xPath = violation[1];
                       // Add the catalog index to the instance.
-                      instance.catalogIndex = getXPathCatalogIndex(report.catalog, xPath);
+                      instance.catalogIndex = getXPathCatalogIndex(report, xPath);
                       // Add the instance to the standard result.
                       instances.push(instance);
                     }


### PR DESCRIPTION
Implements the restructuring you proposed in #54 — `pathIDs` as a top-level report property during the job — together with the type fixes for the dangling `catalogIndex` references, since the relocation alone cures neither the Number/String mismatch nor the `! index` miss test.

## Structure

- `getCatalog`'s in-page builder now returns the path-ID map separately from the catalog, and `getCatalog` stores it as `report.pathIDs`; the catalog contains only element entries.
- `pruneCatalog` deletes `report.pathIDs` exactly where it deleted `catalog.pathID`, so the **shipped report shape is unchanged**.
- The map travels to the forked per-tool children for free, since `doActs` round-trips the whole temporary report through the per-act JSON file.

## Bug fixes (the dangling references)

- `getXPathCatalogIndex(report, xPath)` returns the index **as a string on both paths** (previously the append path returned a Number that could never equal a string catalog key in `pruneCatalog`'s cited set, so appended entries were always pruned).
- Miss test is `index === undefined` — an index of `'0'` (the `html` element) is a match, not a miss.
- The next index is the count of catalog entries, which is correct now that the catalog is homogeneous (previously `Object.keys(catalog).length` counted the `pathID` map itself, drifting one per append).
- `pruneCatalog` coerces cited indexes with `String(...)` and tests instance indexes for presence rather than truth.

## Reference revisions

`doTest`, `getBasicResult`, and `addCatalogIndex` take the report instead of the catalog, and the ~50 call sites in the rule modules and tool adapters pass `report` instead of `report.catalog` — mechanical throughout. Two side benefits: `allCaps.js`'s `Object.entries(report.catalog)` iteration and `doActs`'s pre-prune `elementCount` no longer see the map as a phantom element.

Two latent crashes surfaced by the sweep are also fixed:

- `testaro/docType.js` called `getXPathCatalogIndex` without importing it — a `ReferenceError` whenever a page lacked a doctype.
- `testaro/buttonMenu.js` imported `addCatalogIndex` from `procs/catalog`, where it doesn't exist, and never imported the `getXPathCatalogIndex` it actually calls at its two call sites.

## Verification

`node --check` passes on all 61 changed files. A standalone harness exercising `getXPathCatalogIndex` + `pruneCatalog` against the failure modes from the issue confirms: a found `'0'` is reused rather than duplicated, a miss appends at the next contiguous index as a string, a repeat lookup of the appended path reuses its entry, and pruning keeps cited entries (appended ones included), removes uncited ones, and deletes `report.pathIDs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
