### PR TITLE
catalog: record no boxID for unpainted elements (proposal 1 of #50)

### DIFF
--- a/procs/catalog.js
+++ b/procs/catalog.js
@@ -112,7 +112,14 @@ exports.getCatalog = async report => {
             texts[text] ??= [];
             texts[text].push(index);
           }
-          const domRect = element.getBoundingClientRect();
+          // Get its bounding box, but only if the element is painted. Chromium reports
+          // plausible nonzero boxes for laid-out but unpainted content (visibility: hidden
+          // and content-visibility: hidden subtrees), and such a box disagrees with the
+          // page image, overlapping unrelated visible elements.
+          const isVisible = typeof element.checkVisibility === 'function'
+          ? element.checkVisibility({checkVisibilityCSS: true, visibilityProperty: true})
+          : true;
+          const domRect = isVisible ? element.getBoundingClientRect() : null;
           // Get its box ID.
           const boxID = domRect
           ? ['x', 'y', 'width', 'height'].map(key => Math.round(domRect[key])).join(':')


### PR DESCRIPTION
## Summary

Proposal 1 of #50, as accepted in [this comment](https://github.com/jrpool/testaro/issues/50#issuecomment-5335864937): guard the catalog box measurement with `checkVisibility`, so elements that are laid out but never painted record an empty `boxID` instead of a phantom box.

Chromium returns plausible nonzero `getBoundingClientRect` boxes for unpainted content — `visibility: hidden` and `content-visibility: hidden` subtrees. A boxID recorded for such an element points at a location where the page image shows unrelated visible content. `checkVisibility()` is the spec-provided "is this actually painted" discriminator.

An empty boxID is the established no-box value, so consumers degrade gracefully. Browsers without `checkVisibility` keep today's behavior via the `typeof` fallback.

## Relationship to the merged #71

The two proposals compose: #71 expands closed `<details>` so disclosure content is painted, shown in the page image, and accurately boxed; this guard covers what remains unpainted after expansion (e.g. `visibility: hidden` subtrees). It also fixes an adjacent quirk: `display: none` elements previously recorded a `0:0:0:0` boxID, because `getBoundingClientRect` always returns a DOMRect and the falsy-`domRect` branch never triggered — they now correctly record no box.

## Verification

Ran `getCatalog` end to end (chromium) against a page exercising every case:

| element | before | after |
|---|---|---|
| painted `<p>` | box | box (unchanged) |
| `visibility: hidden` `<p>` | phantom box | `''` |
| child of `content-visibility: hidden` | phantom box | `''` |
| `display: none` `<p>` | `0:0:0:0` | `''` |
| `<summary>` + content of closed `<details>` | box (via #71) | box (unchanged) |

This combination (both proposals together) has also been running in our production monitoring fleet as a patch since July, verified against the reproduction page in #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
