### PR TITLE
catalog/shoot: optional imageScale for a device-pixel page image, motion-safe (fixes #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Here is a sample job, showing properties that you can set:
   strict: true, // Whether to reject redirections from the target URL
   standard: 'only', // Report native (no), standard (only), or both (also) results
   imageColor: 0, // Color type (0, 2, 4, 6) of the page image, if one is to be created along with a catalog
+  imageScale: 2, // Optional: also capture the page image at this device pixel density (see the images section)
   device: { // Device to emulate
     id: 'iPhone 8',
     windowOptions: {
@@ -375,7 +376,9 @@ In some cases no catalog entry can be found. The reasons may include:
 
 #### `images`
 
-Testaro inserts an `images` array property if necessary to store page images in the report. If the job has an `imageColor` property with `0`, `2`, `4`, or `6` as its value and Testaro will insert a `catalog` property, then Testaro also creates a page image with that color type and makes its base64-encoded PNG the first item in the `images` array.
+Testaro inserts an `images` array property if necessary to store page images in the report. If the job has an `imageColor` property with `0`, `2`, `4`, or `6` as its value and Testaro will insert a `catalog` property, then Testaro also creates a page image with that color type and makes its base64-encoded PNG the first item in the `images` array. The first item is always captured at CSS-pixel scale (one image pixel per CSS pixel), so the `motion` test of the `testaro` tool can compare it with its own CSS-pixel screenshot.
+
+If the job also has an `imageScale` property with a number greater than 1 as its value, then the catalog page is rendered at that device scale factor, and Testaro captures a second page image at device-pixel scale and makes it the second item in the `images` array. That image has `imageScale` times the pixels of the CSS layout in each dimension, for crisp display on high-resolution screens. The `boxID` properties of the catalog remain in CSS pixels; consumers can map them onto the second image by multiplying the coordinates by `imageScale`. Fractional values (such as a device's native `2.625`) are valid. A natural choice is the emulated device's own `deviceScaleFactor`, which also makes the catalog page select the same `srcset`/`image-set` resources as the test pages. If `imageScale` is omitted, `1`, or invalid, the behavior is identical to that before this property existed.
 
 There is a `shoot` act type that can be used to make additional page images during a job.
 

--- a/procs/catalog.js
+++ b/procs/catalog.js
@@ -33,6 +33,16 @@ const {shoot} = require('./shoot');
 exports.getCatalog = async report => {
   const {browserID} = report;
   const targetURL = report.target?.url;
+  // Image scale factor (report.imageScale). When greater than 1, the catalog context
+  // runs at that deviceScaleFactor and a supplemental page image is captured at device
+  // scale, i.e. with imageScale times the pixels of the CSS layout. Box IDs are
+  // CSS-pixel regardless, because getBoundingClientRect reports CSS pixels by
+  // definition; consumers map them onto the supplemental image by multiplying by
+  // imageScale. Omitted, 1, or invalid values keep the behavior identical to before
+  // this option existed.
+  const imageScale = Number.isFinite(report.imageScale) && report.imageScale > 1
+    ? report.imageScale
+    : 1;
   // If the report specifies a global browser ID and a global target URL:
   if (browserID && targetURL) {
     // Launch a browser and visit the target, or abort the job on failure.
@@ -40,7 +50,8 @@ exports.getCatalog = async report => {
       report,
       actIndex: null,
       tempBrowserID: browserID,
-      tempURL: targetURL
+      tempURL: targetURL,
+      contextOverrides: imageScale > 1 ? {deviceScaleFactor: imageScale} : {}
     });
     // If the launch and navigation succeeded:
     if (page) {
@@ -58,13 +69,27 @@ exports.getCatalog = async report => {
       });
       // If a page image is required:
       if ([0, 2, 4, 6].includes(report.imageColor)) {
-        // Create one and add it to the report.
+        // Create one at CSS-pixel scale and add it to the report as images[0]. This
+        // scale is invariant to imageScale and to the context's deviceScaleFactor, so
+        // the testaro motion rule, which compares its own CSS-scale screenshot with
+        // images[0], is unaffected by the imageScale option.
         console.log('Creating page image');
         await shoot(page, report, {
           exclusionSelector: '',
           colorType: report.imageColor,
           action: 'report'
         });
+        // If a supersampled page image is also required:
+        if (imageScale > 1) {
+          // Create one at device-pixel scale and add it to the report as images[1].
+          console.log(`Creating page image at ${imageScale}x device scale`);
+          await shoot(page, report, {
+            exclusionSelector: '',
+            colorType: report.imageColor,
+            action: 'report',
+            scale: 'device'
+          });
+        }
       }
       // Get a catalog of the elements in the page.
       console.log('Creating catalog');

--- a/procs/launch.js
+++ b/procs/launch.js
@@ -281,7 +281,10 @@ const launchOnce = async opts => {
     tempURL = '',
     headEmulation = 'high',// low, high
     xPathNeed = 'script',// own, script, attribute, none
-    needsAccessibleName = false
+    needsAccessibleName = false,
+    // Extra Playwright context options (e.g. deviceScaleFactor for device-pixel page
+    // images), spread last so they win over the defaults.
+    contextOverrides = {}
   } = opts;
   const act = report.acts[actIndex] ?? {};
   const {device} = report;
@@ -373,7 +376,9 @@ const launchOnce = async opts => {
           'Accept-Encoding': 'gzip, deflate, br',
           'DNT': '1',
           'Upgrade-Insecure-Requests': '1'
-        }
+        },
+        // Caller-specified context options (see contextOverrides above).
+        ...contextOverrides
       };
       browserContext = await browser.newContext(contextOptions);
       // Prevent default timeouts.
@@ -599,7 +604,9 @@ exports.launch = async (opts = {}) => {
     headEmulation = 'high',
     xPathNeed = 'script',
     needsAccessibleName = false,
-    retries = 2
+    retries = 2,
+    // Extra Playwright context options, passed through to launchOnce.
+    contextOverrides = {}
   } = opts;
   // If the report is valid:
   const jobValidation = isValidJob(report);
@@ -615,7 +622,8 @@ exports.launch = async (opts = {}) => {
         tempURL,
         headEmulation,
         xPathNeed,
-        needsAccessibleName
+        needsAccessibleName,
+        contextOverrides
       }
     );
     // If the launch and navigation succeeded:
@@ -657,7 +665,8 @@ exports.launch = async (opts = {}) => {
             tempURL,
             headEmulation,
             xPathNeed,
-            needsAccessibleName
+            needsAccessibleName,
+            contextOverrides
           }
         );
         // If the launch and navigation succeeded:

--- a/procs/shoot.js
+++ b/procs/shoot.js
@@ -26,10 +26,13 @@ const randomFileName = (suffixLength = 3) => {
   return fileName;
 };
 // Creates and returns a screenshot.
-const screenShot = async (page, exclusionLocator = null) => {
+const screenShot = async (page, exclusionLocator = null, scale = 'css') => {
   const options = {
     fullPage: true,
-    scale: 'css',
+    // 'css' renders 1 image pixel per CSS pixel; 'device' renders at the context's
+    // deviceScaleFactor, i.e. an image whose pixel coordinates are the CSS
+    // coordinates multiplied by that factor.
+    scale,
     timeout: applyMultiplier(4000)
   };
   if (exclusionLocator) {
@@ -49,10 +52,12 @@ exports.shoot = async (page, report, {
   // Color fidelity: 0 (grayscale), 2 (RGB), 4 (grayscale alpha), 6 (RGBA).
   colorType = 0,
   // Disposition: return, report, file.
-  action = 'return'
+  action = 'return',
+  // Screenshot scale ('css' or 'device'); see screenShot above.
+  scale = 'css'
 } = {}) => {
   // Make and get a screenshot as a buffer.
-  let shot = await screenShot(page, exclusionSelector ? page.locator(exclusionSelector) : null);
+  let shot = await screenShot(page, exclusionSelector ? page.locator(exclusionSelector) : null, scale);
   // If it succeeded:
   if (shot.length) {
     // Get the screenshot as an object representation of a PNG image.


### PR DESCRIPTION
Implements #51 with the revised, motion-safe design (see my reply there answering your question about the `motion` rule — you were right, and this design removes the coupling entirely).

## What it does

When `report.imageScale` is a number > 1:

- the catalog's browser context is launched with `deviceScaleFactor: imageScale` (via a new `contextOverrides` pass-through in `launch()`), and
- after the usual CSS-scale page image is captured as `images[0]`, a **second** image is captured at `scale: 'device'` and appended as `images[1]` — `imageScale`× the pixels of the CSS layout in each dimension.

**`images[0]` keeps its contract**: always CSS-pixel scale, exactly as today. The `motion` rule — which compares its own CSS-scale screenshot against `images[0]` and fails fast on any dimension mismatch — is therefore unaffected by `imageScale`. (The originally proposed single-shot design would have made every motion comparison under `imageScale > 1` a guaranteed size-mismatch false positive; this is the fix for the problem you spotted.)

`boxID`s remain CSS-pixel by definition; consumers map them onto `images[1]` by multiplying by `imageScale`. Omitted, `1`, or invalid values keep behavior byte-identical to today, including no `images[1]`.

## Changes

- `procs/launch.js`: `launch()`/`launchOnce()` accept `contextOverrides` — extra Playwright context options spread after the defaults (used here for `deviceScaleFactor`; the launch-arg `--force-device-scale-factor=1` is cleanly overridden by the context option, verified empirically).
- `procs/shoot.js`: `shoot()` accepts `scale` (`'css'` default, or `'device'`), passed to `page.screenshot`.
- `procs/catalog.js`: validates `report.imageScale`, applies the context override, and takes the supplemental device-scale shot when applicable.
- `README.md`: documents the `imageScale` job property and the `images[1]` semantics.

## Verification

End-to-end `getCatalog` runs on a synthetic page (chromium, viewport 1280×800):

| imageScale | images[0] | images[1] |
|---|---|---|
| (absent) | 1280×800 | — (array length 1, as today) |
| 2 | 1280×800 | 2560×1600 |
| 2.625 | 1280×800 | 3360×2100 (exact) |

Box IDs are CSS-pixel in all cases, and the closed-`<details>` expansion from #71 is visible in both images (both shots happen after it).

One note for completeness: when `imageScale` differs from the emulated device's own DSF, `images[0]` is a CSS-scale downsample of a higher-DPR render while motion's own shot renders at the test context's DPR — same dimensions, near-identical pixels; pixelmatch's default antialiasing exclusion absorbs the rendering difference. Setting `imageScale` to the device's `deviceScaleFactor` (the natural policy suggested in the issue) makes the two rendering pipelines identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
