### PR TITLE
motion: raise the rule time budget from 5 to 30 seconds (fixes #76)

### DIFF
--- a/tests/testaro.js
+++ b/tests/testaro.js
@@ -324,7 +324,10 @@ const allRules = [
     what: 'motion without user request',
     contaminates: false,
     needsAccessibleName: false,
-    timeOut: 5,
+    // The budget must cover a full-page screenshot (itself allowed 4 seconds in
+    // procs/shoot.js), decoding two full-page PNGs, and a pixel comparison; 5
+    // seconds made the rule time out whenever an initial image existed.
+    timeOut: 30,
     defaultOn: true
   },
   {


### PR DESCRIPTION
Remedy 1 from #76: raises the `motion` rule's `timeOut` from 5 to 30 seconds (matching the existing `allCaps` budget), with a comment recording why the budget needs the room.

## Verification

Full job on a 150-section local page (chromium, 1280×800, `imageColor: 2`, `rules: ['y', 'motion']`):

- Before: the rule's measured time, 7 seconds, exceeds the old 5-second budget — it would have been prevented by timeout on even this moderate page (consistent with the fleet data in #76: 4 of 4 image-bearing scans timed out).
- After: completes in those same 7 seconds with a correct no-motion verdict (`totals: [0,0,0,0]`, no instances) — to my knowledge the first completed motion comparison our fleet or local testing has produced.

## One further observation for #76's longer-term remedies

While testing on a *very* tall gradient-heavy page (400 sections), the failure moved upstream: the **catalog's own page image** failed at `shoot()`'s internal `page.screenshot` 4-second allowance ("Screenshot failed: Timeout 4000ms exceeded"), so `images[0]` never existed and motion was prevented with "Initial image missing". So the 4-second screenshot allowance bounds not just motion's shot but the existence of the baseline itself on tall pages — worth folding into any follow-up on #76's remedy 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
