### PR TITLE
Preserve unlocatable extracts in the what property of nuVal and nuVnu instances (fixes #38)

### DIFF
--- a/procs/nu.js
+++ b/procs/nu.js
@@ -93,3 +93,15 @@ exports.curate = async (data, nuData, rules) => {
   // Return the result.
   return result;
 };
+// Maximum length of the excerpt of a standard instance.
+const excerptMax = 400;
+// Gets an excerpt for a standard instance from the extract of a message, if the element catalog cannot report the extract.
+exports.getExtractExcerpt = extract => {
+  // If there is no extract, or the extract contains a data-xpath attribute identifying an element:
+  if (! extract || / data-xpath="/.test(extract)) {
+    // Report that no excerpt is needed, because the catalog reports the element.
+    return null;
+  }
+  // Return the extract (e.g. the erroneous text of a CSS: Parse Error message), truncated if necessary.
+  return extract.length > excerptMax ? `${extract.slice(0, excerptMax)} …` : extract;
+};

--- a/procs/nu.js
+++ b/procs/nu.js
@@ -93,9 +93,9 @@ exports.curate = async (data, nuData, rules) => {
   // Return the result.
   return result;
 };
-// Maximum length of the excerpt of a standard instance.
+// Maximum length of an extract excerpt included in the what property of a standard instance.
 const excerptMax = 400;
-// Gets an excerpt for a standard instance from the extract of a message, if the element catalog cannot report the extract.
+// Gets an excerpt of the extract of a message for inclusion in the what property of a standard instance, if the element catalog cannot report the extract.
 exports.getExtractExcerpt = extract => {
   // If there is no extract, or the extract contains a data-xpath attribute identifying an element:
   if (! extract || / data-xpath="/.test(extract)) {

--- a/tests/nuVal.js
+++ b/tests/nuVal.js
@@ -18,7 +18,7 @@
 
 // IMPORTS
 
-const {curate, getContent} = require('../procs/nu');
+const {curate, getContent, getExtractExcerpt} = require('../procs/nu');
 const {getAttributeXPath, getXPathCatalogIndex} = require('../procs/xPath');
 
 // FUNCTIONS
@@ -112,6 +112,13 @@ exports.reporter = async (page, report, actIndex) => {
         if (xPath) {
           // Add the catalog index to the standard instance.
           standardInstance.catalogIndex = getXPathCatalogIndex(report, xPath);
+        }
+        // Get an excerpt from the extract, if the extract identifies no element.
+        const excerpt = getExtractExcerpt(message.extract);
+        // If one was obtained (e.g. the erroneous CSS of a CSS: Parse Error message):
+        if (excerpt) {
+          // Add it to the standard instance, so the extract is not lost.
+          standardInstance.excerpt = excerpt;
         }
         // Add the standard instance to the standard result.
         standardResult.instances.push(standardInstance);

--- a/tests/nuVal.js
+++ b/tests/nuVal.js
@@ -113,12 +113,12 @@ exports.reporter = async (page, report, actIndex) => {
           // Add the catalog index to the standard instance.
           standardInstance.catalogIndex = getXPathCatalogIndex(report, xPath);
         }
-        // Get an excerpt from the extract, if the extract identifies no element.
-        const excerpt = getExtractExcerpt(message.extract);
+        // Get an excerpt of the extract, if the extract identifies no element.
+        const extractExcerpt = getExtractExcerpt(message.extract);
         // If one was obtained (e.g. the erroneous CSS of a CSS: Parse Error message):
-        if (excerpt) {
-          // Add it to the standard instance, so the extract is not lost.
-          standardInstance.excerpt = excerpt;
+        if (extractExcerpt) {
+          // Add it to the description of the violation, so the extract is not lost.
+          standardInstance.what = `${message.message} Extract: ${extractExcerpt}`;
         }
         // Add the standard instance to the standard result.
         standardResult.instances.push(standardInstance);

--- a/tests/nuVnu.js
+++ b/tests/nuVnu.js
@@ -16,7 +16,7 @@
 
 // IMPORTS
 
-const {curate, getContent} = require('../procs/nu');
+const {curate, getContent, getExtractExcerpt} = require('../procs/nu');
 const {getAttributeXPath, getXPathCatalogIndex} = require('../procs/xPath');
 const fs = require('fs/promises');
 const path = require('path');
@@ -100,6 +100,13 @@ exports.reporter = async (page, report, actIndex) => {
           if (xPath) {
             // Add the catalog index to the standard instance.
             standardInstance.catalogIndex = getXPathCatalogIndex(report, xPath);
+          }
+          // Get an excerpt from the extract, if the extract identifies no element.
+          const excerpt = getExtractExcerpt(message.extract);
+          // If one was obtained (e.g. the erroneous CSS of a CSS: Parse Error message):
+          if (excerpt) {
+            // Add it to the standard instance, so the extract is not lost.
+            standardInstance.excerpt = excerpt;
           }
           // Add the standard instance to the standard result.
           standardResult.instances.push(standardInstance);

--- a/tests/nuVnu.js
+++ b/tests/nuVnu.js
@@ -101,12 +101,12 @@ exports.reporter = async (page, report, actIndex) => {
             // Add the catalog index to the standard instance.
             standardInstance.catalogIndex = getXPathCatalogIndex(report, xPath);
           }
-          // Get an excerpt from the extract, if the extract identifies no element.
-          const excerpt = getExtractExcerpt(message.extract);
+          // Get an excerpt of the extract, if the extract identifies no element.
+          const extractExcerpt = getExtractExcerpt(message.extract);
           // If one was obtained (e.g. the erroneous CSS of a CSS: Parse Error message):
-          if (excerpt) {
-            // Add it to the standard instance, so the extract is not lost.
-            standardInstance.excerpt = excerpt;
+          if (extractExcerpt) {
+            // Add it to the description of the violation, so the extract is not lost.
+            standardInstance.what = `${message.message} Extract: ${extractExcerpt}`;
           }
           // Add the standard instance to the standard result.
           standardResult.instances.push(standardInstance);


### PR DESCRIPTION
Fixes #38.

## Problem

`nuVal` and `nuVnu` use a message's `extract` only to obtain a `data-xpath` attribute for the element catalog, then discard it. For messages whose extract is not annotated HTML — notably `CSS: Parse Error.`, whose extract is the erroneous CSS itself — `getAttributeXPath` falls back to `/html`, so the standard instance is anchored to the page root and the only informative content of the violation is lost. A report consumer sees `CSS: Parse Error.` with no indication of what failed to parse.

## Fix

*Revised per review: violation-specific facts belong in the existing `what` property (“A description of the rule or of the violation”), not in a new instance property, so the shape of a standard instance is unchanged.*

A shared helper, `getExtractExcerpt` in `procs/nu.js`, returns an excerpt of the extract **only when the extract contains no `data-xpath` attribute** — exactly the complement of the case the catalog already handles. The reporters append it to the `what` description:

- DOM-anchored messages are unchanged: the catalog reports the element, and `what` stays the bare message.
- Unlocatable messages (CSS parse errors and other non-DOM findings) get `what` = `<message> Extract: <extract>`, with the extract truncated at 400 characters (CSS extracts can be whole minified stylesheets).
- `ruleID` keeps the bare message in all cases, so grouping instances by rule is unaffected.

Both `tests/nuVal.js` and `tests/nuVnu.js` use the helper, keeping the two engines' standardization identical.

## Verification

- `node --check` passes on all three files.
- Unit assertions on the helper: CSS extract returned verbatim; `data-xpath`-annotated extract returns null; missing/empty extract returns null without throwing; >400-char extract truncated with an ellipsis.
- End-to-end run of the `nuVal` reporter with a stubbed validator response containing one `CSS: Parse Error.` and one ordinary HTML message:

```json
[
  {
    "ruleID": "CSS: Parse Error.",
    "what": "CSS: Parse Error. Extract: .hero { colr: #fff, }",
    "ordinalSeverity": 3,
    "count": 1,
    "catalogIndex": "0"
  },
  {
    "ruleID": "Bad value  for attribute role on element div.",
    "what": "Bad value  for attribute role on element div.",
    "ordinalSeverity": 3,
    "count": 1,
    "catalogIndex": "1"
  }
]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
