### PR TITLE
launch: make browserClose actually close the context and browser (fixes #80)

### DIFF
--- a/procs/launch.js
+++ b/procs/launch.js
@@ -83,9 +83,11 @@ const deSlash = url => (url || '').replace(/\/+$/, '');
 // Close a browser context and/or its browser, if they exist.
 const browserClose = exports.browserClose = async page => {
   if (page) {
-    const browserContext = page.context;
+    // Get the context (i.e. window) of the page and the browser of the context. These are methods, not properties; referencing them as properties made this function silently fail to close anything, because a function object has no close method and the resulting TypeError was caught and discarded.
+    const browserContext = page.context();
     if (browserContext) {
-      const {browser} = browserContext;
+      // The browser is null for a context not owned by a browser, such as a persistent context.
+      const browser = browserContext.browser();
       try {
         await browserContext.close();
       }


### PR DESCRIPTION
Fixes #80.

`browserClose` referenced `page.context` and `browserContext.browser` as properties, but they are Playwright methods. `page.context` therefore yielded a function object, whose absent `close` method made the close attempt throw a TypeError that the empty catch block discarded, and whose absent `browser` property made the browser-close branch unreachable. So `browserClose` silently closed nothing: every browser launched in the main process outlived its act until the process exited, and browsers launched in forked tool children survived until the child exited.

This PR calls the methods instead. `browserContext.browser()` returns null for a context not owned by a browser (e.g. a persistent context, as proposed in #77); the existing `if (browser)` guard covers that.

## Verification

- Repro from #80: after `browserClose(page)`, `browser.isConnected()` is now `false` (previously remained `true`).
- A single-act job (testaro `bulk` on `validation/tests/targets/bulk/bad.html`) produces totals `[1,0,0,0]`, identical to before the change.
- A multi-act job (test, url, test) runs to completion without abort, with results identical to before the change, confirming that acts tolerate browsers now genuinely closing between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)