### PR TITLE
Floor accessibility-checker at >=4.0.29 so pre-fix engines cannot resolve (fixes #82)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@siteimprove/alfa-act": "*",
     "@siteimprove/alfa-playwright": "*",
     "@siteimprove/alfa-rules": "*",
-    "accessibility-checker": "*",
+    "accessibility-checker": ">=4.0.29",
     "aria-query": "*",
     "aslint-testaro": "*",
     "axe-playwright": "*",


### PR DESCRIPTION
Fixes #82.

`accessibility-checker-engine` ≤ 4.0.26 ships unconditional self-assigning prototype polyfills that throw `Cannot assign to read only property 'startsWith'` on pages that lock built-in prototypes (Wix Thunderbolt et al.), killing the whole `ibm` act — the error you saw in your #47 test runs. IBM removed the polyfills in engine 4.0.27 (2026-07-14).

`main`'s lockfile already pins `accessibility-checker` 4.0.30, so fresh installs are safe; this floor just prevents environments with older lockfiles or installs from silently resolving a pre-fix version under the current `"*"` range. The locked 4.0.30 satisfies `>=4.0.29`, so `package-lock.json` needs no change.

Full diagnosis with engine-version grep table in #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
