### PR TITLE
focAll: report the specific unreached and unexpected elements (fixes #39)

### DIFF
--- a/testaro/focAll.js
+++ b/testaro/focAll.js
@@ -9,7 +9,7 @@
 
 /*
   focAll
-  This test reports discrepancies between focusable and Tab-focused element counts. The test first counts all the visible focusable (i.e. with tabIndex 0) elements (except counting each group of radio buttons as only one focusable element). Then it repeatedly presses the Tab (or Option-Tab in webkit) key until it has reached all the elements it can and counts those elements. If the two counts differ, navigation can be made more difficult. The cause may be surprising changes in content during navigation with the Tab key, or inability to reach every focusable element (or widget, such as one radio button or tab in each group) merely by pressing the Tab key.
+  This test reports discrepancies between the visible focusable elements of a page and the elements actually reached with the Tab (or, in webkit, Option-Tab) key. The test first identifies and marks all the visible focusable elements, i.e. those with a nonnegative tabIndex, except elements that browsers exclude from Tab navigation (disabled elements, inert elements, and a and area elements without href attributes). Radio buttons are grouped as browsers group them: radio buttons sharing a name and a form owner belong to one group, and the group is reachable with one Tab keypress, but each radio button without a name is independently reachable. Then the test repeatedly presses the Tab (or Option-Tab) key until it has reached all the elements it can, marking each reached element. Finally, the test reports each focusable element that was never reached (for example, because keypresses cause surprising changes in content or focus) and each reached element that was not a visible focusable element when the page was loaded (for example, because it was revealed only during navigation or was invisible although Tab-focusable). Any such element can make navigation with the Tab key difficult or impossible.
 */
 
 // IMPORTS
@@ -19,16 +19,42 @@ const {getXPathCatalogIndex} = require('../procs/xPath');
 // FUNCTIONS
 
 // Runs the test and returns the result.
-exports.reporter = async (page, report) => {
+exports.reporter = async (page, report, _, withItems) => {
   // Get locators of visible elements.
   const locAll = await page.locator('body *:visible');
-  // Get the count of focusable elements.
+  // Mark the focusable elements and get the count of Tab stops among them.
   const focusableCount = await locAll.evaluateAll(elements => {
-    const focusables = elements.filter(element => element.tabIndex === 0);
-    // Count as focusable only 1 radio button per group.
-    const radios = focusables.filter(el => el.tagName === 'INPUT' && el.type === 'radio');
-    const radioNames = new Set(radios.map(radio => radio.name));
-    return focusables.length - radios.length + radioNames.size;
+    // Get the focusable elements, i.e. those that can be reached with the Tab key.
+    const focusables = elements.filter(element => {
+      // If the element has a negative tabIndex, it is not focusable.
+      if (element.tabIndex < 0) {
+        return false;
+      }
+      // If the element or an ancestor is disabled or inert, it is not focusable.
+      if (element.matches(':disabled') || element.closest('[inert]')) {
+        return false;
+      }
+      // If the element is an a or area element without an href attribute, it is not focusable.
+      if (['A', 'AREA'].includes(element.tagName) && ! element.hasAttribute('href')) {
+        return false;
+      }
+      return true;
+    });
+    // Mark them.
+    focusables.forEach(element => {
+      element.dataset.testarofocusable = 'true';
+    });
+    // Get the radio buttons among them that browsers group, i.e. those with names.
+    const namedRadios = focusables.filter(
+      element => element.tagName === 'INPUT' && element.type === 'radio' && element.name
+    );
+    // Get the identifiers (form owner and name) of their groups.
+    const groupIDs = new Set(namedRadios.map(radio => {
+      const formIndex = radio.form ? Array.prototype.indexOf.call(document.forms, radio.form) : -1;
+      return `${formIndex}:${radio.name}`;
+    }));
+    // Return the count of Tab stops, counting each radio-button group as only 1.
+    return focusables.length - namedRadios.length + groupIDs.size;
   });
   /*
     Repeatedly perform a Tab or (in webkit) Opt-Tab keypress and count the focused elements.
@@ -43,7 +69,11 @@ exports.reporter = async (page, report) => {
   while (refocused < 100 && tabFocused < 2000) {
     await page.keyboard.press(keyName);
     const isNewFocus = await page.evaluate(() => {
-      const focus = document.activeElement;
+      let focus = document.activeElement;
+      // If the focus is in a shadow DOM, get the innermost focused element.
+      while (focus && focus.shadowRoot && focus.shadowRoot.activeElement) {
+        focus = focus.shadowRoot.activeElement;
+      }
       if (focus === null || focus.tagName === 'BODY' || focus.dataset.testarofocused) {
         return false;
       }
@@ -59,22 +89,123 @@ exports.reporter = async (page, report) => {
       refocused++;
     }
   }
+  // Get the XPaths of the elements violating the rule, in both directions.
+  const {unreached, unexpected} = await page.evaluate(() => {
+    // Get all elements, including any in open shadow roots.
+    const allElements = [];
+    const addElements = root => {
+      root.querySelectorAll('*').forEach(element => {
+        allElements.push(element);
+        if (element.shadowRoot) {
+          addElements(element.shadowRoot);
+        }
+      });
+    };
+    addElements(document);
+    // Returns the identifier of the group of a radio button.
+    const getGroupID = radio => {
+      const formIndex = radio.form ? Array.prototype.indexOf.call(document.forms, radio.form) : -1;
+      return `${formIndex}:${radio.name}`;
+    };
+    // Get the identifiers of the radio-button groups with any reached member.
+    const reachedGroupIDs = new Set(
+      allElements
+      .filter(
+        element => element.dataset.testarofocused
+        && element.tagName === 'INPUT'
+        && element.type === 'radio'
+        && element.name
+      )
+      .map(getGroupID)
+    );
+    // Initialize the violation data.
+    const unreached = [];
+    const unexpected = [];
+    // For each element:
+    allElements.forEach(element => {
+      const wasFocusable = !! element.dataset.testarofocusable;
+      const wasFocused = !! element.dataset.testarofocused;
+      // If it was focusable but was never reached:
+      if (wasFocusable && ! wasFocused) {
+        const isGroupedRadio = element.tagName === 'INPUT'
+        && element.type === 'radio'
+        && element.name;
+        // If it is not a member of a radio-button group with another reached member:
+        if (! (isGroupedRadio && reachedGroupIDs.has(getGroupID(element)))) {
+          // Add its XPath to the violation data.
+          unreached.push(window.getXPath(element) ?? '/html');
+        }
+      }
+      // Otherwise, if it was reached but was not a visible focusable element:
+      else if (wasFocused && ! wasFocusable) {
+        // Get whether it is a scrollable container, which some browsers make Tab-focusable.
+        const styleDec = window.getComputedStyle(element);
+        const isScroller = ['auto', 'scroll'].includes(styleDec.overflowY)
+        && element.scrollHeight > element.clientHeight
+        || ['auto', 'scroll'].includes(styleDec.overflowX)
+        && element.scrollWidth > element.clientWidth;
+        // If it is not a scrollable container made focusable by the browser alone:
+        if (! (isScroller && element.tabIndex < 0)) {
+          // Add its XPath to the violation data.
+          unexpected.push(window.getXPath(element) ?? '/html');
+        }
+      }
+      // Remove the marker attributes from the element.
+      delete element.dataset.testarofocusable;
+      delete element.dataset.testarofocused;
+    });
+    return {unreached, unexpected};
+  });
+  const count = unreached.length + unexpected.length;
   const data = {
     focusableCount,
     tabFocused,
-    discrepancy: tabFocused - focusableCount
+    discrepancy: tabFocused - focusableCount,
+    unreachedCount: unreached.length,
+    unexpectedCount: unexpected.length
   };
-  const count = Math.abs(data.discrepancy);
-  // Return the result.
-  return {
-    data,
-    totals: [0, 0, count, 0],
-    standardInstances: count ? [{
+  // Initialize the standard instances.
+  const standardInstances = [];
+  // If itemization is required:
+  if (withItems) {
+    // For each element that was focusable but was never reached:
+    unreached.forEach(xPath => {
+      // Add an instance to the standard instances.
+      standardInstances.push({
+        ruleID: 'focAll',
+        what: 'Element is focusable but was not reached by Tab navigation',
+        ordinalSeverity: 2,
+        count: 1,
+        catalogIndex: getXPathCatalogIndex(report, xPath)
+      });
+    });
+    // For each element that was reached but was not a visible focusable element:
+    unexpected.forEach(xPath => {
+      // Add an instance to the standard instances.
+      standardInstances.push({
+        ruleID: 'focAll',
+        what: 'Element was reached by Tab navigation but was not a visible focusable element',
+        ordinalSeverity: 2,
+        count: 1,
+        catalogIndex: getXPathCatalogIndex(report, xPath)
+      });
+    });
+  }
+  // Otherwise, if there were any violations:
+  else if (count) {
+    // Add a summary instance to the standard instances.
+    standardInstances.push({
       ruleID: 'focAll',
       what: 'Some focusable elements are not Tab-focusable or vice versa',
       ordinalSeverity: 2,
       count,
       catalogIndex: getXPathCatalogIndex(report, '/html/body')
-    }] : []
+    });
+  }
+  // Return the result.
+  return {
+    data,
+    totals: [0, 0, count, 0],
+    standardInstances
   };
 };

--- a/validation/tests/jobProperties/focAll.json
+++ b/validation/tests/jobProperties/focAll.json
@@ -53,6 +53,11 @@
           0
         ],
         [
+          "standardResult.instances.length",
+          "=",
+          1
+        ],
+        [
           "standardResult.instances.0.ruleID",
           "=",
           "focAll"
@@ -60,7 +65,7 @@
         [
           "standardResult.instances.0.what",
           "i",
-          "vice versa"
+          "was not reached"
         ],
         [
           "standardResult.instances.0.ordinalSeverity",
@@ -100,6 +105,11 @@
           0
         ],
         [
+          "standardResult.instances.length",
+          "=",
+          2
+        ],
+        [
           "standardResult.instances.0.ruleID",
           "=",
           "focAll"
@@ -107,7 +117,7 @@
         [
           "standardResult.instances.0.what",
           "i",
-          "vice versa"
+          "was not a visible focusable"
         ],
         [
           "standardResult.instances.0.ordinalSeverity",
@@ -117,7 +127,12 @@
         [
           "standardResult.instances.0.count",
           "=",
-          2
+          1
+        ],
+        [
+          "standardResult.instances.1.count",
+          "=",
+          1
         ]
       ],
       "rules": [

--- a/validation/tests/targets/focAll/good.html
+++ b/validation/tests/targets/focAll/good.html
@@ -17,7 +17,21 @@
   <body>
     <main>
       <h1>Page with full focusability</h1>
-      <p>This page contains a link to <a href="https://en.wikipedia.org">information</a>, a <button type="button">button</button>, and a <label>text input <input type="text"></label>. All three, and no other elements, can be focused with Tab-key navigation.</p>
+      <p>This page contains a link to <a href="https://en.wikipedia.org">information</a>, a <button type="button">button</button>, and a <label>text input <input type="text"></label>. It also contains two forms, each containing a radio-button group, with both groups sharing one name. Each group is one Tab stop, at its checked radio button. The three controls and the two groups, and no other elements, can be focused with Tab-key navigation.</p>
+      <form>
+        <fieldset>
+          <legend>Beverage</legend>
+          <label><input type="radio" name="choice" value="coffee" checked> Coffee</label>
+          <label><input type="radio" name="choice" value="tea"> Tea</label>
+        </fieldset>
+      </form>
+      <form>
+        <fieldset>
+          <legend>Meal</legend>
+          <label><input type="radio" name="choice" value="lunch" checked> Lunch</label>
+          <label><input type="radio" name="choice" value="dinner"> Dinner</label>
+        </fieldset>
+      </form>
     </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes #39 by making `focAll` report the specific elements responsible for a focusability discrepancy, instead of a single count anchored at `/html/body`.

## What was useless before

`focAll` counted visible `tabIndex === 0` elements, counted Tab-reached elements, and reported `|tabFocused − focusableCount|` as one instance at `/html/body`. A remediator learned only that *some* elements, *somewhere*, are unreachable (or unexpectedly reachable) — no XPath, no direction.

The count comparison also admits **offsetting errors**: one unreachable element plus one tab stop revealed dynamically during navigation yields a discrepancy of 0, and the page is reported clean.

## What this PR does

The test already marks every Tab-reached element with `data-testarofocused`; it just discarded that identity. This PR keeps it and adds a matching `data-testarofocusable` marker during the initial scan, then diffs the two sets after the Tab loop:

- **Focusable but never reached** (e.g. focus stolen by a script) → one instance per element.
- **Reached but not a visible focusable element** (e.g. content revealed only during navigation, or invisible-but-focusable content) → one instance per element.

`withItems` — which the runner already passes and `focAll` ignored — now selects between per-element instances (each with a `catalogIndex` from its XPath) and the old-style summary instance. `totals[2]` is the sum of both directions, so offsetting errors no longer cancel.

## Correctness fixes that fell out

Auditing the count model against real browser behavior surfaced several latent false-positive/false-negative sources, all fixed here and each verified empirically in chromium and webkit:

1. **Radio grouping now matches the browser's.** Browsers group radio buttons by (form owner, non-empty name): one Tab stop per group, but each *unnamed* radio is its own Tab stop, and same-named groups in different forms are separate groups. The old page-global `Set` of names collapsed unnamed radios into one phantom group and merged same-named groups across forms — the latter produced a standing false `discrepancy` of +1 on a fully conformant two-form page. (Unnamed radios remain `radioSet`'s jurisdiction — its first check already reports them per element — so `focAll` correctly stays silent on them now.)
2. **Disabled controls and `a`/`area` without `href` are excluded from the expected set.** Both report `tabIndex` 0 (verified in chromium and webkit) but are not Tab-focusable, so each one on a page was a false unit of discrepancy before. Inert subtrees are excluded for the same reason.
3. **Positive `tabindex` elements are included in the expected set** (`tabIndex >= 0`, not `=== 0`). They are genuine Tab stops — chromium and webkit both reach them first — so the old test counted each as a spurious discrepancy.
4. **Chromium's keyboard-focusable scrollers are suppressed** in the reached-but-not-focusable direction (scrollable container with negative `tabIndex`): they are browser-initiated Tab stops, not page defects. A scroller an author explicitly puts in the tab order is still tested normally.
5. **Shadow-DOM focus is resolved to the innermost active element** (walking `shadowRoot.activeElement`), and the post-loop sweep traverses open shadow roots, so marks land on and are read from the real elements rather than their hosts.

## Validation

- `validation/tests/targets/focAll/good.html` gains two forms with same-named, checked radio groups — a regression test for fix 1 (the old code reports a false discrepancy on it; the new code reports it clean).
- `validation/tests/jobProperties/focAll.json` now asserts per-instance properties: `less.html` yields exactly one "focusable but was not reached" instance (the text input whose focus is stolen), and `more.html` yields exactly two "reached but not a visible focusable element" instances (the link and button revealed during navigation).
- `npm test focAll` passes (webkit). Also verified per-element XPaths directly in chromium: `less.html` → `/html/body/main[1]/p[1]/label[1]/input[1]`; `more.html` → `/html/body/main[1]/p[2]/a[1]` and `/html/body/main[1]/p[2]/button[1]`.

## Scope notes

- Content reachable only after activating a disclosure (`aria-expanded` triggers, popups) is deliberately out of scope: while a disclosure is closed its content is not required to be focusable, and content that *is* wrongly Tab-reachable while hidden is exactly what the reached-but-not-focusable direction now reports per element. Testing post-activation states would need safe activation and would fit better as a separate rule (related: #36, #50).
- `data` keeps `focusableCount`, `tabFocused`, and `discrepancy` for continuity, and adds `unreachedCount` / `unexpectedCount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)