### PR TITLE
Make getAttributeXPath tolerate messages without an extract (fixes #86)

### DIFF
--- a/procs/xPath.js
+++ b/procs/xPath.js
@@ -57,6 +57,11 @@ exports.getNormalizedXPath = xPath => {
 };
 // Gets an XPath from a data-xpath attribute in an HTML excerpt.
 exports.getAttributeXPath = html => {
+  // If there is no excerpt (e.g. a Nu Html Checker message without an extract):
+  if (! html) {
+    // Return the fallback XPath, as for an excerpt without a data-xpath attribute.
+    return '/html';
+  }
   const match = html.match(/ data-xpath="([^" ]+)"/);
   return match ? match[1] : '/html';
 };


### PR DESCRIPTION
Fixes #86.

## Problem

`getAttributeXPath` calls `html.match(…)` without checking that `html` exists. The Nu Html Checker's JSON output makes `extract` optional (e.g. the terminal `Too many messages.` message and non-document errors), so `tests/nuVal.js` and `tests/nuVnu.js` can pass `undefined`, and the resulting `TypeError` inside the message loop fails the entire act's standardization — every message in the act is lost, not just the extract-less one.

## Fix

Missing input now behaves like an excerpt without a `data-xpath` attribute: the documented `/html` fallback is returned. This is a guard clause only — no call site changes, and the function's invariant of always returning an XPath string, which the unguarded call sites in `axe`, `qualWeb`, and `htmlcs` rely on, is preserved. The extract-less message is anchored to the page root, the same treatment any unlocatable excerpt already gets.

## Verification

- `node --check` passes on `procs/xPath.js`.
- Unit assertions: `undefined`, `null`, and `''` each return `/html`; an excerpt without `data-xpath` still returns `/html`; a `data-xpath`-annotated excerpt still returns its XPath.
- End-to-end run of the `nuVal` reporter with a stubbed validator response containing one extract-less `Too many messages.` message and one ordinary annotated message. On `main` the reporter call rejects with the `TypeError`; with the fix it completes:

```json
[
  {
    "ruleID": "Too many messages.",
    "what": "Too many messages.",
    "ordinalSeverity": 3,
    "count": 1,
    "catalogIndex": "0"
  },
  {
    "ruleID": "Bad value  for attribute role on element div.",
    "what": "Bad value  for attribute role on element div.",
    "ordinalSeverity": 3,
    "count": 1,
    "catalogIndex": "1"
  }
]
```

with catalog entry `"0"` being the `/html` fallback (`{"pathID": "/html", "tagName": "HTML"}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
