### PR TITLE
feat: Add second netWatch authentication option with basic authorization header

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 - **Key files**: `run.js` (main executor), `actSpecs.js` (act specifications), `call.js` (CLI entry), `tests/testaro.js` (Testaro tool rules)
 - **Tools**: Integrates these accessibility tools: Axe, Alfa, IBM Checker, QualWeb, ASLint, WAVE, Ed11y, HTML CodeSniffer, Nu Html Checker API, Nu Html Checker, Testaro
 - **Data flow**: Jobs (JSON) → run.js → tool tests → reports (with standardized results)
-- **Env vars**: Required for WAVE (`WAVE_KEY`); optional `DEBUG`, `WAITS`, `JOBDIR`, `REPORTDIR`, `AGENT`
+- **Env vars**: Required for WAVE (`WAVE_KEY`); optional `DEBUG`, `WAITS`, `JOBDIR`, `REPORTDIR`
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 - **Key files**: `run.js` (main executor), `actSpecs.js` (act specifications), `call.js` (CLI entry), `tests/testaro.js` (Testaro tool rules)
 - **Tools**: Integrates these accessibility tools: Axe, Alfa, IBM Checker, QualWeb, ASLint, WAVE, Ed11y, HTML CodeSniffer, Nu Html Checker API, Nu Html Checker, Testaro
 - **Data flow**: Jobs (JSON) → run.js → tool tests → reports (with standardized results)
-- **Env vars**: Required for WAVE (`WAVE_KEY`); optional `DEBUG`, `WAITS`, `JOBDIR`, `REPORTDIR`
+- **Env vars**: Required for WAVE (`WAVE_KEY`); optional `DEBUG`, `WAITS`, `JOBDIR`, `REPORTDIR`; for server polling `NETWATCH_URL_JOB`, `NETWATCH_URL_REPORT`, `NETWATCH_AUTH_TYPE`, `NETWATCH_WORKER_ID`, `NETWATCH_WORKER_SECRET`
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,9 +81,7 @@ Key variables:
 - `WAITS` — ms delay inserted between Playwright operations (useful for debugging)
 - `WAVE_KEY` — API key for the WAVE subscription API
 - `JOBDIR` / `REPORTDIR` — root directories for job files and report output
-- `AGENT` — instance name used in network-watch mode
-- `NETWATCH_URL_JOB`/`NETWATCH_URL_REPORT`/`NETWATCH_URL_AUTH` — server polling configuration
-- `WORKER_ID`/`WORKER_SECRET` — optional Basic auth credentials for the watched server
+- `NETWATCH_URL_JOB`/`NETWATCH_URL_REPORT`/`NETWATCH_AUTH_TYPE`/`NETWATCH_WORKER_ID`/`NETWATCH_WORKER_SECRET` — server polling configuration
 - `TIMEOUT_MULTIPLIER` — scales all per-tool time limits (default 1)
 
 ## Code style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,8 @@ Key variables:
 - `WAVE_KEY` — API key for the WAVE subscription API
 - `JOBDIR` / `REPORTDIR` — root directories for job files and report output
 - `AGENT` — instance name used in network-watch mode
-- `NETWATCH_URL_<N>_JOB/REPORT/AUTH`, `NETWATCH_URLS` — server polling configuration
+- `NETWATCH_URL_JOB`/`NETWATCH_URL_REPORT`/`NETWATCH_URL_AUTH` — server polling configuration
+- `WORKER_ID`/`WORKER_SECRET` — optional Basic auth credentials for the watched server
 - `TIMEOUT_MULTIPLIER` — scales all per-tool time limits (default 1)
 
 ## Code style

--- a/CONTAINERS.md
+++ b/CONTAINERS.md
@@ -68,9 +68,11 @@ To poll a server for jobs instead of watching a directory, override the command 
 ```bash
 docker run --rm --init \
   -e AGENT=agent1 \
-  -e NETWATCH_URL_JOB=https://example.com/api/testaro-agent/job \
-  -e NETWATCH_URL_REPORT=https://example.com/api/testaro-agent/report \
+  -e NETWATCH_URL_JOB=https://example.com/api/job \
+  -e NETWATCH_URL_REPORT=https://example.com/api/report \
   -e NETWATCH_URL_AUTH=password \
+  -e WORKER_ID=agent1 \
+  -e WORKER_SECRET=secret \
   testaro node call netWatch true 300 true
 ```
 

--- a/CONTAINERS.md
+++ b/CONTAINERS.md
@@ -63,16 +63,15 @@ docker run --rm --init \
 
 ## Server polling
 
-To poll a server for jobs instead of watching a directory, override the command and provide the `netWatch` variables:
+To poll a server for jobs instead of watching a directory, override the command and provide the `netWatch` variables, such as:
 
 ```bash
 docker run --rm --init \
-  -e AGENT=agent1 \
-  -e NETWATCH_URL_JOB=https://example.com/api/job \
-  -e NETWATCH_URL_REPORT=https://example.com/api/report \
-  -e NETWATCH_URL_AUTH=password \
-  -e WORKER_ID=agent1 \
-  -e WORKER_SECRET=secret \
+  -e NETWATCH_URL_JOB=https://myserver.com/worker/job \
+  -e NETWATCH_URL_REPORT=https://myserver.com/worker/report \
+  -e NETWATCH_AUTH_TYPE=header \
+  -e NETWATCH_WORKER_ID=worker1 \
+  -e NETWATCH_WORKER_SECRET=seekRut \
   testaro node call netWatch true 300 true
 ```
 

--- a/CONTAINERS.md
+++ b/CONTAINERS.md
@@ -72,8 +72,10 @@ docker run --rm --init \
   -e NETWATCH_AUTH_TYPE=header \
   -e NETWATCH_WORKER_ID=worker1 \
   -e NETWATCH_WORKER_SECRET=seekRut \
-  testaro node call netWatch true 300 true
+  testaro node call netWatch true 300
 ```
+
+The same variables can be supplied through the Compose stack instead: define them in `.env` and run `docker compose run testaro node call netWatch true 300`. A third `netWatch` argument of `true` would disable certificate verification; leave it off except against servers you control.
 
 ## Operational notes
 

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ To allow Testaro to poll a server for jobs, define the following environment var
 
 The URL paths are determined by agreement between Testaro and the server and may omit any identifier of the Testaro instance. A single Testaro instance watches one server.
 
-Testaro sends the job request as a `POST` request. If `NETWATCH_URL_AUTH` is set, the request body is a JSON object with an `agentPW` property; otherwise the body is an empty JSON object. If `WORKER_ID` and `WORKER_SECRET` are both set, the request also carries an `authorization` header whose value is `Basic ` followed by the base64 encoding of `WORKER_ID:WORKER_SECRET`.
+Testaro sends the job request as a `POST` request. If `NETWATCH_URL_AUTH` is set, the request body is a JSON object with an `agentPW` property; otherwise the body is an empty JSON object. If `WORKER_ID` and `WORKER_SECRET` are both set, the request also carries an `authorization` header whose value is `Basic`, followed by a space and the base64 encoding of `WORKER_ID:WORKER_SECRET`.
 
 Testaro sends the report as a `POST` request whose body is a JSON object with a `report` property and, if `NETWATCH_URL_AUTH` is set, an `agentPW` property. The same `authorization` header, if any, is attached.
 
@@ -522,7 +522,7 @@ Thus, when the `rules` argument is omitted, QualWeb will test for all of the rul
 
 The target can be provided to QualWeb either as HTML or as a URL. Experience indicates that the results can differ between these methods, with each method reporting some rule violations or some instances that the other method does not report. For at least some cases, more rules are reported violated when HTML is provided (`withNewItems: false`).
 
-QualWeb creates sandboxed Puppeteer pages to perform its tests on. Therefore, the host must permit sandboxed browsers to be launched. See the discussion above about browser security.
+QualWeb creates sandboxed Playwright pages to perform its tests on. Therefore, the host must permit sandboxed browsers to be launched. See the discussion above about browser security.
 
 ### Testaro
 

--- a/README.md
+++ b/README.md
@@ -288,20 +288,17 @@ In both cases, the first argument of `dirWatch` tells Testaro whether to continu
 
 ### Server polling
 
-Testaro can poll a server for jobs to be performed. The server can act as the “controller” described in [How to run a thousand accessibility tests](https://medium.com/cvs-health-tech-blog/how-to-run-a-thousand-accessibility-tests-63692ad120c3). The server is responsible for preparing Testaro jobs, assigning them to Testaro agents, receiving reports back from those agents, and performing any further processing of the reports, including enhancement, storage, and disclosure to audiences. It can be any server reachable with a URL. That includes a server running on the same host as Testaro, with a URL such as `localhost:3000`.
+Testaro can poll a server for jobs to be performed. The server can act as the “controller” described in [How to run a thousand accessibility tests](https://medium.com/cvs-health-tech-blog/how-to-run-a-thousand-accessibility-tests-63692ad120c3). The server is responsible for preparing Testaro jobs, assigning them to Testaro workers, receiving reports back from those workers, and performing any further processing of the reports, including enhancement, storage, and disclosure to audiences. It can be any server reachable with a URL. That includes a server running on the same host as Testaro, with a URL such as `localhost:3000`.
 
-To allow Testaro to poll a server for jobs, define the following environment variables:
+To allow Testaro to poll a server for jobs, define the environment variables documented under `netWatch variables` in the [env.example](env.example) file. The URL paths are determined by agreement between Testaro and the server. A single Testaro instance can watch one server.
 
-- `NETWATCH_URL_JOB`: which URL to poll for available jobs
-- `NETWATCH_URL_REPORT`: which URL to send job reports to
-- `NETWATCH_URL_AUTH` (optional): a password supplied to the server as the `agentPW` property of the request body when polling and when delivering a report
-- `WORKER_ID` and `WORKER_SECRET` (optional, but both required if either is set): credentials supplied to the server as a `Basic` authorization header when polling and when delivering a report
+`NETWATCH_AUTH_TYPE` selects how Testaro authenticates to the server:
 
-The URL paths are determined by agreement between Testaro and the server and may omit any identifier of the Testaro instance. A single Testaro instance watches one server.
+- `none`: no credentials are sent. `NETWATCH_WORKER_ID` and `NETWATCH_WORKER_SECRET` are not required.
+- `pathBody`: the ID of the Testaro instance may be part of the URL path, as required by the server, and the password (`NETWATCH_WORKER_SECRET`) is transmitted in the request body as the value of an `agentPW` property.
+- `header`: the request carries an `authorization` header whose value is `Basic`, followed by a space and the base64 encoding of `NETWATCH_WORKER_ID:NETWATCH_WORKER_SECRET`.
 
-Testaro sends the job request as a `POST` request. If `NETWATCH_URL_AUTH` is set, the request body is a JSON object with an `agentPW` property; otherwise the body is an empty JSON object. If `WORKER_ID` and `WORKER_SECRET` are both set, the request also carries an `authorization` header whose value is `Basic`, followed by a space and the base64 encoding of `WORKER_ID:WORKER_SECRET`.
-
-Testaro sends the report as a `POST` request whose body is a JSON object with a `report` property and, if `NETWATCH_URL_AUTH` is set, an `agentPW` property. The same `authorization` header, if any, is attached.
+Testaro sends job requests and completed reports as `POST` requests. When Testaro sends a report to the server, the report is the value of a `report` property in the request body.
 
 An application can make Testaro poll a server for jobs with:
 

--- a/README.md
+++ b/README.md
@@ -292,13 +292,16 @@ Testaro can poll a server for jobs to be performed. The server can act as the â€
 
 To allow Testaro to poll a server for jobs, define the following environment variables:
 
-- `NETWATCH_URL_JOB`: which URL to poll (the URL must contain the value of the `AGENT` environment variable)
+- `NETWATCH_URL_JOB`: which URL to poll for available jobs
 - `NETWATCH_URL_REPORT`: which URL to send job reports to
-- `NETWATCH_URL_AUTH`: the password to supply to the server when polling and when delivering a report
+- `NETWATCH_URL_AUTH` (optional): a password supplied to the server as the `agentPW` property of the request body when polling and when delivering a report
+- `WORKER_ID` and `WORKER_SECRET` (optional, but both required if either is set): credentials supplied to the server as a `Basic` authorization header when polling and when delivering a report
 
-The job request sent to the server can be a `POST` request, in which the `agentPW` property of the payload will be the password. Or it can be a `GET` request with the URL containing the password.
+The URL paths are determined by agreement between Testaro and the server and may omit any identifier of the Testaro instance. A single Testaro instance watches one server.
 
-Testaro will send the report as a `POST` request whose payload is a JSON object with two properties: `agentPW` (the password) and `report` (the report). However, if the environment does not contain a password, the payload is a JSON object containing only the report.
+Testaro sends the job request as a `POST` request. If `NETWATCH_URL_AUTH` is set, the request body is a JSON object with an `agentPW` property; otherwise the body is an empty JSON object. If `WORKER_ID` and `WORKER_SECRET` are both set, the request also carries an `authorization` header whose value is `Basic ` followed by the base64 encoding of `WORKER_ID:WORKER_SECRET`.
+
+Testaro sends the report as a `POST` request whose body is a JSON object with a `report` property and, if `NETWATCH_URL_AUTH` is set, an `agentPW` property. The same `authorization` header, if any, is attached.
 
 An application can make Testaro poll a server for jobs with:
 

--- a/README.md
+++ b/README.md
@@ -295,25 +295,27 @@ To allow Testaro to poll a server for jobs, define the environment variables doc
 `NETWATCH_AUTH_TYPE` selects how Testaro authenticates to the server:
 
 - `none`: no credentials are sent. `NETWATCH_WORKER_ID` and `NETWATCH_WORKER_SECRET` are not required.
-- `pathBody`: the ID of the Testaro instance may be part of the URL path, as required by the server, and the password (`NETWATCH_WORKER_SECRET`) is transmitted in the request body as the value of an `agentPW` property.
-- `header`: the request carries an `authorization` header whose value is `Basic`, followed by a space and the base64 encoding of `NETWATCH_WORKER_ID:NETWATCH_WORKER_SECRET`.
+- `pathBody`: the password (`NETWATCH_WORKER_SECRET`) is transmitted in the request body as the value of an `agentPW` property. If the server requires the ID of the Testaro instance in the URL path, include it in `NETWATCH_URL_JOB` and `NETWATCH_URL_REPORT` yourself; Testaro does not insert it.
+- `header`: the request carries an `authorization` header whose value is `Basic`, followed by a space and the base64 encoding of `NETWATCH_WORKER_ID:NETWATCH_WORKER_SECRET`. The worker ID must not contain a colon.
 
-Testaro sends job requests and completed reports as `POST` requests. When Testaro sends a report to the server, the report is the value of a `report` property in the request body.
+Testaro sends job requests and completed reports as `POST` requests. When Testaro sends a report to the server, the report is the value of a `report` property in the request body. If `NETWATCH_WORKER_ID` is defined, Testaro also records it as the `sources.agent` property of the report, so the server can attribute the report to this instance under any auth type.
+
+The `AGENT` and `NETWATCH_URL_AUTH` variables of earlier versions are deprecated. Testaro still honors them (as `NETWATCH_WORKER_ID` and as a `pathBody` password, respectively) but warns; rename them.
 
 An application can make Testaro poll a server for jobs with:
 
 ```javaScript
 const {netWatch} = require('testaro/netWatch');
-netWatch(true, 300, true);
+netWatch(true, 300);
 ```
 
 A user can make Testaro poll a server for jobs with:
 
 ```bash
-node call netWatch true 300 true
+node call netWatch true 300
 ```
 
-The first argument of `netWatch` tells Testaro whether to continue polling after performing the first job. The second argument tells Testaro how many seconds to wait after receiving a no-jobs response before polling again. The third argument tells Testaro whether to be certificate-tolerant, i.e. to accept SSL certificates that fail verification against a list of certificate authorities (the default is `true`).
+The first argument of `netWatch` tells Testaro whether to continue polling after performing the first job. The second argument tells Testaro how many seconds to wait after receiving a no-jobs response before polling again. The optional third argument tells Testaro whether to be certificate-tolerant, i.e. to accept SSL certificates that fail verification against a list of certificate authorities (the default is `false`). Certificate tolerance disables the protection of an `https` connection, exposing credentials and reports to interception, so use it only against servers you control, such as local test servers with self-signed certificates.
 
 ## Reports
 

--- a/call.js
+++ b/call.js
@@ -74,7 +74,7 @@ const callDirWatch = async (isForever, intervalInSeconds) => {
 };
 // Starts a network watch, converting the interval argument to a number.
 const callNetWatch = async (isForever, intervalInSeconds, isCertTolerant) => {
-  await netWatch(
+  return await netWatch(
     isForever === 'true',
     Number.parseInt(intervalInSeconds, 10),
     isCertTolerant ? isCertTolerant === 'true' : undefined
@@ -100,9 +100,10 @@ else if (fn === 'dirWatch' && fnArgs.length === 2) {
 }
 else if (fn === 'netWatch' && [2, 3].includes(fnArgs.length)) {
   callNetWatch(... fnArgs)
-  .then(() => {
+  .then(isOK => {
     console.log('Network watch ended');
-    process.exit(0);
+    // Exit with a failure code if the watch was misconfigured or aborted, so supervisors notice.
+    process.exit(isOK ? 0 : 1);
   });
 }
 else {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,16 @@ services:
       # Send nuVal requests to the sidecar instead of the W3C service.
       TESTARO_NU_URL: "http://nu:8888/?parser=html&out=json"
       # JODBIR and REPORTDIR from Dockerfile override those from .env.
-      # Import other specific environment variables from .env file.
-      AGENT: ${AGENT}
+      # Import other specific environment variables from .env file. The
+      # NETWATCH_* variables default to empty so that directory-watch use
+      # needs no .env entries for them; set them in .env for server polling.
       WAVE_KEY: ${WAVE_KEY}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      NETWATCH_URL_JOB: ${NETWATCH_URL_JOB:-}
+      NETWATCH_URL_REPORT: ${NETWATCH_URL_REPORT:-}
+      NETWATCH_AUTH_TYPE: ${NETWATCH_AUTH_TYPE:-}
+      NETWATCH_WORKER_ID: ${NETWATCH_WORKER_ID:-}
+      NETWATCH_WORKER_SECRET: ${NETWATCH_WORKER_SECRET:-}
     volumes:
       # Host directories for jobs and reports. The container runs as the
       # unprivileged pwuser; the host directories must be writable by it

--- a/env.example
+++ b/env.example
@@ -14,13 +14,16 @@ WAITS=0
 NODE_OPTIONS='--trace-uncaught --trace-warnings'
 # Suppresses a routine warning from QualWeb.
 PUPPETEER_DISABLE_HEADLESS_WARNING=true
-# Replace the next 2 placeholders with http://localhost:3000 if Kilotest and Testaro are on the same host or the URL of the server (e.g., https://kilotest.com) if they are on different hosts.
+# Replace the next 2 placeholders with http://localhost:3000 if Kilotest and Testaro are on the same host or the URL of the server (e.g., https://kilotest.com) if they are on different hosts. The URL path is determined by agreement between Testaro and the server and may omit any identifier of the Testaro instance.
 # URL to poll for available jobs when watching the network.
-NETWATCH_URL_JOB=__placeholder__/api/testaro-agent/job
+NETWATCH_URL_JOB=__placeholder__
 # URL to report results to when watching the network.
-NETWATCH_URL_REPORT=__placeholder__/api/testaro-agent/report
-# Password of this Testaro agent
+NETWATCH_URL_REPORT=__placeholder__
+# Password of this Testaro agent, supplied as the agentPW property of request bodies when set (optional).
 NETWATCH_URL_AUTH=__placeholder__
+# Identifier and secret of this Testaro worker, supplied as a Basic authorization header when both are set (optional).
+WORKER_ID=__placeholder__
+WORKER_SECRET=__placeholder__
 # Directory (relative to project root) to watch for jobs.
 JOBDIR=__placeholder__
 # Directory (relative to project root) to write reports to when watching a directory for jobs.

--- a/env.example
+++ b/env.example
@@ -2,8 +2,6 @@
 WAVE_KEY=__placeholder__
 # You can get an Anthropic API key at https://console.anthropic.com/.
 ANTHROPIC_API_KEY=__placeholder__
-# Any message from this instance to the server (optional).
-AGENT=__placeholder__
 # Whether to make the browser visible (normally false).
 HEADED_BROWSER=false
 # Whether to output even forked-job logging to the primary log (normally false).
@@ -37,17 +35,12 @@ TESTARO_CHROMIUM_NO_SANDBOX=false
 NETWATCH_URL_JOB=__placeholder__
 # URL to send a job report.
 NETWATCH_URL_REPORT=__placeholder__
-
-# If the server requires authentication without an authorization header:
-
-# Password to be supplied an the agentPW property of the body of the POST request.
-NETWATCH_URL_AUTH=__placeholder__
-
-# If the server requires authentication with an authorization header:
-
-# Identifier and secret of this worker.
-WORKER_ID=__placeholder__
-WORKER_SECRET=__placeholder__
+# Type of authentication (none, pathBody, or header) required by the server.
+NETWATCH_AUTH_TYPE=__placeholder__
+# ID of this instance.
+NETWATCH_WORKER_ID=__placeholder__
+# Password of this instance.
+NETWATCH_WORKER_SECRET=__placeholder__
 
 ## License
 

--- a/env.example
+++ b/env.example
@@ -2,7 +2,7 @@
 WAVE_KEY=__placeholder__
 # You can get an Anthropic API key at https://console.anthropic.com/.
 ANTHROPIC_API_KEY=__placeholder__
-# Name to identify this Testaro instance to a server.
+# Any message from this instance to the server (optional).
 AGENT=__placeholder__
 # Whether to make the browser visible (normally false).
 HEADED_BROWSER=false
@@ -12,18 +12,8 @@ DEBUG=false
 WAITS=0
 # See https://nodejs.org/api/cli.html#options for all permitted options.
 NODE_OPTIONS='--trace-uncaught --trace-warnings'
-# Suppresses a routine warning from QualWeb.
+# Whether to suppress a routine warning from QualWeb.
 PUPPETEER_DISABLE_HEADLESS_WARNING=true
-# Replace the next 2 placeholders with http://localhost:3000 if Kilotest and Testaro are on the same host or the URL of the server (e.g., https://kilotest.com) if they are on different hosts. The URL path is determined by agreement between Testaro and the server and may omit any identifier of the Testaro instance.
-# URL to poll for available jobs when watching the network.
-NETWATCH_URL_JOB=__placeholder__
-# URL to report results to when watching the network.
-NETWATCH_URL_REPORT=__placeholder__
-# Password of this Testaro agent, supplied as the agentPW property of request bodies when set (optional).
-NETWATCH_URL_AUTH=__placeholder__
-# Identifier and secret of this Testaro worker, supplied as a Basic authorization header when both are set (optional).
-WORKER_ID=__placeholder__
-WORKER_SECRET=__placeholder__
 # Directory (relative to project root) to watch for jobs.
 JOBDIR=__placeholder__
 # Directory (relative to project root) to write reports to when watching a directory for jobs.
@@ -39,6 +29,25 @@ TESTARO_NU_URL=__placeholder__
 # seccomp policies and some hardened hosts prohibit. Set this to true in containers,
 # or run containers with a seccomp profile that permits user-namespace cloning.
 TESTARO_CHROMIUM_NO_SANDBOX=false
+
+# netWatch variables
+
+# Replace the next 2 placeholders with the URL of the server (e.g., http://localhost:3000 or  https://kilotest.com), including the path required by the server.
+# URL to poll for available jobs.
+NETWATCH_URL_JOB=__placeholder__
+# URL to send a job report.
+NETWATCH_URL_REPORT=__placeholder__
+
+# If the server requires authentication without an authorization header:
+
+# Password to be supplied an the agentPW property of the body of the POST request.
+NETWATCH_URL_AUTH=__placeholder__
+
+# If the server requires authentication with an authorization header:
+
+# Identifier and secret of this worker.
+WORKER_ID=__placeholder__
+WORKER_SECRET=__placeholder__
 
 ## License
 

--- a/env.example
+++ b/env.example
@@ -37,9 +37,10 @@ NETWATCH_URL_JOB=__placeholder__
 NETWATCH_URL_REPORT=__placeholder__
 # Type of authentication (none, pathBody, or header) required by the server.
 NETWATCH_AUTH_TYPE=__placeholder__
-# ID of this instance.
+# ID of this instance. Recorded in reports as sources.agent and used by header
+# authentication (where it must not contain a colon).
 NETWATCH_WORKER_ID=__placeholder__
-# Password of this instance.
+# Password of this instance. Required when NETWATCH_AUTH_TYPE is pathBody or header.
 NETWATCH_WORKER_SECRET=__placeholder__
 
 ## License

--- a/netWatch.js
+++ b/netWatch.js
@@ -112,6 +112,9 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
             .on('error', async error => {
               // Report it.
               console.log(`${logStart}error message ${error.message}`);
+              // Wait for the specified interval.
+              await wait(1000 * intervalInSeconds);
+              resolve(true);
             })
             // If the response delivers data:
             .on('data', chunk => {
@@ -165,12 +168,17 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
                       let responseJSON = JSON.stringify(responseObj, null, 2);
                       console.log(`Job ${id} finished (${nowString()})`);
                       const reportLogStart = `Submitted report ${id} to ${reportURL} and got `;
+                      // Get the options and client for a report-submission request.
                       const requestOptions = {
                         method: 'POST',
                         headers
                       };
+                      let client = httpClient;
+                      if (reportURL.protocol === 'https:') {
+                        client = httpsClient;
+                        requestOptions.rejectUnauthorized = ! isCertTolerant;
+                      }
                       // Submit the report.
-                      const client = reportURL.protocol === 'https:' ? httpsClient : httpClient;
                       client.request(reportURL, requestOptions, repResponse => {
                         // Initialize a collection of data from the response.
                         const chunks = [];

--- a/netWatch.js
+++ b/netWatch.js
@@ -67,7 +67,11 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
     jobHost
     && reportHost
     && ['none', 'pathBody', 'header'].includes(authType)
-    && (authType === 'none' || workerID && workerSecret)
+    && (
+      authType === 'none'
+      || authType === 'pathBody' && workerSecret
+      || authType === 'header' && workerID && workerSecret
+    )
   ) {
     // Configure the watch.
     const headers = {
@@ -135,12 +139,7 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
                   const jobValidity = isValidJob(contentObj);
                   // If it is invalid:
                   if (! jobValidity.isValid) {
-                    // Report this to the server.
-                    response.setHeader('content-type', 'application/json; charset=utf-8');
-                    response.end(JSON.stringify({
-                      message: 'invalidJob',
-                      error: jobValidity.error
-                    }));
+                    // Report this.
                     console.log(`${logStart}invalid job (${jobValidity.error})`);
                     // Wait for the specified interval.
                     await wait(1000 * intervalInSeconds);

--- a/netWatch.js
+++ b/netWatch.js
@@ -98,12 +98,17 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
       // Perform it.
       await new Promise(async resolve => {
         try {
-          const client = jobURL.protocol === 'https:' ? httpsClient : httpClient;
-          // Request a job.
+          // Get the client and request options for a job request.
+          let client = httpClient;
           const requestOptions = {
             method: 'POST',
             headers
           };
+          if (jobURL.protocol === 'https:') {
+            client = httpsClient;
+            requestOptions.rejectUnauthorized = ! isCertTolerant;
+          }
+          // Request a job.
           client.request(jobURL, requestOptions, response => {
             // Initialize a collection of data from the response.
             const chunks = [];

--- a/netWatch.js
+++ b/netWatch.js
@@ -44,8 +44,24 @@ const toURL = urlString => {
 const jobURL = toURL(process.env.NETWATCH_URL_JOB);
 const jobHost = jobURL && jobURL.host;
 const reportURL = toURL(process.env.NETWATCH_URL_REPORT);
-const reportHost = reportURL && reportURL.host;
 const agentPW = process.env.NETWATCH_URL_AUTH;
+// If a worker ID and secret are configured, build a Basic authorization header
+// value from them, so a watched server can authenticate the Testaro instance.
+const workerID = process.env.WORKER_ID;
+const workerSecret = process.env.WORKER_SECRET;
+const basicAuth = workerID && workerSecret
+  ? `Basic ${Buffer.from(`${workerID}:${workerSecret}`).toString('base64')}`
+  : null;
+// Builds the headers for a request to a watched server.
+const makeHeaders = () => {
+  const headers = {
+    'content-type': 'application/json; charset=utf-8'
+  };
+  if (basicAuth) {
+    headers.authorization = basicAuth;
+  }
+  return headers;
+};
 
 // FUNCTIONS
 
@@ -94,10 +110,7 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
           // Request a job.
           const requestOptions = {
             method: 'POST',
-            headers: {
-              host: jobHost,
-              'content-type': 'application/json; charset=utf-8'
-            }
+            headers: makeHeaders()
           };
           client.request(jobURL, requestOptions, response => {
             // Initialize a collection of data from the response.
@@ -136,7 +149,7 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
                   if (! jobValidity.isValid) {
                     // Report this to the server.
                     respondWithObject({
-                      message: `invalidJob`,
+                      message: 'invalidJob',
                       error: jobValidity.error
                     }, response);
                     console.log(`${logStart}invalid job (${jobValidity.error})`);
@@ -155,18 +168,17 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
                     try {
                       const report = await doJob(contentObj);
                       const responseObj = {
-                        agentPW,
                         report
                       };
+                      if (agentPW) {
+                        responseObj.agentPW = agentPW;
+                      }
                       let responseJSON = JSON.stringify(responseObj, null, 2);
                       console.log(`Job ${id} finished (${nowString()})`);
                       const reportLogStart = `Submitted report ${id} to ${reportURL} and got `;
                       const requestOptions = {
                         method: 'POST',
-                        headers: {
-                          host: reportHost,
-                          'content-type': 'application/json; charset=utf-8'
-                        }
+                        headers: makeHeaders()
                       };
                       // Submit the report.
                       const client = reportURL.protocol === 'https:' ? httpsClient : httpClient;
@@ -252,7 +264,7 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
                 // Wait for the specified interval.
                 await wait(1000 * intervalInSeconds);
                 resolve(true);
-              };
+              }
             });
           })
           // If the job request throws an error:
@@ -282,9 +294,9 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
             resolve(true);
           })
           // Finish sending the job request.
-          .end(JSON.stringify({
-            agentPW
-          }));
+          .end(JSON.stringify(
+            agentPW ? {agentPW} : {}
+          ));
         }
         // If requesting a job throws an error:
         catch(error) {

--- a/netWatch.js
+++ b/netWatch.js
@@ -28,11 +28,9 @@ const {doJob} = require('./run');
 // Module to process dates and times.
 const {nowString} = require('./procs/dateTime');
 
-// CONSTANTS
+// FUNCTIONS
 
-// The netWatch environment variables are required only for network watching,
-// but call.js loads this module for every command, so their absence or
-// invalidity must not throw here; netWatch reports it if netWatch is used.
+// Returns the URL represented by a string, or null if invalid.
 const toURL = urlString => {
   try {
     return new URL(urlString);
@@ -41,30 +39,6 @@ const toURL = urlString => {
     return null;
   }
 };
-const jobURL = toURL(process.env.NETWATCH_URL_JOB);
-const jobHost = jobURL && jobURL.host;
-const reportURL = toURL(process.env.NETWATCH_URL_REPORT);
-const agentPW = process.env.NETWATCH_URL_AUTH;
-// If a worker ID and secret are configured, build a Basic authorization header
-// value from them, so a watched server can authenticate the Testaro instance.
-const workerID = process.env.WORKER_ID;
-const workerSecret = process.env.WORKER_SECRET;
-const basicAuth = workerID && workerSecret
-  ? `Basic ${Buffer.from(`${workerID}:${workerSecret}`).toString('base64')}`
-  : null;
-// Builds the headers for a request to a watched server.
-const makeHeaders = () => {
-  const headers = {
-    'content-type': 'application/json; charset=utf-8'
-  };
-  if (basicAuth) {
-    headers.authorization = basicAuth;
-  }
-  return headers;
-};
-
-// FUNCTIONS
-
 // Waits.
 const wait = ms => {
   return new Promise(resolve => {
@@ -73,22 +47,36 @@ const wait = ms => {
     }, ms);
   });
 };
-// Ends a response with an object in JSON format.
-const respondWithObject = (object, response) => {
-  response.setHeader('content-type', 'application/json; charset=utf-8');
-  response.end(JSON.stringify(object));
-};
 /*
   Requests a network job and, when found, performs and reports it.
   Arguments:
   0. whether to continue watching after a job is run.
   1: interval in seconds from a no-job check to the next check.
-  2. whether to ignore unknown-certificate errors from watched servers.
+  2. whether to ignore unknown-certificate errors from a watched server.
 */
 exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) => {
-  // If the job and report URLs exist and are valid:
-  if (jobURL && reportURL) {
+  const jobURL = toURL(process.env.NETWATCH_URL_JOB);
+  const reportURL = toURL(process.env.NETWATCH_URL_REPORT);
+  const authType = process.env.NETWATCH_AUTH_TYPE;
+  const workerID = process.env.NETWATCH_WORKER_ID;
+  const workerSecret = process.env.NETWATCH_WORKER_SECRET;
+  const jobHost = jobURL && jobURL.host;
+  const reportHost = reportURL && reportURL.host;
+  // If the netWatch configuration is valid:
+  if (
+    jobHost
+    && reportHost
+    && ['none', 'pathBody', 'header'].includes(authType)
+    && (authType === 'none' || workerID && workerSecret)
+  ) {
     // Configure the watch.
+    const headers = {
+      'content-type': 'application/json; charset=utf-8'
+    };
+    if (authType === 'header') {
+      const authBuffer = Buffer.from(`${workerID}:${workerSecret}`);
+      headers.authorization = `Basic ${authBuffer.toString('base64')}`;
+    }
     let noJobYet = true;
     let abort = false;
     const certInfo = `Certificate-${isCertTolerant ? '' : 'in'}tolerant`;
@@ -110,7 +98,7 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
           // Request a job.
           const requestOptions = {
             method: 'POST',
-            headers: makeHeaders()
+            headers
           };
           client.request(jobURL, requestOptions, response => {
             // Initialize a collection of data from the response.
@@ -132,7 +120,7 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
               try {
                 // Parse it as a JSON job.
                 let contentObj = JSON.parse(content);
-                const {id, sources} = contentObj;
+                const {id} = contentObj;
                 // If it is a no-job message:
                 if (! Object.keys(contentObj).length) {
                   // Report this.
@@ -148,10 +136,11 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
                   // If it is invalid:
                   if (! jobValidity.isValid) {
                     // Report this to the server.
-                    respondWithObject({
+                    response.setHeader('content-type', 'application/json; charset=utf-8');
+                    response.end(JSON.stringify({
                       message: 'invalidJob',
                       error: jobValidity.error
-                    }, response);
+                    }));
                     console.log(`${logStart}invalid job (${jobValidity.error})`);
                     // Wait for the specified interval.
                     await wait(1000 * intervalInSeconds);
@@ -161,24 +150,25 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
                   else {
                     // Prevent further watching, if unwanted.
                     noJobYet = false;
-                    // Add the agent and the server ID to the job.
-                    sources.agent = process.env.AGENT || '';
-                    // Perform the job and create a report.
                     console.log(`${logStart}job ${id} (${nowString()})`);
                     try {
+                      // Perform the job and create a report.
                       const report = await doJob(contentObj);
+                      // Make it the report property of the response body.
                       const responseObj = {
                         report
                       };
-                      if (agentPW) {
-                        responseObj.agentPW = agentPW;
+                      // If a worker secret is required:
+                      if (authType === 'pathBody') {
+                        // Add it to the response body.
+                        responseObj.agentPW = workerSecret;
                       }
                       let responseJSON = JSON.stringify(responseObj, null, 2);
                       console.log(`Job ${id} finished (${nowString()})`);
                       const reportLogStart = `Submitted report ${id} to ${reportURL} and got `;
                       const requestOptions = {
                         method: 'POST',
-                        headers: makeHeaders()
+                        headers
                       };
                       // Submit the report.
                       const client = reportURL.protocol === 'https:' ? httpsClient : httpClient;
@@ -295,7 +285,7 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
           })
           // Finish sending the job request.
           .end(JSON.stringify(
-            agentPW ? {agentPW} : {}
+            authType === 'pathBody' ? {agentPW: workerSecret} : {}
           ));
         }
         // If requesting a job throws an error:
@@ -313,6 +303,6 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
   // Otherwise, i.e. if the job or report URL does not exist or is invalid:
   else {
     // Report this.
-    console.log('ERROR: Job or report URL does not exist or is invalid');
+    console.log('ERROR: Configuration of netWatch is invalid');
   }
 };

--- a/netWatch.js
+++ b/netWatch.js
@@ -18,6 +18,8 @@
 
 // Module to keep secrets.
 require('dotenv').config();
+// Module to access files.
+const fs = require('fs/promises');
 // Module to validate jobs.
 const {isValidJob} = require('./procs/job');
 // Modules to make requests to servers.
@@ -27,6 +29,15 @@ const httpsClient = require('https');
 const {doJob} = require('./run');
 // Module to process dates and times.
 const {nowString} = require('./procs/dateTime');
+
+// CONSTANTS
+
+// Auth types and the environment variables each one requires.
+const authRequirements = {
+  none: [],
+  pathBody: ['NETWATCH_WORKER_SECRET'],
+  header: ['NETWATCH_WORKER_ID', 'NETWATCH_WORKER_SECRET']
+};
 
 // FUNCTIONS
 
@@ -47,166 +58,301 @@ const wait = ms => {
     }, ms);
   });
 };
+// Returns the value of a basic authorization header for a worker ID and secret.
+const basicAuthHeader = (workerID, workerSecret) =>
+  `Basic ${Buffer.from(`${workerID}:${workerSecret}`).toString('base64')}`;
+// Returns the netWatch configuration from the environment, with any problems named.
+const getConfig = () => {
+  const problems = [];
+  const warnings = [];
+  let authType = process.env.NETWATCH_AUTH_TYPE;
+  let workerID = process.env.NETWATCH_WORKER_ID;
+  let workerSecret = process.env.NETWATCH_WORKER_SECRET;
+  // If the worker ID is specified only by the deprecated AGENT variable:
+  if (! workerID && process.env.AGENT) {
+    // Adopt it and warn about the deprecation.
+    workerID = process.env.AGENT;
+    warnings.push('AGENT is deprecated; rename it to NETWATCH_WORKER_ID');
+  }
+  // If the auth type is unspecified but the deprecated NETWATCH_URL_AUTH variable exists:
+  if (! authType && process.env.NETWATCH_URL_AUTH) {
+    // Treat the configuration as a pathBody configuration and warn about the deprecation.
+    authType = 'pathBody';
+    workerSecret ||= process.env.NETWATCH_URL_AUTH;
+    warnings.push(
+      'NETWATCH_URL_AUTH is deprecated; set NETWATCH_AUTH_TYPE=pathBody and NETWATCH_WORKER_SECRET'
+    );
+  }
+  // If no auth configuration exists at all:
+  if (! authType && ! workerSecret) {
+    // Treat the configuration as an unauthenticated configuration and warn about this.
+    authType = 'none';
+    warnings.push('NETWATCH_AUTH_TYPE not set; defaulting to none (no credentials sent)');
+  }
+  const jobURL = toURL(process.env.NETWATCH_URL_JOB);
+  const reportURL = toURL(process.env.NETWATCH_URL_REPORT);
+  // Identify any problems with the configuration, naming the offending variables.
+  if (! jobURL) {
+    problems.push(`NETWATCH_URL_JOB missing or not a valid URL (${process.env.NETWATCH_URL_JOB})`);
+  }
+  if (! reportURL) {
+    problems.push(
+      `NETWATCH_URL_REPORT missing or not a valid URL (${process.env.NETWATCH_URL_REPORT})`
+    );
+  }
+  if (! Object.keys(authRequirements).includes(authType)) {
+    problems.push(
+      `NETWATCH_AUTH_TYPE (${authType}) not one of ${Object.keys(authRequirements).join(', ')}`
+    );
+  }
+  else {
+    const varValues = {
+      NETWATCH_WORKER_ID: workerID,
+      NETWATCH_WORKER_SECRET: workerSecret
+    };
+    authRequirements[authType].forEach(varName => {
+      if (! varValues[varName]) {
+        problems.push(`${varName} required when NETWATCH_AUTH_TYPE is ${authType}`);
+      }
+    });
+    // If the worker ID contains a colon, prohibited in basic authentication by RFC 7617:
+    if (authType === 'header' && workerID && workerID.includes(':')) {
+      problems.push('NETWATCH_WORKER_ID must not contain a colon');
+    }
+    // If any credential is not ASCII-only, so servers may decode it differently:
+    if ([workerID, workerSecret].some(value => value && /[^\x20-\x7e]/.test(value))) {
+      warnings.push(
+        'NETWATCH_WORKER_ID or NETWATCH_WORKER_SECRET contains non-ASCII characters, which servers may decode differently'
+      );
+    }
+  }
+  return {problems, warnings, jobURL, reportURL, authType, workerID, workerSecret};
+};
+// Saves a report that could not be submitted, so it is not lost.
+const saveFailedReport = async report => {
+  try {
+    const saveDir = `${process.env.REPORTDIR || '.'}/netWatchFailed`;
+    await fs.mkdir(saveDir, {recursive: true});
+    const savePath = `${saveDir}/${report && report.id || 'report'}.json`;
+    await fs.writeFile(savePath, JSON.stringify(report, null, 2));
+    console.log(`Unsubmitted report saved at ${savePath}`);
+  }
+  catch(error) {
+    console.log(`ERROR saving unsubmitted report (${error.message})`);
+  }
+};
 /*
   Requests a network job and, when found, performs and reports it.
   Arguments:
   0. whether to continue watching after a job is run.
   1: interval in seconds from a no-job check to the next check.
-  2. whether to ignore unknown-certificate errors from a watched server.
+  2. whether to ignore unknown-certificate errors from a watched server (default false).
+  Returns whether watching ended without an abort, an invalid configuration, or a lost report.
 */
-exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) => {
-  const jobURL = toURL(process.env.NETWATCH_URL_JOB);
-  const reportURL = toURL(process.env.NETWATCH_URL_REPORT);
-  const authType = process.env.NETWATCH_AUTH_TYPE;
-  const workerID = process.env.NETWATCH_WORKER_ID;
-  const workerSecret = process.env.NETWATCH_WORKER_SECRET;
-  const jobHost = jobURL && jobURL.host;
-  const reportHost = reportURL && reportURL.host;
-  // If the netWatch configuration is valid:
-  if (
-    jobHost
-    && reportHost
-    && ['none', 'pathBody', 'header'].includes(authType)
-    && (
-      authType === 'none'
-      || authType === 'pathBody' && workerSecret
-      || authType === 'header' && workerID && workerSecret
-    )
-  ) {
-    // Configure the watch.
-    const headers = {
-      'content-type': 'application/json; charset=utf-8'
+exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = false) => {
+  const {problems, warnings, jobURL, reportURL, authType, workerID, workerSecret} = getConfig();
+  // Report any warnings about the configuration.
+  warnings.forEach(warning => {
+    console.log(`WARNING: ${warning}`);
+  });
+  // If the netWatch configuration is invalid:
+  if (problems.length) {
+    // Report each problem and quit.
+    problems.forEach(problem => {
+      console.log(`ERROR: ${problem}`);
+    });
+    console.log('ERROR: Configuration of netWatch is invalid');
+    return false;
+  }
+  // Configure the watch.
+  const headers = {
+    'content-type': 'application/json; charset=utf-8'
+  };
+  if (authType === 'header') {
+    headers.authorization = basicAuthHeader(workerID, workerSecret);
+  }
+  // Body properties transmitting the credentials, if the auth type requires them there.
+  const authBody = authType === 'pathBody' ? {agentPW: workerSecret} : {};
+  const jobRequestJSON = JSON.stringify(authBody);
+  // Returns the client and request options for a request to a URL.
+  const requestConfigFor = url => {
+    const options = {
+      method: 'POST',
+      headers: {... headers}
     };
-    if (authType === 'header') {
-      const authBuffer = Buffer.from(`${workerID}:${workerSecret}`);
-      headers.authorization = `Basic ${authBuffer.toString('base64')}`;
+    let client = httpClient;
+    if (url.protocol === 'https:') {
+      client = httpsClient;
+      options.rejectUnauthorized = ! isCertTolerant;
     }
-    let noJobYet = true;
-    let abort = false;
-    const certInfo = `Certificate-${isCertTolerant ? '' : 'in'}tolerant`;
-    const foreverInfo = isForever ? 'repeating' : 'one-job';
-    const intervalInfo = `with ${intervalInSeconds}-second intervals`;
+    return {client, options};
+  };
+  // If certificate tolerance would expose credentials on an encrypted connection:
+  if (isCertTolerant && [jobURL, reportURL].some(url => url.protocol === 'https:')) {
+    // Warn about this.
     console.log(
-      `${certInfo} ${foreverInfo} network watching started ${intervalInfo} (${nowString()})\n`
+      'WARNING: Certificate tolerance disables certificate verification, so credentials and reports are exposed to interception'
     );
-    // As long as watching is to continue:
-    while ((isForever || noJobYet) && ! abort) {
-      // Log the start of a check.
-      console.log('--');
-      // Configure the next check.
-      const logStart = `Requested job from ${jobHost} and got `;
-      // Perform it.
-      await new Promise(async resolve => {
-        try {
-          // Get the client and request options for a job request.
-          let client = httpClient;
-          const requestOptions = {
-            method: 'POST',
-            headers
-          };
-          if (jobURL.protocol === 'https:') {
-            client = httpsClient;
-            requestOptions.rejectUnauthorized = ! isCertTolerant;
-          }
-          // Request a job.
-          client.request(jobURL, requestOptions, response => {
-            // Initialize a collection of data from the response.
-            const chunks = [];
-            response
-            // If the response throws an error:
-            .on('error', async error => {
+  }
+  let noJobYet = true;
+  let abort = false;
+  let reportLost = false;
+  const jobHost = jobURL.host;
+  const certInfo = `Certificate-${isCertTolerant ? '' : 'in'}tolerant`;
+  const foreverInfo = isForever ? 'repeating' : 'one-job';
+  const intervalInfo = `with ${intervalInSeconds}-second intervals`;
+  console.log(
+    `${certInfo} ${foreverInfo} network watching started ${intervalInfo} (${nowString()})\n`
+  );
+  // As long as watching is to continue:
+  while ((isForever || noJobYet) && ! abort) {
+    // Log the start of a check.
+    console.log('--');
+    // Configure the next check.
+    const logStart = `Requested job from ${jobHost} and got `;
+    // Perform it.
+    await new Promise(resolve => {
+      // Ensure the check is concluded at most once, so error events cannot start overlapping checks.
+      let settled = false;
+      let jobDispatched = false;
+      const finish = () => {
+        if (! settled) {
+          settled = true;
+          resolve(true);
+        }
+      };
+      const finishAfterWait = async () => {
+        if (! settled) {
+          // Wait for the specified interval.
+          await wait(1000 * intervalInSeconds);
+          finish();
+        }
+      };
+      try {
+        // Get the client and request options for a job request.
+        const {client, options} = requestConfigFor(jobURL);
+        // Request a job.
+        client.request(jobURL, options, response => {
+          // Initialize a collection of data from the response.
+          const chunks = [];
+          response
+          // If the response throws an error:
+          .on('error', error => {
+            // Report it.
+            console.log(`${logStart}error message ${error.message}`);
+            // Unless a job is already being performed, wait and conclude the check.
+            if (! jobDispatched) {
+              finishAfterWait();
+            }
+          })
+          // If the response delivers data:
+          .on('data', chunk => {
+            // Add them to the collection.
+            chunks.push(chunk);
+          })
+          // When the response is completed:
+          .on('end', async () => {
+            const content = chunks.join('');
+            const {statusCode} = response;
+            // If the server reported a failure:
+            if (statusCode < 200 || statusCode > 299) {
               // Report it.
-              console.log(`${logStart}error message ${error.message}`);
-              // Wait for the specified interval.
-              await wait(1000 * intervalInSeconds);
-              resolve(true);
-            })
-            // If the response delivers data:
-            .on('data', chunk => {
-              // Add them to the collection.
-              chunks.push(chunk);
-            })
-            // When the response is completed:
-            .on('end', async () => {
-              const content = chunks.join('');
-              try {
-                // Parse it as a JSON job.
-                let contentObj = JSON.parse(content);
-                const {id} = contentObj;
-                // If it is a no-job message:
-                if (! Object.keys(contentObj).length) {
+              console.log(
+                `ERROR: ${logStart}status ${statusCode} and response ${content.slice(0, 1000)}`
+              );
+              // If it was an authentication or authorization rejection:
+              if ([401, 403].includes(statusCode)) {
+                // Abort the watch, because rechecking cannot succeed until it is reconfigured.
+                abort = true;
+                finish();
+              }
+              // Otherwise, i.e. if the failure may be transient:
+              else {
+                // Wait and conclude the check.
+                finishAfterWait();
+              }
+              return;
+            }
+            try {
+              // Parse it as a JSON job.
+              let contentObj = JSON.parse(content);
+              const {id} = contentObj;
+              // If it is a no-job message:
+              if (! Object.keys(contentObj).length) {
+                // Report this.
+                console.log(`${logStart}no job to do; waiting ${intervalInSeconds} sec before next check`);
+                // Wait and conclude the check.
+                finishAfterWait();
+              }
+              // Otherwise, if it is a job:
+              else if (id) {
+                // Check it for validity.
+                const jobValidity = isValidJob(contentObj);
+                // If it is invalid:
+                if (! jobValidity.isValid) {
                   // Report this.
-                  console.log(`${logStart}no job to do; waiting ${intervalInSeconds} sec before next check`);
-                  // Wait for the specified interval.
-                  await wait(1000 * intervalInSeconds);
-                  resolve(true);
+                  console.log(`${logStart}invalid job (${jobValidity.error})`);
+                  // Wait and conclude the check.
+                  finishAfterWait();
                 }
-                // Otherwise, if it is a job:
-                else if (id) {
-                  // Check it for validity.
-                  const jobValidity = isValidJob(contentObj);
-                  // If it is invalid:
-                  if (! jobValidity.isValid) {
-                    // Report this.
-                    console.log(`${logStart}invalid job (${jobValidity.error})`);
-                    // Wait for the specified interval.
-                    await wait(1000 * intervalInSeconds);
-                    resolve(true);
+                // Otherwise, i.e. if it is valid:
+                else {
+                  // Prevent further watching, if unwanted.
+                  noJobYet = false;
+                  jobDispatched = true;
+                  // Identify this worker in the report, if a worker ID exists.
+                  if (workerID && contentObj.sources) {
+                    contentObj.sources.agent = workerID;
                   }
-                  // Otherwise, i.e. if it is valid:
-                  else {
-                    // Prevent further watching, if unwanted.
-                    noJobYet = false;
-                    console.log(`${logStart}job ${id} (${nowString()})`);
-                    try {
-                      // Perform the job and create a report.
-                      const report = await doJob(contentObj);
-                      // Make it the report property of the response body.
-                      const responseObj = {
-                        report
-                      };
-                      // If a worker secret is required:
-                      if (authType === 'pathBody') {
-                        // Add it to the response body.
-                        responseObj.agentPW = workerSecret;
-                      }
-                      let responseJSON = JSON.stringify(responseObj, null, 2);
-                      console.log(`Job ${id} finished (${nowString()})`);
-                      const reportLogStart = `Submitted report ${id} to ${reportURL} and got `;
-                      // Get the options and client for a report-submission request.
-                      const requestOptions = {
-                        method: 'POST',
-                        headers
-                      };
-                      let client = httpClient;
-                      if (reportURL.protocol === 'https:') {
-                        client = httpsClient;
-                        requestOptions.rejectUnauthorized = ! isCertTolerant;
-                      }
-                      // Submit the report.
-                      client.request(reportURL, requestOptions, repResponse => {
-                        // Initialize a collection of data from the response.
-                        const chunks = [];
-                        repResponse
-                        // If the response to the report threw an error:
-                        .on('error', async error => {
-                          // Report this.
-                          console.log(`${reportLogStart}error message ${error.message}\n`);
-                          // Wait for the specified interval.
-                          await wait(1000 * intervalInSeconds);
-                          resolve(true);
-                        })
-                        // If the response delivers data:
-                        .on('data', chunk => {
-                          // Add them to the collection.
-                          chunks.push(chunk);
-                        })
-                        // When the response to the report is completed:
-                        .on('end', async () => {
-                          const content = chunks.join('');
+                  console.log(`${logStart}job ${id} (${nowString()})`);
+                  try {
+                    // Perform the job and create a report.
+                    const report = await doJob(contentObj);
+                    // Make it the report property of the response body, with any body credentials.
+                    const responseObj = {
+                      ... authBody,
+                      report
+                    };
+                    let responseJSON = JSON.stringify(responseObj, null, 2);
+                    console.log(`Job ${id} finished (${nowString()})`);
+                    const reportLogStart = `Submitted report ${id} to ${reportURL} and got `;
+                    // Get the client and request options for a report-submission request.
+                    const {client: repClient, options: repOptions} = requestConfigFor(reportURL);
+                    // Submit the report.
+                    repClient.request(reportURL, repOptions, repResponse => {
+                      // Initialize a collection of data from the response.
+                      const repChunks = [];
+                      repResponse
+                      // If the response to the report threw an error:
+                      .on('error', error => {
+                        // Report this.
+                        console.log(`${reportLogStart}error message ${error.message}\n`);
+                        // Wait and conclude the check.
+                        finishAfterWait();
+                      })
+                      // If the response delivers data:
+                      .on('data', chunk => {
+                        // Add them to the collection.
+                        repChunks.push(chunk);
+                      })
+                      // When the response to the report is completed:
+                      .on('end', async () => {
+                        const repContent = repChunks.join('');
+                        const repStatusCode = repResponse.statusCode;
+                        // If the server reported a failure:
+                        if (repStatusCode < 200 || repStatusCode > 299) {
+                          // Report this and save the report, so it is not lost.
+                          console.log(
+                            `ERROR: ${reportLogStart}status ${repStatusCode} and response ${repContent.slice(0, 1000)}\n`
+                          );
+                          reportLost = true;
+                          await saveFailedReport(report);
+                        }
+                        // Otherwise, i.e. if the server accepted the report:
+                        else {
                           try {
-                            // Parse it as a JSON message.
-                            const ackObj = JSON.parse(content);
+                            // Parse the acknowledgement as JSON.
+                            const ackObj = JSON.parse(repContent);
                             // Report it.
                             console.log(
                               `${reportLogStart}response message: ${JSON.stringify(ackObj, null, 2)}\n`
@@ -216,105 +362,95 @@ exports.netWatch = async (isForever, intervalInSeconds, isCertTolerant = true) =
                           catch(error) {
                             // Report this.
                             console.log(
-                              `ERROR: ${reportLogStart}status ${repResponse.statusCode}, error message ${error.message}, and response ${content.slice(0, 1000)}\n`
+                              `ERROR: ${reportLogStart}status ${repStatusCode}, error message ${error.message}, and response ${repContent.slice(0, 1000)}\n`
                             );
-                            // Wait for the specified interval.
-                            await wait(1000 * intervalInSeconds);
                           }
-                          // Free the memory used by the job and the report.
-                          contentObj = {};
-                          responseJSON = '';
-                          resolve(true);
-                        });
-                      })
-                      // If the report submission throws an error:
-                      .on('error', async error => {
-                        // Abort the watch.
-                        abort = true;
-                        // Report this.
-                        console.log(
-                          `ERROR ${error.code} in report submission: ${reportLogStart}error message ${error.message}\n`
-                        );
-                        // Wait for the specified interval.
-                        await wait(1000 * intervalInSeconds);
-                        resolve(true);
-                      })
-                      // Finish submitting the report.
-                      .end(responseJSON);
-                    }
-                    catch(error) {
-                      console.log(`ERROR performing job ${id} (${error.message})`);
-                      // Wait for the specified interval.
-                      await wait(1000 * intervalInSeconds);
-                      resolve(true);
-                    }
+                        }
+                        // Free the memory used by the job and the report.
+                        contentObj = {};
+                        responseJSON = '';
+                        finish();
+                      });
+                    })
+                    // If the report submission throws an error:
+                    .on('error', async error => {
+                      // Abort the watch.
+                      abort = true;
+                      // Report this and save the report, so it is not lost.
+                      console.log(
+                        `ERROR ${error.code} in report submission: ${reportLogStart}error message ${error.message}\n`
+                      );
+                      reportLost = true;
+                      await saveFailedReport(report);
+                      finish();
+                    })
+                    // Finish submitting the report.
+                    .end(responseJSON);
+                  }
+                  catch(error) {
+                    console.log(`ERROR performing job ${id} (${error.message})`);
+                    // Wait and conclude the check.
+                    finishAfterWait();
                   }
                 }
-                // Otherwise, i.e. if it is a message:
-                else {
-                  // Report it.
-                  console.log(`${logStart}${JSON.stringify(contentObj, null, 2)}`);
-                  // Wait for the specified interval.
-                  await wait(1000 * intervalInSeconds);
-                  resolve(true);
-                }
               }
-              // Otherwise, i.e. if it is not JSON:
-              catch(error) {
-                // Report this.
-                console.log(`ERROR: ${logStart}status ${response.statusCode}, error message ${error.message}, and non-JSON response ${content.slice(0, 1000)}\n`);
-                // Wait for the specified interval.
-                await wait(1000 * intervalInSeconds);
-                resolve(true);
+              // Otherwise, i.e. if it is a message:
+              else {
+                // Report it.
+                console.log(`${logStart}${JSON.stringify(contentObj, null, 2)}`);
+                // Wait and conclude the check.
+                finishAfterWait();
               }
-            });
-          })
-          // If the job request throws an error:
-          .on('error', async error => {
-            // If it is a refusal to connect:
-            if (error.code && error.code.includes('ECONNREFUSED')) {
-              // Report this.
-              console.log(`${logStart}no connection`);
             }
-            // Otherwise, if it was a DNS failure:
-            else if (error.code && error.code.includes('ENOTFOUND')) {
+            // Otherwise, i.e. if it is not JSON:
+            catch(error) {
               // Report this.
-              console.log(`${logStart}no domain name resolution`);
+              console.log(`ERROR: ${logStart}status ${response.statusCode}, error message ${error.message}, and non-JSON response ${content.slice(0, 1000)}\n`);
+              // Wait and conclude the check.
+              finishAfterWait();
             }
-            // Otherwise, if it was any other error with a message:
-            else if (error.message) {
-              // Report this.
-              console.log(`ERROR: ${logStart}got error message ${error.message.slice(0, 200)}`);
-            }
-            // Otherwise, i.e. if it was any other error with no message:
-            else {
-              // Report this.
-              console.log(`ERROR: ${logStart}got an error with no message`);
-            }
-            // Wait for the specified interval.
-            await wait(1000 * intervalInSeconds);
-            resolve(true);
-          })
-          // Finish sending the job request.
-          .end(JSON.stringify(
-            authType === 'pathBody' ? {agentPW: workerSecret} : {}
-          ));
-        }
-        // If requesting a job throws an error:
-        catch(error) {
-          // Report this.
-          console.log(`ERROR requesting a network job (${error.message})`);
-          // Wait for the specified interval.
-          await wait(1000 * intervalInSeconds);
-          resolve(true);
-        }
-      });
-    }
-    console.log(`Watching ${abort ? 'aborted' : 'complete'}`);
+          });
+        })
+        // If the job request throws an error:
+        .on('error', error => {
+          // If it is a refusal to connect:
+          if (error.code && error.code.includes('ECONNREFUSED')) {
+            // Report this.
+            console.log(`${logStart}no connection`);
+          }
+          // Otherwise, if it was a DNS failure:
+          else if (error.code && error.code.includes('ENOTFOUND')) {
+            // Report this.
+            console.log(`${logStart}no domain name resolution`);
+          }
+          // Otherwise, if it was any other error with a message:
+          else if (error.message) {
+            // Report this.
+            console.log(`ERROR: ${logStart}got error message ${error.message.slice(0, 200)}`);
+          }
+          // Otherwise, i.e. if it was any other error with no message:
+          else {
+            // Report this.
+            console.log(`ERROR: ${logStart}got an error with no message`);
+          }
+          // Unless a job is already being performed, wait and conclude the check.
+          if (! jobDispatched) {
+            finishAfterWait();
+          }
+        })
+        // Finish sending the job request.
+        .end(jobRequestJSON);
+      }
+      // If requesting a job throws an error:
+      catch(error) {
+        // Report this.
+        console.log(`ERROR requesting a network job (${error.message})`);
+        // Wait and conclude the check.
+        finishAfterWait();
+      }
+    });
   }
-  // Otherwise, i.e. if the job or report URL does not exist or is invalid:
-  else {
-    // Report this.
-    console.log('ERROR: Configuration of netWatch is invalid');
-  }
+  console.log(`Watching ${abort ? 'aborted' : 'complete'}`);
+  return ! (abort || reportLost);
 };
+exports.basicAuthHeader = basicAuthHeader;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testaro",
-  "version": "78.0.8",
+  "version": "78.1.0",
   "description": "Run 1300 web accessibility tests from 10 tools and get a standardized report",
   "main": "index.js",
   "scripts": {

--- a/validation/executors/netWatch.js
+++ b/validation/executors/netWatch.js
@@ -1,5 +1,6 @@
 /*
   © 2022–2024 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jonathan Robert Pool.
 
   Licensed under the MIT License. See LICENSE file at the project root or
   https://opensource.org/license/mit/ for details.
@@ -20,8 +21,15 @@ const fs = require('fs/promises');
 
 // Override netWatch environment variables with validation-specific ones.
 const jobDir = `${__dirname}/../jobs/todo`;
-process.env.JOB_URLS = 'http://localhost:3007/api/job';
-process.env.AGENT = 'testarauth';
+process.env.NETWATCH_URL_JOB = 'http://localhost:3007/api/job';
+process.env.NETWATCH_URL_REPORT = 'http://localhost:3007/api/report';
+process.env.NETWATCH_AUTH_TYPE = 'header';
+process.env.NETWATCH_WORKER_ID = 'testaro1';
+process.env.NETWATCH_WORKER_SECRET = 'testarosecret';
+const workerAuth = `Basic ${
+  Buffer.from(`${process.env.NETWATCH_WORKER_ID}:${process.env.NETWATCH_WORKER_SECRET}`)
+  .toString('base64')
+}`;
 const {netWatch} = require('../../netWatch');
 const client = require('http');
 const jobID = '240101T1200-simple-example';
@@ -39,7 +47,7 @@ setTimeout(() => {
 let server;
 // Handles Testaro requests to the server.
 const requestHandler = (request, response) => {
-  const {method} = request;
+  const {method, url} = request;
   const bodyParts = [];
   request.on('error', err => {
     console.error(err);
@@ -48,66 +56,52 @@ const requestHandler = (request, response) => {
     bodyParts.push(chunk);
   })
   .on('end', async () => {
-    // Remove any trailing slash from the URL.
-    const requestURL = request.url.replace(/\/$/, '');
-    // If the request method is GET:
-    if (method === 'GET') {
-      // If a job is validly requested:
+    // If the authorization header is missing or wrong:
+    if (request.headers.authorization !== workerAuth) {
+      response.statusCode = 401;
+      response.end(JSON.stringify({error: 'ERROR: Authorization invalid'}));
+      return;
+    }
+    // If the request is a job request:
+    if (method === 'POST' && url === '/api/job') {
       console.log('Server got a job request from Testaro');
-      if (requestURL === `/api/job?agent=${process.env.AGENT}`) {
-        // If at least 7 seconds has elapsed since timing started:
-        if (Date.now() > startTime + 7000) {
-          // Respond with a job.
-          const jobJSON = await fs.readFile(`${jobDir}/${jobID}.json`);
-          await response.end(jobJSON);
-          console.log('Server sent job to Testaro');
-          jobGiven = true;
-        }
-        // Otherwise, i.e. if timing started less than 7 seconds ago:
-        else {
-          // Send an empty-object response.
-          await response.end('{}');
-        }
+      // If at least 7 seconds has elapsed since timing started:
+      if (Date.now() > startTime + 7000) {
+        // Respond with a job.
+        const jobJSON = await fs.readFile(`${jobDir}/${jobID}.json`);
+        response.end(jobJSON);
+        console.log('Server sent job to Testaro');
+        jobGiven = true;
       }
+      // Otherwise, i.e. if timing started less than 7 seconds ago:
       else {
-        const error = {
-          error: 'ERROR: Job request invalid'
-        };
-        const errorJSON = JSON.stringify(error);
-        await response.end(errorJSON);
+        // Send an empty-object response.
+        response.end('{}');
       }
     }
-    // Otherwise, if the request method is POST:
-    else if (method === 'POST') {
+    // Otherwise, if the request is a report submission:
+    else if (method === 'POST' && url === '/api/report') {
       console.log('Server got report from Testaro');
       const ack = {};
-      // If a report is validly submitted:
-      if (requestURL === '/api') {
-        // If a job was earlier given to Testaro:
-        if (jobGiven) {
-          // Respond, reporting success or failure.
-          try {
-            const bodyJSON = bodyParts.join('');
-            const body = JSON.parse(bodyJSON);
-            if (
-              body.acts
-              && body.sources
-              && body.sources.agent
-              && body.sources.agent === process.env.AGENT
-            ) {
-              ack.message = 'Success: Valid report submitted';
-            }
-            else {
-              ack.message = 'Failure: Report invalid';
-            }
+      // If a job was earlier given to Testaro:
+      if (jobGiven) {
+        // Respond, reporting success or failure.
+        try {
+          const bodyJSON = bodyParts.join('');
+          const body = JSON.parse(bodyJSON);
+          if (body.report && body.report.acts && body.report.jobData) {
+            ack.message = 'Success: Valid report submitted';
           }
-          catch(error) {
-            ack.message = `ERROR: ${error.message}`;
+          else {
+            ack.message = 'Failure: Report invalid';
           }
+        }
+        catch(error) {
+          ack.message = `ERROR: ${error.message}`;
         }
       }
       else {
-        ack.message = 'ERROR: Report submission invalid';
+        ack.message = 'ERROR: Report submitted before a job was given';
       }
       const ackJSON = JSON.stringify(ack);
       response.end(ackJSON);
@@ -115,6 +109,11 @@ const requestHandler = (request, response) => {
       // This ends the validation, so stop the server.
       server.close();
       console.log('Server closed');
+    }
+    // Otherwise, i.e. if the request is neither:
+    else {
+      response.statusCode = 404;
+      response.end(JSON.stringify({error: 'ERROR: Request invalid'}));
     }
   });
 };

--- a/validation/executors/netWatch.js
+++ b/validation/executors/netWatch.js
@@ -1,6 +1,7 @@
 /*
   © 2022–2024 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jonathan Robert Pool.
+  © 2026 Jeff Witt.
 
   Licensed under the MIT License. See LICENSE file at the project root or
   https://opensource.org/license/mit/ for details.
@@ -9,117 +10,207 @@
 */
 
 /*
-  watchNet.js
-  Validator for network watching.
+  netWatch.js
+  Validator for network watching, covering all three auth types.
 */
 
 // IMPORTS
 
 const fs = require('fs/promises');
+const client = require('http');
 
 // CONSTANTS
 
-// Override netWatch environment variables with validation-specific ones.
 const jobDir = `${__dirname}/../jobs/todo`;
+const jobID = '240101T1200-simple-example';
+const workerID = 'testaro1';
+const workerSecret = 'testarosecret';
+// Override netWatch environment variables with validation-specific ones.
 process.env.NETWATCH_URL_JOB = 'http://localhost:3007/api/job';
 process.env.NETWATCH_URL_REPORT = 'http://localhost:3007/api/report';
-process.env.NETWATCH_AUTH_TYPE = 'header';
-process.env.NETWATCH_WORKER_ID = 'testaro1';
-process.env.NETWATCH_WORKER_SECRET = 'testarosecret';
-const workerAuth = `Basic ${
-  Buffer.from(`${process.env.NETWATCH_WORKER_ID}:${process.env.NETWATCH_WORKER_SECRET}`)
-  .toString('base64')
-}`;
+process.env.NETWATCH_WORKER_ID = workerID;
+process.env.NETWATCH_WORKER_SECRET = workerSecret;
 const {netWatch} = require('../../netWatch');
-const client = require('http');
-const jobID = '240101T1200-simple-example';
+/*
+  The authorization-header value netWatch is expected to send in header mode: per RFC 7617, Basic
+  followed by base64 of testaro1:testarosecret. Intentionally a literal, not derived from the
+  netWatch code, so an encoding regression there fails here.
+*/
+const workerAuth = 'Basic dGVzdGFybzE6dGVzdGFyb3NlY3JldA==';
+// Auth types to be validated.
+const authTypes = ['header', 'pathBody', 'none'];
+
+// FUNCTIONS
+
+// Returns an error description if a request carries wrong credentials for an auth type, else ''.
+const credentialError = (authType, request, bodyObj) => {
+  const authHeader = request.headers.authorization;
+  if (authType === 'header') {
+    if (authHeader !== workerAuth) {
+      return 'authorization header missing or wrong';
+    }
+    if (bodyObj.agentPW !== undefined) {
+      return 'agentPW unexpectedly in the request body';
+    }
+  }
+  else if (authType === 'pathBody') {
+    if (authHeader) {
+      return 'authorization header unexpectedly present';
+    }
+    if (bodyObj.agentPW !== workerSecret) {
+      return 'agentPW missing from or wrong in the request body';
+    }
+  }
+  else {
+    if (authHeader) {
+      return 'authorization header unexpectedly present';
+    }
+    if (bodyObj.agentPW !== undefined) {
+      return 'agentPW unexpectedly in the request body';
+    }
+  }
+  return '';
+};
+// Validates netWatch with one auth type; returns whether the scenario succeeded.
+const runScenario = authType => {
+  return new Promise(resolveScenario => {
+    process.env.NETWATCH_AUTH_TYPE = authType;
+    let jobGiven = false;
+    let noJobSent = false;
+    let reportOK = false;
+    let server;
+    // Responds to a request with a JSON object and a status code.
+    const respondWithObject = (object, response, statusCode = 200) => {
+      response.statusCode = statusCode;
+      response.setHeader('content-type', 'application/json; charset=utf-8');
+      response.end(JSON.stringify(object));
+    };
+    // Handles Testaro requests to the server.
+    const requestHandler = (request, response) => {
+      const {method} = request;
+      // Ignore any trailing slash on the request URL.
+      const url = request.url.replace(/\/$/, '');
+      const bodyParts = [];
+      request.on('error', err => {
+        console.error(err);
+      })
+      .on('data', chunk => {
+        bodyParts.push(chunk);
+      })
+      .on('end', async () => {
+        let bodyObj = {};
+        try {
+          bodyObj = JSON.parse(bodyParts.join('') || '{}');
+        }
+        catch(error) {
+          console.log(`Scenario ${authType} failure: non-JSON request body (${error.message})`);
+        }
+        // If the request carries wrong credentials for this auth type:
+        const credError = credentialError(authType, request, bodyObj);
+        if (credError) {
+          // Report this and reject the request; netWatch is expected to abort on this.
+          console.log(`Scenario ${authType} failure: ${credError}`);
+          respondWithObject({error: 'ERROR: Authorization invalid'}, response, 401);
+          server.close();
+          return;
+        }
+        // Otherwise, if the request is a job request:
+        if (method === 'POST' && url === '/api/job') {
+          console.log(`Server got a job request from Testaro (${authType})`);
+          // If this is the first job request of the scenario:
+          if (! noJobSent) {
+            // Send a no-job response, to validate the no-job branch.
+            noJobSent = true;
+            respondWithObject({}, response);
+          }
+          // Otherwise, i.e. if the no-job branch was already validated:
+          else {
+            // Respond with a job.
+            const jobJSON = await fs.readFile(`${jobDir}/${jobID}.json`);
+            response.setHeader('content-type', 'application/json; charset=utf-8');
+            response.end(jobJSON);
+            console.log(`Server sent job to Testaro (${authType})`);
+            jobGiven = true;
+          }
+        }
+        // Otherwise, if the request is a report submission:
+        else if (method === 'POST' && url === '/api/report') {
+          console.log(`Server got report from Testaro (${authType})`);
+          const ack = {};
+          // If a job was earlier given to Testaro:
+          if (jobGiven) {
+            // Check the report, including the worker identification.
+            const {report} = bodyObj;
+            if (
+              report
+              && report.acts
+              && report.jobData
+              && report.sources
+              && report.sources.agent === workerID
+            ) {
+              ack.message = 'Success: Valid report submitted';
+              reportOK = true;
+            }
+            else {
+              ack.message = 'Failure: Report invalid or worker not identified';
+            }
+          }
+          else {
+            ack.message = 'ERROR: Report submitted before a job was given';
+          }
+          respondWithObject(ack, response);
+          console.log(`Server responded: ${ack.message}`);
+          // This ends the scenario, so stop the server.
+          server.close();
+          console.log('Server closed');
+        }
+        // Otherwise, i.e. if the request is neither:
+        else {
+          // Report this and reject the request.
+          console.log(`Scenario ${authType} failure: unexpected request ${method} ${request.url}`);
+          respondWithObject({error: 'ERROR: Request invalid'}, response, 404);
+          server.close();
+        }
+      });
+    };
+    // Create a server.
+    server = client.createServer({}, requestHandler);
+    // Start the server listening for Testaro requests, then start a one-job watch.
+    server.listen(3007, async () => {
+      console.log(`Job and report server listening on port 3007 (auth type ${authType})`);
+      const watchOK = await netWatch(false, 5, false);
+      server.close();
+      resolveScenario(reportOK && watchOK);
+    });
+  });
+};
 
 // OPERATION
 
-// Start a timer.
-const startTime = Date.now();
-// Initialize the state.
-let jobGiven = false;
-// Start checking for jobs every 5 seconds in 5 seconds.
-setTimeout(() => {
-  netWatch(false, 5, false);
-}, 5000);
-let server;
-// Handles Testaro requests to the server.
-const requestHandler = (request, response) => {
-  const {method, url} = request;
-  const bodyParts = [];
-  request.on('error', err => {
-    console.error(err);
-  })
-  .on('data', chunk => {
-    bodyParts.push(chunk);
-  })
-  .on('end', async () => {
-    // If the authorization header is missing or wrong:
-    if (request.headers.authorization !== workerAuth) {
-      response.statusCode = 401;
-      response.end(JSON.stringify({error: 'ERROR: Authorization invalid'}));
-      return;
+// Impose a deadline, so a hang becomes a failure instead of a silent stall.
+const watchdog = setTimeout(() => {
+  console.log('Failure: netWatch validation timed out');
+  process.exit(1);
+}, 600000);
+// Run the scenarios in sequence and exit with a code reporting the outcome.
+(async () => {
+  const failures = [];
+  for (const authType of authTypes) {
+    const isOK = await runScenario(authType);
+    // Drop any kept-alive connections to the closed server before the next scenario.
+    client.globalAgent.destroy();
+    console.log(`Scenario ${authType}: ${isOK ? 'valid' : 'INVALID'}\n`);
+    if (! isOK) {
+      failures.push(authType);
     }
-    // If the request is a job request:
-    if (method === 'POST' && url === '/api/job') {
-      console.log('Server got a job request from Testaro');
-      // If at least 7 seconds has elapsed since timing started:
-      if (Date.now() > startTime + 7000) {
-        // Respond with a job.
-        const jobJSON = await fs.readFile(`${jobDir}/${jobID}.json`);
-        response.end(jobJSON);
-        console.log('Server sent job to Testaro');
-        jobGiven = true;
-      }
-      // Otherwise, i.e. if timing started less than 7 seconds ago:
-      else {
-        // Send an empty-object response.
-        response.end('{}');
-      }
-    }
-    // Otherwise, if the request is a report submission:
-    else if (method === 'POST' && url === '/api/report') {
-      console.log('Server got report from Testaro');
-      const ack = {};
-      // If a job was earlier given to Testaro:
-      if (jobGiven) {
-        // Respond, reporting success or failure.
-        try {
-          const bodyJSON = bodyParts.join('');
-          const body = JSON.parse(bodyJSON);
-          if (body.report && body.report.acts && body.report.jobData) {
-            ack.message = 'Success: Valid report submitted';
-          }
-          else {
-            ack.message = 'Failure: Report invalid';
-          }
-        }
-        catch(error) {
-          ack.message = `ERROR: ${error.message}`;
-        }
-      }
-      else {
-        ack.message = 'ERROR: Report submitted before a job was given';
-      }
-      const ackJSON = JSON.stringify(ack);
-      response.end(ackJSON);
-      console.log(`Server responded: ${ack.message}`);
-      // This ends the validation, so stop the server.
-      server.close();
-      console.log('Server closed');
-    }
-    // Otherwise, i.e. if the request is neither:
-    else {
-      response.statusCode = 404;
-      response.end(JSON.stringify({error: 'ERROR: Request invalid'}));
-    }
-  });
-};
-// Create a server.
-server = client.createServer({}, requestHandler);
-// Start a server listening for Testaro requests.
-server.listen(3007, () => {
-  console.log('Job and report server listening on port 3007');
-});
+  }
+  clearTimeout(watchdog);
+  if (failures.length) {
+    console.log(`Failure: Invalid scenarios: ${failures.join(', ')}`);
+    process.exit(1);
+  }
+  else {
+    console.log('Success: Valid reports submitted for all auth types');
+    process.exit(0);
+  }
+})();

--- a/validation/jobs/todo/240101T1200-simple-example.json
+++ b/validation/jobs/todo/240101T1200-simple-example.json
@@ -2,7 +2,20 @@
   "id": "240101T1200-simple-example",
   "what": "Test example.edu with bulk",
   "strict": true,
+  "standard": "only",
+  "device": {
+    "id": "default",
+    "windowOptions": {}
+  },
+  "browserID": "chromium",
   "timeLimit": 10,
+  "creationTimeStamp": "240101T1200",
+  "executionTimeStamp": "240101T1200",
+  "target": {
+    "what": "example.edu home page",
+    "url": "https://example.edu/"
+  },
+  "sources": {},
   "acts": [
     {
       "type": "launch",
@@ -20,10 +33,5 @@
         "bulk"
       ]
     }
-  ],
-  "sources": {},
-  "standard": "only",
-  "sendReportTo": "http://localhost:3007/api",
-  "timeStamp": "240101T1500",
-  "creationTimeStamp": "240101T1200"
+  ]
 }


### PR DESCRIPTION
When Testaro polls a server for jobs and sends a report to a server, allow Testaro to authenticate with the server using a basic authorization header, not only using the mixture of path segment and request body property now allowed. One Testaro consumer (Kilotest) now requires header authentication, and it is a standard protocol, so permitting it expands the ability of Testaro to serve potential consuming applications.