### PR TITLE
fix: validate executionTimeStamp in isValidJob (operator precedence)

### DIFF
--- a/procs/job.js
+++ b/procs/job.js
@@ -235,7 +235,7 @@ exports.isValidJob = job => {
       };
     }
     if (
-      ! (executionTimeStamp && typeof executionTimeStamp === 'string') && dateOf(executionTimeStamp)
+      ! (executionTimeStamp && typeof executionTimeStamp === 'string' && dateOf(executionTimeStamp))
     ) {
       return {
         isValid: false,


### PR DESCRIPTION
Fixes #95.

One-line fix: in `isValidJob`, the `&& dateOf(executionTimeStamp)` term bound outside the negation, so the check could never fire — a present-but-malformed `executionTimeStamp` made the negated conjunct false, and an absent one made `dateOf()` return `null`. Either way the job was accepted. The fix moves `dateOf()` inside the negated group, mirroring the `creationTimeStamp` check directly above it.

Verified against the `240101T1200-simple-example` job (as rewritten on the `authHeader` branch):

| case | before | after |
|---|---|---|
| valid stamp | accepted | accepted |
| `"not-a-stamp"` | accepted | `Bad job executionTimeStamp` |
| absent | accepted | `Bad job executionTimeStamp` |

This makes `executionTimeStamp` required-and-valid, matching the README's job schema (which lists it unconditionally, unlike `stealth`, which is marked optional) and matching the `creationTimeStamp` treatment. Jobs that previously omitted the field will now be rejected with a named error instead of silently passing — that is the check working as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)