### PR TITLE
TypeScript Phase 0: CI type gate, dependency pinning, engines, tsconfig, report type declarations (#73)

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,0 +1,31 @@
+name: TypeScript
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  typecheck:
+    name: Type check and syntax check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --no-audit --no-fund
+      - name: Type check
+        run: npm run typecheck
+      - name: Syntax-check all JavaScript
+        run: |
+          set -e
+          find . -name '*.js' \
+            -not -path './node_modules/*' \
+            -not -path './.git/*' \
+            -not -path './dist/*' \
+            -not -path './ed11y/*' \
+            -print0 | xargs -0 -n1 node --check

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,40 +1,45 @@
 {
   "name": "testaro",
-  "version": "77.0.1",
+  "version": "78.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "testaro",
-      "version": "77.0.1",
+      "version": "78.0.8",
       "license": "MIT",
       "dependencies": {
-        "@qualweb/act-rules": "*",
-        "@qualweb/best-practices": "*",
-        "@qualweb/core": "*",
-        "@qualweb/playwright-driver": "*",
-        "@qualweb/wcag-techniques": "*",
-        "@siteimprove/alfa-act": "*",
-        "@siteimprove/alfa-playwright": "*",
-        "@siteimprove/alfa-rules": "*",
-        "accessibility-checker": "*",
-        "aria-query": "*",
-        "aslint-testaro": "*",
-        "axe-playwright": "*",
-        "dotenv": "*",
-        "pixelmatch": "*",
-        "playwright": "*",
-        "playwright-dompath": "*",
-        "playwright-extra": "*",
-        "playwright-extra-plugin-stealth": "*",
-        "pngjs": "*",
-        "puppeteer-extra-plugin-stealth": "*",
-        "vnu-jar": "*"
+        "@qualweb/act-rules": "^0.8.5",
+        "@qualweb/best-practices": "^0.7.13",
+        "@qualweb/core": "^0.9.5",
+        "@qualweb/playwright-driver": "^1.0.1",
+        "@qualweb/wcag-techniques": "^0.4.8",
+        "@siteimprove/alfa-act": "^0.119.0",
+        "@siteimprove/alfa-playwright": "^0.84.2",
+        "@siteimprove/alfa-rules": "^0.119.0",
+        "accessibility-checker": "^4.0.30",
+        "aria-query": "^5.3.2",
+        "aslint-testaro": "^1.0.1",
+        "axe-playwright": "^2.2.2",
+        "dotenv": "^17.4.2",
+        "pixelmatch": "^7.2.0",
+        "playwright": "^1.62.1",
+        "playwright-dompath": "^0.0.7",
+        "playwright-extra": "^4.3.6",
+        "playwright-extra-plugin-stealth": "^0.0.1",
+        "pngjs": "^7.0.0",
+        "puppeteer-extra-plugin-stealth": "^2.11.2",
+        "vnu-jar": "^26.8.15"
       },
       "devDependencies": {
-        "dom-accessibility-api": "*",
-        "esbuild": "*",
-        "eslint": "*"
+        "@types/node": "^20.0.0",
+        "dom-accessibility-api": "^0.7.1",
+        "esbuild": "^0.28.2",
+        "eslint": "^10.8.1",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2516,13 +2521,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/sarif": {
@@ -5947,6 +5952,20 @@
       "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
       "license": "MIT"
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
@@ -5958,11 +5977,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "license": "MIT",
-      "optional": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testaro",
   "version": "78.0.8",
   "description": "Run 1300 web accessibility tests from 10 tools and get a standardized report",
-  "main": "index.js",
+  "main": "run.js",
   "scripts": {
     "build:nameComputation": "esbuild src/nameComputation.js --bundle --format=iife --global-name=computeAccessibleName --outfile=dist/nameComputation.js",
     "build": "npm run build:nameComputation",
@@ -11,7 +11,8 @@
     "test": "node validation/executors/test",
     "run": "node validation/executors/run",
     "dirWatch": "node validation/executors/dirWatch",
-    "netWatch": "node validation/executors/netWatch"
+    "netWatch": "node validation/executors/netWatch",
+    "typecheck": "tsc --noEmit"
   },
   "repository": {
     "type": "git",
@@ -30,32 +31,34 @@
   },
   "homepage": "https://github.com/jrpool/testaro#readme",
   "dependencies": {
-    "@qualweb/core": "*",
-    "@qualweb/act-rules": "*",
-    "@qualweb/playwright-driver": "*",
-    "@qualweb/wcag-techniques": "*",
-    "@qualweb/best-practices": "*",
-    "@siteimprove/alfa-act": "*",
-    "@siteimprove/alfa-playwright": "*",
-    "@siteimprove/alfa-rules": "*",
-    "accessibility-checker": ">=4.0.29",
-    "aria-query": "*",
-    "aslint-testaro": "*",
-    "axe-playwright": "*",
-    "dotenv": "*",
-    "pixelmatch": "*",
-    "playwright": "*",
-    "playwright-dompath": "*",
-    "playwright-extra": "*",
-    "playwright-extra-plugin-stealth": "*",
-    "pngjs": "*",
-    "puppeteer-extra-plugin-stealth": "*",
-    "vnu-jar": "*"
+    "@qualweb/core": "^0.9.5",
+    "@qualweb/act-rules": "^0.8.5",
+    "@qualweb/playwright-driver": "^1.0.1",
+    "@qualweb/wcag-techniques": "^0.4.8",
+    "@qualweb/best-practices": "^0.7.13",
+    "@siteimprove/alfa-act": "^0.119.0",
+    "@siteimprove/alfa-playwright": "^0.84.2",
+    "@siteimprove/alfa-rules": "^0.119.0",
+    "accessibility-checker": "^4.0.30",
+    "aria-query": "^5.3.2",
+    "aslint-testaro": "^1.0.1",
+    "axe-playwright": "^2.2.2",
+    "dotenv": "^17.4.2",
+    "pixelmatch": "^7.2.0",
+    "playwright": "^1.62.1",
+    "playwright-dompath": "^0.0.7",
+    "playwright-extra": "^4.3.6",
+    "playwright-extra-plugin-stealth": "^0.0.1",
+    "pngjs": "^7.0.0",
+    "puppeteer-extra-plugin-stealth": "^2.11.2",
+    "vnu-jar": "^26.8.15"
   },
   "devDependencies": {
-    "dom-accessibility-api": "*",
-    "esbuild": "*",
-    "eslint": "*"
+    "dom-accessibility-api": "^0.7.1",
+    "esbuild": "^0.28.2",
+    "eslint": "^10.8.1",
+    "typescript": "^5.6.0",
+    "@types/node": "^20.0.0"
   },
   "overrides": {
     "adm-zip": "^0.6.0"
@@ -67,5 +70,9 @@
     "esbuild": true,
     "fsevents": true,
     "vnu-jar": true
+  },
+  "types": "./types.d.ts",
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/testaro/elements.js
+++ b/testaro/elements.js
@@ -19,7 +19,7 @@
 // FUNCTIONS
 
 exports.reporter = async (
-  page, _, _, detailLevel = 0, tagName = null, onlyVisible = false, attribute
+  page, _0, _1, detailLevel = 0, tagName = null, onlyVisible = false, attribute
 ) => {
   // Determine a selector of the specified elements, including any descendants of open shadow roots.
   let selector = `body ${tagName ? tagName.toLowerCase() : '*'}`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "es2022",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "lib": ["es2022", "dom", "dom.iterable"],
+    "types": ["node"],
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "htmlcs", "ed11y", "dist", "validation/tests/targets"]
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,180 @@
+/*
+  © 2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+/*
+  types
+  Type declarations for the shapes Testaro produces and consumes.
+
+  Phase 0 of the TypeScript migration (issue #73): declarations only, no runtime
+  code. These describe the report as it exists today; where the runtime is
+  looser than a type can promise, the property is optional or unknown rather
+  than aspirational. The Act type is deliberately permissive in this phase; the
+  discriminated union over act types arrives when procs/job.js is converted.
+*/
+
+// The tools whose adapters ship with Testaro (the keys of the tools map in procs/job.js).
+export type ToolID =
+  | 'alfa'
+  | 'aslint'
+  | 'axe'
+  | 'ed11y'
+  | 'htmlcs'
+  | 'ibm'
+  | 'nuVal'
+  | 'nuVnu'
+  | 'qualWeb'
+  | 'testaro'
+  | 'wave';
+
+// The browser types a job may specify.
+export type BrowserID = 'chromium' | 'firefox' | 'webkit';
+
+// Rule-violation counts at the 4 ordinal severities, least severe first.
+export type SeverityTotals = [number, number, number, number];
+
+// One violation (or group of violations of one rule) in a standard result.
+export interface StandardInstance {
+  ruleID: string;
+  what: string;
+  ordinalSeverity: 0 | 1 | 2 | 3;
+  count?: number;
+  // Key of the violating element in the report catalog (v70+ reports).
+  catalogIndex?: string | number;
+  // Inline element identifiers of pre-catalog (v60) reports; absent on v70+.
+  tagName?: string;
+  id?: string;
+  location?: {
+    doc: string;
+    type: 'selector' | 'xpath' | 'box' | '';
+    spec: string | string[] | BoundingBox | Record<string, never>;
+  };
+  boxID?: string;
+  pathID?: string;
+  excerpt?: string;
+}
+
+export interface BoundingBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+// The Testaro-standardized result of one test act.
+export interface StandardResult {
+  prevented?: boolean;
+  totals?: SeverityTotals;
+  instances?: StandardInstance[];
+}
+
+// One entry per element in the report catalog (v70+).
+export interface CatalogEntry {
+  tagName: string;
+  id: string;
+  startTag: string;
+  text: string;
+  textLinkable: boolean;
+  boxID: string;
+  pathID: string;
+  headingIndex: string;
+}
+
+// The element catalog: element index (stringified integer) to entry.
+export type Catalog = Record<string, CatalogEntry>;
+
+// One act of a job. Permissive in Phase 0; see the file comment.
+export interface Act {
+  type: string;
+  which?: string;
+  what?: string;
+  startTime?: string;
+  endTime?: string;
+  actualURL?: string;
+  data?: Record<string, unknown>;
+  result?: {
+    nativeResult?: unknown;
+    standardResult?: StandardResult;
+    [key: string]: unknown;
+  };
+  expectations?: unknown;
+  expectationFailures?: number;
+  [key: string]: unknown;
+}
+
+// A job before execution and the report it becomes during and after execution.
+export interface Report {
+  id: string;
+  what?: string;
+  strict?: boolean;
+  standard?: 'also' | 'only' | 'no';
+  observe?: boolean;
+  browserID?: BrowserID;
+  device?: {id: string; windowOptions?: Record<string, unknown>};
+  target?: {
+    what?: string;
+    url: string;
+  };
+  sources?: Record<string, unknown>;
+  creationTimeStamp?: string;
+  executionTimeStamp?: string;
+  timeLimit?: number;
+  acts: Act[];
+  // The severity of required page-image colorfulness; even values require an image.
+  imageColor?: number;
+  // The element catalog, added by getCatalog and pruned before the report ships.
+  catalog?: Catalog;
+  jobData?: {
+    aborted?: boolean;
+    abortedAct?: number;
+    endTime?: string;
+    elapsedSeconds?: number;
+    visitLatency?: number;
+    logCount?: number;
+    logSize?: number;
+    errorLogCount?: number;
+    errorLogSize?: number;
+    prohibitedCount?: number;
+    visitRejectionCount?: number;
+    visitTimeoutCount?: number;
+    preventions?: Partial<Record<ToolID, unknown>>;
+    toolTimes?: Partial<Record<ToolID, number>>;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/*
+  The classification a getBadWhat predicate returns for a candidate element:
+  falsy for no violation, a description string for a violation, or an object
+  when the violation carries data. A `0:`–`3:` prefix on a description
+  overrides the rule's default ordinal severity. Predicates are serialized with
+  toString() and rehydrated inside the page, so they must be closure-free; the
+  type checker cannot enforce that invariant.
+*/
+export type BadWhat =
+  | null
+  | undefined
+  | false
+  | ''
+  | string
+  | {description: string; data?: unknown};
+export type GetBadWhat = (element: Element) => BadWhat | Promise<BadWhat>;
+
+declare global {
+  interface Window {
+    // Injected by procs/launch.js for use inside page.evaluate callbacks.
+    getXPath: (element: Element) => string | null | undefined;
+    getAccessibleName: (element: Element) => string;
+    computeAccessibleName: (element: Element) => string;
+    getProtoInstance: (element: Element) => unknown;
+    // Set by the HTML CodeSniffer bundle while the htmlcs tool runs.
+    HTMLCS_WCAG?: unknown;
+    HTMLCS_RUNNER?: {run: (standard: string) => void};
+  }
+}


### PR DESCRIPTION
Phase 0 of the migration proposed in #73 (RFC in the issue thread). **No runtime change** — this PR stands on its own even if the migration stopped here.

## What's in it

- **`.github/workflows/typescript.yml`**: a required job that type-checks (`tsc --noEmit`) and syntax-checks every first-party JS file (`node --check`). Scoped to the type gate only — validation/lint CI is deliberately left to the `ci/gateable-validation` work so the two don't collide on one workflow file.
- **Dependency pinning**: every runtime dependency was a floating `"*"`; all are now caret ranges of the versions already resolved in `package-lock.json` (pinned to what's locked, not to latest — nothing upgrades). Lockfile regenerated against the pinned ranges.
- **`engines: { node: ">=20" }`** — previously only stated in README prose.
- **`tsconfig.json`**: strict / es2022 / commonjs / DOM+Node libs, `noEmit` for now.
- **`types.d.ts`**: declarations for `Report`, `Act`, `StandardResult`, `StandardInstance`, `Catalog`, `ToolID`, `GetBadWhat`, and the `Window` augmentation for the injected page functions. Pure declarations — downstream TypeScript consumers can use them today via the new `"types"` field.
- **`main` repointed** from the nonexistent `index.js` to `run.js`.
- **`testaro/elements.js` fix — the syntax sweep's first catch**: its reporter declared two parameters both named `_`, an unconditional SyntaxError in a parameter list with defaults, so any `require('../testaro/elements')` would throw. Now `_0`/`_1`, matching `buttonMenu.js`. (The same fix exists on `ci/gateable-validation`; identical content, so whichever lands second merges cleanly.)

## Verification

- `npx tsc --noEmit` green on this branch as rebased onto current `main`.
- `node --check` green across all first-party JS (after the elements.js fix).
- `npm install` resolves the pinned ranges cleanly; only additions are `typescript` + `@types/node`.

Next (separate PRs, per the RFC's phase plan): Phase 1 converts `types.ts` + the core procs (`procs/testaro.js`, `procs/xPath.js`, `procs/catalog.js`) with committed in-place emit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)