### PR TITLE
fix: numeric ordinalSeverity in doTest summary instances (#99)

### DIFF
--- a/procs/testaro.js
+++ b/procs/testaro.js
@@ -128,12 +128,9 @@ const doTest = async (page, report, withItems, ruleID, candidateSelector, whats,
                 standardInstances.push({
                     ruleID,
                     what: whats,
-                    /*
-                      for...in yields the index as a string, so summary instances ship
-                      ordinalSeverity as '0'–'3', not 0–3. Preserved verbatim from the
-                      JavaScript original; flagged for a behavior-correcting follow-up.
-                    */
-                    ordinalSeverity: index,
+                    // Numeric, not the for...in string index, so summary instances match
+                    // itemized instances and validator expectations (issue #99).
+                    ordinalSeverity: Number(index),
                     count: totals[index]
                 });
             }

--- a/procs/testaro.ts
+++ b/procs/testaro.ts
@@ -172,12 +172,9 @@ export const doTest = async (
         standardInstances.push({
           ruleID,
           what: whats,
-          /*
-            for...in yields the index as a string, so summary instances ship
-            ordinalSeverity as '0'–'3', not 0–3. Preserved verbatim from the
-            JavaScript original; flagged for a behavior-correcting follow-up.
-          */
-          ordinalSeverity: index as unknown as StandardInstance['ordinalSeverity'],
+          // Numeric, not the for...in string index, so summary instances match
+          // itemized instances and validator expectations (issue #99).
+          ordinalSeverity: Number(index) as StandardInstance['ordinalSeverity'],
           count: totals[index as unknown as number]
         });
       }


### PR DESCRIPTION
Fixes #99.

`doTest`'s non-itemized branch built summary standard instances with `ordinalSeverity: index` inside a `for...in` over the totals array, so the shipped value was the **string** `'0'`–`'3'`. Now `Number(index)`, matching itemized instances, the `StandardInstance` type, and validator expectations.

## Sweeps performed

- **Validator expectations**: no expectation in `validation/tests/jobProperties/` was "corrected" to the string form (no `"criterion": "0"`–`"3"` for ordinalSeverity anywhere) — expectations already use numbers, which is why this bug surfaced as drift failures rather than passing tests.
- **In-repo consumers**: no code in the repo compares `instance.ordinalSeverity` against strings; the tool adapters each construct their own numeric values.
- **External consumers**: controllers or scorers that adapted to the string form for non-itemized testaro results will see numbers after this change. Testilo's scoring reads totals (numeric, unchanged); flagging here for anyone who consumed instances directly.

## Verification

`npm test autocomplete` — the non-itemized act's expectation that failed on `main` (`criterion: 2, actual: "2"`) now passes. The itemized act's 6 failures (`instances.1.tagName: null`, `location.*: null`, `excerpt: null`) are unrelated pre-existing drift — those expectations still assume v60-style inline element fields that v70+ catalog reports no longer carry — and are unchanged by this PR; they belong to the validator-modernization work on `ci/gateable-validation`. Concretely: validateTest prints only acts with nonzero expectationFailures, and post-fix the non-itemized act no longer appears in that printout at all — all four of its expectations (totals, description, ordinalSeverity, count) pass. The only act still printed is the itemized one, with exactly its pre-existing 6 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
