### PR TITLE
fix: await addCatalogIndex in getBasicResult (#100)

### DIFF
--- a/procs/testaro.js
+++ b/procs/testaro.js
@@ -180,12 +180,9 @@ const getBasicResult = async (report, withItems, ruleID, ordinalSeverity, whats,
                 ordinalSeverity,
                 count: 1
             };
-            /*
-              Add a catalog index to it. The call is not awaited, exactly as in the
-              JavaScript original; flagged for a behavior-correcting follow-up,
-              because the report can be serialized before the index arrives.
-            */
-            addCatalogIndex(protoInstance, loc, report);
+            // Add a catalog index to it, awaited so the index is present before the
+            // report can be serialized (issue #100).
+            await addCatalogIndex(protoInstance, loc, report);
             // Add the standard instance to the standard instances.
             standardInstances.push(protoInstance);
         }

--- a/procs/testaro.ts
+++ b/procs/testaro.ts
@@ -233,12 +233,9 @@ export const getBasicResult = async (
         ordinalSeverity,
         count: 1
       };
-      /*
-        Add a catalog index to it. The call is not awaited, exactly as in the
-        JavaScript original; flagged for a behavior-correcting follow-up,
-        because the report can be serialized before the index arrives.
-      */
-      addCatalogIndex(protoInstance, loc, report);
+      // Add a catalog index to it, awaited so the index is present before the
+      // report can be serialized (issue #100).
+      await addCatalogIndex(protoInstance, loc, report);
       // Add the standard instance to the standard instances.
       standardInstances.push(protoInstance);
     }


### PR DESCRIPTION
Fixes #100.

`getBasicResult` called the async `addCatalogIndex` without `await`, so each itemized instance's `catalogIndex` was assigned in a race with report serialization, and the catalog's stub-entry appends happened in nondeterministic order.

## Verification

`npm test hover` (hover is one of the two `getBasicResult` rules) on current `main` vs this branch, outputs diffed with timestamps normalized:

- **On `main`, zero instances carry `catalogIndex`** — the race loses every time in this environment, so the bug is not theoretical.
- On this branch, all three itemized instances carry their index (`"23"`, `"15"`, `"24"`).
- The expectation-failure set is unchanged (the same 10 pre-existing v60-style expectation failures on both sides — those belong to the validator-modernization work), and the only other diff line is the hover rule's own run-to-run timing jitter (`77ms` vs `78ms`) inside a violation description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)