### PR TITLE
TypeScript Phase 2 batch 2: 12 more doTest-shape rule modules (#73)

### DIFF
--- a/testaro/adbID.d.ts
+++ b/testaro/adbID.d.ts
@@ -1,0 +1,3 @@
+import type { Page } from 'playwright';
+import type { Report } from '../types';
+export declare const reporter: (page: Page, report: Report, _: unknown, withItems: boolean) => Promise<import("../procs/testaro").RuleResult>;

--- a/testaro/adbID.js
+++ b/testaro/adbID.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2025 CVS Health and/or one of its affiliates. All rights reserved.
   © 2025 Juan S. Casado.
@@ -9,55 +10,51 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const testaro_1 = require("../procs/testaro");
 /*
   adbID
   Clean-room rule
   This test reports elements referencing aria-describedby targets that are missing or, because of duplicate IDs, ambiguous. An earlier version of this test was originally developed under a clean-room procedure to ensure its independence from the implementation of a test for a similar rule in the Tenon tool.
+  Compiled to adbID.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const {doTest} = require('../procs/testaro');
-
 // FUNCTIONS
-
 // Runs the test and returns the result.
-exports.reporter = async (page, report, _, withItems) => {
-  const getBadWhat = element => {
-    // Get the IDs in the aria-describedby attribute of the element.
-    const IDs = element.getAttribute('aria-describedby').trim().split(/\s+/).filter(Boolean);
-    // If there are none:
-    if (! IDs.length) {
-      // Return a violation description.
-      return 'Element has an aria-describedby attribute with no value';
-    }
-    // Otherwise, i.e. if there is at least 1 ID:
-    else {
-      // For each ID:
-      for (const id of IDs) {
-        // Get the element with that ID.
-        const describer = document.getElementById(id);
-        // If it doesn't exist:
-        if (! describer) {
-          // Return a violation description.
-          return `No element has the aria-describedby ID ${id}`;
-        }
-        // Otherwise, i.e. if it exists:
-        else {
-          // Get the elements with that ID.
-          const sameIDElements = document.querySelectorAll(`#${id}`);
-          // If there is more than one:
-          if (sameIDElements.length > 1) {
+const reporter = async (page, report, _, withItems) => {
+    const getBadWhat = element => {
+        // Get the IDs in the aria-describedby attribute of the element.
+        const IDs = element.getAttribute('aria-describedby').trim().split(/\s+/).filter(Boolean);
+        // If there are none:
+        if (!IDs.length) {
             // Return a violation description.
-            return `Multiple elements share the aria-describedby ID ${id}`;
-          }
+            return 'Element has an aria-describedby attribute with no value';
         }
-      }
-    }
-  };
-  const whats = 'Elements have aria-describedby attributes with missing or invalid id values';
-  return await doTest(
-    page, report, withItems, 'adbID', 'body [aria-describedby]', whats, 3, getBadWhat.toString()
-  );
+        // Otherwise, i.e. if there is at least 1 ID:
+        else {
+            // For each ID:
+            for (const id of IDs) {
+                // Get the element with that ID.
+                const describer = document.getElementById(id);
+                // If it doesn't exist:
+                if (!describer) {
+                    // Return a violation description.
+                    return `No element has the aria-describedby ID ${id}`;
+                }
+                // Otherwise, i.e. if it exists:
+                else {
+                    // Get the elements with that ID.
+                    const sameIDElements = document.querySelectorAll(`#${id}`);
+                    // If there is more than one:
+                    if (sameIDElements.length > 1) {
+                        // Return a violation description.
+                        return `Multiple elements share the aria-describedby ID ${id}`;
+                    }
+                }
+            }
+        }
+    };
+    const whats = 'Elements have aria-describedby attributes with missing or invalid id values';
+    return await (0, testaro_1.doTest)(page, report, withItems, 'adbID', 'body [aria-describedby]', whats, 3, getBadWhat.toString());
 };
+exports.reporter = reporter;

--- a/testaro/adbID.ts
+++ b/testaro/adbID.ts
@@ -1,0 +1,66 @@
+/*
+  © 2025 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2025 Juan S. Casado.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {doTest} from '../procs/testaro';
+import type {GetBadWhat, Report} from '../types';
+
+/*
+  adbID
+  Clean-room rule
+  This test reports elements referencing aria-describedby targets that are missing or, because of duplicate IDs, ambiguous. An earlier version of this test was originally developed under a clean-room procedure to ensure its independence from the implementation of a test for a similar rule in the Tenon tool.
+  Compiled to adbID.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Runs the test and returns the result.
+export const reporter = async (page: Page, report: Report, _: unknown, withItems: boolean) => {
+  const getBadWhat: GetBadWhat = element => {
+    // Get the IDs in the aria-describedby attribute of the element.
+    const IDs = element.getAttribute('aria-describedby')!.trim().split(/\s+/).filter(Boolean);
+    // If there are none:
+    if (! IDs.length) {
+      // Return a violation description.
+      return 'Element has an aria-describedby attribute with no value';
+    }
+    // Otherwise, i.e. if there is at least 1 ID:
+    else {
+      // For each ID:
+      for (const id of IDs) {
+        // Get the element with that ID.
+        const describer = document.getElementById(id);
+        // If it doesn't exist:
+        if (! describer) {
+          // Return a violation description.
+          return `No element has the aria-describedby ID ${id}`;
+        }
+        // Otherwise, i.e. if it exists:
+        else {
+          // Get the elements with that ID.
+          const sameIDElements = document.querySelectorAll(`#${id}`);
+          // If there is more than one:
+          if (sameIDElements.length > 1) {
+            // Return a violation description.
+            return `Multiple elements share the aria-describedby ID ${id}`;
+          }
+        }
+      }
+    }
+  };
+  const whats = 'Elements have aria-describedby attributes with missing or invalid id values';
+  return await doTest(
+    page, report, withItems, 'adbID', 'body [aria-describedby]', whats, 3, getBadWhat.toString()
+  );
+};

--- a/testaro/allCapStyle.d.ts
+++ b/testaro/allCapStyle.d.ts
@@ -1,0 +1,3 @@
+import type { Page } from 'playwright';
+import type { Report } from '../types';
+export declare const reporter: (page: Page, report: Report, _: unknown, withItems: boolean) => Promise<import("../procs/testaro").RuleResult>;

--- a/testaro/allCapStyle.js
+++ b/testaro/allCapStyle.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2023 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -7,46 +8,42 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const testaro_1 = require("../procs/testaro");
 /*
   allCapStyle
   Related to Tenon rule 153.
   This test reports elements with transformed upper-case text. Blocks of upper-case text are difficult to read.
+  Compiled to allCapStyle.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const {doTest} = require('../procs/testaro');
-
 // FUNCTIONS
-
 // Runs the test and returns the result.
-exports.reporter = async (page, report, _, withItems) => {
-  const getBadWhat = element => {
-    // Get the style declaration of the element.
-    const styleDec = window.getComputedStyle(element);
-    const {textTransform} = styleDec;
-    // If the style declaration transforms the element text to upper case:
-    if (textTransform === 'uppercase') {
-      const parent = element.parentElement;
-      // If the element has a parent:
-      if (parent) {
-        // Get the style declaration of the parent.
-        const parentStyleDec = window.getComputedStyle(parent);
-        const {textTransform: parentTextTransform} = parentStyleDec;
-        // If the style declaration transforms the parent text to upper case:
-        if (parentTextTransform === 'uppercase') {
-          // Do not report a violation, because the transformation may be inherited.
-          return null;
+const reporter = async (page, report, _, withItems) => {
+    const getBadWhat = element => {
+        // Get the style declaration of the element.
+        const styleDec = window.getComputedStyle(element);
+        const { textTransform } = styleDec;
+        // If the style declaration transforms the element text to upper case:
+        if (textTransform === 'uppercase') {
+            const parent = element.parentElement;
+            // If the element has a parent:
+            if (parent) {
+                // Get the style declaration of the parent.
+                const parentStyleDec = window.getComputedStyle(parent);
+                const { textTransform: parentTextTransform } = parentStyleDec;
+                // If the style declaration transforms the parent text to upper case:
+                if (parentTextTransform === 'uppercase') {
+                    // Do not report a violation, because the transformation may be inherited.
+                    return null;
+                }
+            }
+            // If it has no parent or its transformation is autonomous, return a violation description.
+            return 'Element text is transformed into all-capitals';
         }
-      }
-      // If it has no parent or its transformation is autonomous, return a violation description.
-      return 'Element text is transformed into all-capitals';
-    }
-  };
-  const selector = 'body, body *:not(style, script, svg)';
-  const whats = 'Elements have an all-capital text transformation style';
-  return await doTest(
-    page, report, withItems, 'allCapStyle', selector, whats, 0, getBadWhat.toString()
-  );
+    };
+    const selector = 'body, body *:not(style, script, svg)';
+    const whats = 'Elements have an all-capital text transformation style';
+    return await (0, testaro_1.doTest)(page, report, withItems, 'allCapStyle', selector, whats, 0, getBadWhat.toString());
 };
+exports.reporter = reporter;

--- a/testaro/allCapStyle.ts
+++ b/testaro/allCapStyle.ts
@@ -1,0 +1,55 @@
+/*
+  © 2023 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {doTest} from '../procs/testaro';
+import type {GetBadWhat, Report} from '../types';
+
+/*
+  allCapStyle
+  Related to Tenon rule 153.
+  This test reports elements with transformed upper-case text. Blocks of upper-case text are difficult to read.
+  Compiled to allCapStyle.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Runs the test and returns the result.
+export const reporter = async (page: Page, report: Report, _: unknown, withItems: boolean) => {
+  const getBadWhat: GetBadWhat = element => {
+    // Get the style declaration of the element.
+    const styleDec = window.getComputedStyle(element);
+    const {textTransform} = styleDec;
+    // If the style declaration transforms the element text to upper case:
+    if (textTransform === 'uppercase') {
+      const parent = element.parentElement;
+      // If the element has a parent:
+      if (parent) {
+        // Get the style declaration of the parent.
+        const parentStyleDec = window.getComputedStyle(parent);
+        const {textTransform: parentTextTransform} = parentStyleDec;
+        // If the style declaration transforms the parent text to upper case:
+        if (parentTextTransform === 'uppercase') {
+          // Do not report a violation, because the transformation may be inherited.
+          return null;
+        }
+      }
+      // If it has no parent or its transformation is autonomous, return a violation description.
+      return 'Element text is transformed into all-capitals';
+    }
+  };
+  const selector = 'body, body *:not(style, script, svg)';
+  const whats = 'Elements have an all-capital text transformation style';
+  return await doTest(
+    page, report, withItems, 'allCapStyle', selector, whats, 0, getBadWhat.toString()
+  );
+};

--- a/testaro/attVal.d.ts
+++ b/testaro/attVal.d.ts
@@ -1,0 +1,3 @@
+import type { Page } from 'playwright';
+import type { Report } from '../types';
+export declare const reporter: (page: Page, report: Report, _0: unknown, withItems: boolean, attributeName: string, areLicit: boolean, values: string[]) => Promise<import("../procs/testaro").RuleResult>;

--- a/testaro/attVal.js
+++ b/testaro/attVal.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2023 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -7,31 +8,27 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const testaro_1 = require("../procs/testaro");
 /*
   attVal
   This test reports elements with illicit values of an attribute.
+  Compiled to attVal.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const {doTest} = require('../procs/testaro');
-
 // FUNCTIONS
-
 // Runs the test and returns the result.
-exports.reporter = async (page, report, _0, withItems, attributeName, areLicit, values) => {
-  const getBadWhat = element => {
-    // Get the value of the attribute.
-    const value = element.getAttribute(attributeName);
-    // If it violates the rule:
-    if (areLicit !== values.includes(value)) {
-      // Return a violation description.
-      return `Element has attribute ${attributeName} with illicit value ${value}`;
-    }
-  };
-  const whats = `Elements have attribute ${attributeName} with illicit values`;
-  return await doTest(
-    page, report, withItems, 'attVal', `body [${attributeName}]`, whats, 2, getBadWhat.toString()
-  );
+const reporter = async (page, report, _0, withItems, attributeName, areLicit, values) => {
+    const getBadWhat = element => {
+        // Get the value of the attribute.
+        const value = element.getAttribute(attributeName);
+        // If it violates the rule:
+        if (areLicit !== values.includes(value)) {
+            // Return a violation description.
+            return `Element has attribute ${attributeName} with illicit value ${value}`;
+        }
+    };
+    const whats = `Elements have attribute ${attributeName} with illicit values`;
+    return await (0, testaro_1.doTest)(page, report, withItems, 'attVal', `body [${attributeName}]`, whats, 2, getBadWhat.toString());
 };
+exports.reporter = reporter;

--- a/testaro/attVal.ts
+++ b/testaro/attVal.ts
@@ -1,0 +1,48 @@
+/*
+  © 2023 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {doTest} from '../procs/testaro';
+import type {GetBadWhat, Report} from '../types';
+
+/*
+  attVal
+  This test reports elements with illicit values of an attribute.
+  Compiled to attVal.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Runs the test and returns the result.
+export const reporter = async (
+  page: Page,
+  report: Report,
+  _0: unknown,
+  withItems: boolean,
+  attributeName: string,
+  areLicit: boolean,
+  values: string[]
+) => {
+  const getBadWhat: GetBadWhat = element => {
+    // Get the value of the attribute.
+    const value = element.getAttribute(attributeName);
+    // If it violates the rule:
+    if (areLicit !== values.includes(value as string)) {
+      // Return a violation description.
+      return `Element has attribute ${attributeName} with illicit value ${value}`;
+    }
+  };
+  const whats = `Elements have attribute ${attributeName} with illicit values`;
+  return await doTest(
+    page, report, withItems, 'attVal', `body [${attributeName}]`, whats, 2, getBadWhat.toString()
+  );
+};

--- a/testaro/captionLoc.d.ts
+++ b/testaro/captionLoc.d.ts
@@ -1,0 +1,3 @@
+import type { Page } from 'playwright';
+import type { Report } from '../types';
+export declare const reporter: (page: Page, report: Report, _: unknown, withItems: boolean) => Promise<import("../procs/testaro").RuleResult>;

--- a/testaro/captionLoc.js
+++ b/testaro/captionLoc.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2025 CVS Health and/or one of its affiliates. All rights reserved.
   © 2025 Juan S. Casado.
@@ -9,29 +10,25 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const testaro_1 = require("../procs/testaro");
 /*
   captionLoc
   This test reports caption elements that are not the first children of table elements.
+  Compiled to captionLoc.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const {doTest} = require('../procs/testaro');
-
 // FUNCTIONS
-
-exports.reporter = async (page, report, _, withItems) => {
-  const getBadWhat = element => {
-    const parent = element.parentElement;
-    // If the element is not the first child of a table element:
-    if (! parent || parent.tagName !== 'TABLE' || parent.firstElementChild !== element) {
-      // Return a violation description.
-      return 'caption element is not the first child of a table element';
-    }
-  };
-  const whats = 'caption elements are not the first children of table elements';
-  return await doTest(
-    page, report, withItems, 'captionLoc', 'body caption', whats, 3, getBadWhat.toString()
-  );
+const reporter = async (page, report, _, withItems) => {
+    const getBadWhat = element => {
+        const parent = element.parentElement;
+        // If the element is not the first child of a table element:
+        if (!parent || parent.tagName !== 'TABLE' || parent.firstElementChild !== element) {
+            // Return a violation description.
+            return 'caption element is not the first child of a table element';
+        }
+    };
+    const whats = 'caption elements are not the first children of table elements';
+    return await (0, testaro_1.doTest)(page, report, withItems, 'captionLoc', 'body caption', whats, 3, getBadWhat.toString());
 };
+exports.reporter = reporter;

--- a/testaro/captionLoc.ts
+++ b/testaro/captionLoc.ts
@@ -1,0 +1,40 @@
+/*
+  © 2025 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2025 Juan S. Casado.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {doTest} from '../procs/testaro';
+import type {GetBadWhat, Report} from '../types';
+
+/*
+  captionLoc
+  This test reports caption elements that are not the first children of table elements.
+  Compiled to captionLoc.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+export const reporter = async (page: Page, report: Report, _: unknown, withItems: boolean) => {
+  const getBadWhat: GetBadWhat = element => {
+    const parent = element.parentElement;
+    // If the element is not the first child of a table element:
+    if (! parent || parent.tagName !== 'TABLE' || parent.firstElementChild !== element) {
+      // Return a violation description.
+      return 'caption element is not the first child of a table element';
+    }
+  };
+  const whats = 'caption elements are not the first children of table elements';
+  return await doTest(
+    page, report, withItems, 'captionLoc', 'body caption', whats, 3, getBadWhat.toString()
+  );
+};

--- a/testaro/embAc.d.ts
+++ b/testaro/embAc.d.ts
@@ -1,0 +1,3 @@
+import type { Page } from 'playwright';
+import type { Report } from '../types';
+export declare const reporter: (page: Page, report: Report, _: unknown, withItems: boolean) => Promise<import("../procs/testaro").RuleResult>;

--- a/testaro/embAc.js
+++ b/testaro/embAc.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2021–2023 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -8,30 +9,28 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const testaro_1 = require("../procs/testaro");
 /*
   embAc
   This test reports interactive elements (links, buttons, inputs, and select lists) contained by links or buttons. Such embedding not only violates the HTML standard, but also complicates user interaction and creates risks of error. It becomes non-obvious what a user will activate with a click.
+  Compiled to embAc.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const {doTest} = require('../procs/testaro');
-
 // FUNCTIONS
-
 // Runs the test and returns the result.
-exports.reporter = async (page, report, _, withItems) => {
-  const getBadWhat = element => {
-    // Get whether the embedding element is a link or a button.
-    const embedder = element.parentElement.closest('a, button');
-    const embedderWhat = embedder.tagName.toLowerCase() === 'a' ? 'a link' : 'a button';
-    // Return a violation description.
-    return `interactive element is embedded in ${embedderWhat}`;
-  };
-  const selector = ['a', 'button', 'input', 'select']
-  .map(tag => `a ${tag}, button ${tag}`)
-  .join(', ');
-  const whats = 'interactive elements are embedded in links or buttons';
-  return await doTest(page, report, withItems, 'embAc', selector, whats, 2, getBadWhat.toString());
+const reporter = async (page, report, _, withItems) => {
+    const getBadWhat = element => {
+        // Get whether the embedding element is a link or a button.
+        const embedder = element.parentElement.closest('a, button');
+        const embedderWhat = embedder.tagName.toLowerCase() === 'a' ? 'a link' : 'a button';
+        // Return a violation description.
+        return `interactive element is embedded in ${embedderWhat}`;
+    };
+    const selector = ['a', 'button', 'input', 'select']
+        .map(tag => `a ${tag}, button ${tag}`)
+        .join(', ');
+    const whats = 'interactive elements are embedded in links or buttons';
+    return await (0, testaro_1.doTest)(page, report, withItems, 'embAc', selector, whats, 2, getBadWhat.toString());
 };
+exports.reporter = reporter;

--- a/testaro/embAc.ts
+++ b/testaro/embAc.ts
@@ -1,0 +1,40 @@
+/*
+  © 2021–2023 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {doTest} from '../procs/testaro';
+import type {GetBadWhat, Report} from '../types';
+
+/*
+  embAc
+  This test reports interactive elements (links, buttons, inputs, and select lists) contained by links or buttons. Such embedding not only violates the HTML standard, but also complicates user interaction and creates risks of error. It becomes non-obvious what a user will activate with a click.
+  Compiled to embAc.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Runs the test and returns the result.
+export const reporter = async (page: Page, report: Report, _: unknown, withItems: boolean) => {
+  const getBadWhat: GetBadWhat = element => {
+    // Get whether the embedding element is a link or a button.
+    const embedder = element.parentElement!.closest('a, button');
+    const embedderWhat = embedder!.tagName.toLowerCase() === 'a' ? 'a link' : 'a button';
+    // Return a violation description.
+    return `interactive element is embedded in ${embedderWhat}`;
+  };
+  const selector = ['a', 'button', 'input', 'select']
+  .map(tag => `a ${tag}, button ${tag}`)
+  .join(', ');
+  const whats = 'interactive elements are embedded in links or buttons';
+  return await doTest(page, report, withItems, 'embAc', selector, whats, 2, getBadWhat.toString());
+};

--- a/testaro/focAndOp.d.ts
+++ b/testaro/focAndOp.d.ts
@@ -1,0 +1,3 @@
+import type { Page } from 'playwright';
+import type { Report } from '../types';
+export declare const reporter: (page: Page, report: Report, _: unknown, withItems: boolean) => Promise<import("../procs/testaro").RuleResult>;

--- a/testaro/focAndOp.js
+++ b/testaro/focAndOp.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2021–2024 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -8,117 +9,112 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const testaro_1 = require("../procs/testaro");
 /*
   focAndOp
   Related to Tenon rule 190.
 
   This test reports discrepancies between Tab-focusability and operability. The standard practice is to make focusable elements operable and operable elements focusable. If focusable elements are not operable, users are likely to be surprised that nothing happens when they try to operate such elements. Conversely, if operable elements are not focusable, users who navigate with a keyboard are prevented from operating those elements.  The test considers an element Tab-focusable if its tabIndex property has the value 0. The test considers an element operable if it has a non-inherited pointer cursor and is not a 'LABEL' element, has an operable tag name, has an interactive explicit role, or has an 'onclick' attribute.
+  Compiled to focAndOp.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const {doTest} = require('../procs/testaro');
-
 // FUNCTIONS
-
 // Runs the test and returns the result.
-exports.reporter = async (page, report, _, withItems) => {
-  const getBadWhat = element => {
-    // Get whether the element is visible.
-    const isVisible = element.checkVisibility({
-      contentVisibilityAuto: true,
-      opacityProperty: true,
-      visibilityProperty: true
-    });
-    // If so:
-    if (isVisible) {
-      // Get whether it is focusable.
-      const isFocusable = element.tabIndex === 0;
-      // Get the operable tagnames.
-      const opTags = new Set(
-        ['A', 'BUTTON', 'IFRAME', 'INPUT','OPTION', 'SELECT', 'SUMMARY', 'TEXTAREA']
-      );
-      // Get the operable roles.
-      const opRoles = new Set([
-        'button',
-        'checkbox',
-        'combobox',
-        'composite',
-        'grid',
-        'gridcell',
-        'input',
-        'link',
-        'listbox',
-        'menu',
-        'menubar',
-        'menuitem',
-        'menuitemcheckbox',
-        'option',
-        'radio',
-        'radiogroup',
-        'scrollbar',
-        'searchbox',
-        'select',
-        'slider',
-        'spinbutton',
-        'switch',
-        'tab',
-        'tablist',
-        'textbox',
-        'tree',
-        'treegrid',
-        'treeitem',
-        'widget',
-      ]);
-      // Initialize the operabilities of the element.
-      const opHow = [];
-      // If the element is not a label:
-      if (element.tagName !== 'LABEL') {
-        const liveStyleDec = window.getComputedStyle(element);
-        // If it has a pointer cursor:
-        if (liveStyleDec.cursor === 'pointer') {
-          // Neutralize the cursor style of the parent element of the element.
-          element.parentElement.style.cursor = 'default';
-          // If, after this, the element still has a pointer cursor:
-          if (liveStyleDec.cursor === 'pointer') {
-            // Add this to the operabilities of the element.
-            opHow.push('pointer cursor');
-          }
+const reporter = async (page, report, _, withItems) => {
+    // The candidate selector yields rendered HTML elements.
+    const getBadWhat = (element) => {
+        // Get whether the element is visible.
+        const isVisible = element.checkVisibility({
+            contentVisibilityAuto: true,
+            opacityProperty: true,
+            visibilityProperty: true
+        });
+        // If so:
+        if (isVisible) {
+            // Get whether it is focusable.
+            const isFocusable = element.tabIndex === 0;
+            // Get the operable tagnames.
+            const opTags = new Set(['A', 'BUTTON', 'IFRAME', 'INPUT', 'OPTION', 'SELECT', 'SUMMARY', 'TEXTAREA']);
+            // Get the operable roles.
+            const opRoles = new Set([
+                'button',
+                'checkbox',
+                'combobox',
+                'composite',
+                'grid',
+                'gridcell',
+                'input',
+                'link',
+                'listbox',
+                'menu',
+                'menubar',
+                'menuitem',
+                'menuitemcheckbox',
+                'option',
+                'radio',
+                'radiogroup',
+                'scrollbar',
+                'searchbox',
+                'select',
+                'slider',
+                'spinbutton',
+                'switch',
+                'tab',
+                'tablist',
+                'textbox',
+                'tree',
+                'treegrid',
+                'treeitem',
+                'widget',
+            ]);
+            // Initialize the operabilities of the element.
+            const opHow = [];
+            // If the element is not a label:
+            if (element.tagName !== 'LABEL') {
+                const liveStyleDec = window.getComputedStyle(element);
+                // If it has a pointer cursor:
+                if (liveStyleDec.cursor === 'pointer') {
+                    // Neutralize the cursor style of the parent element of the element.
+                    element.parentElement.style.cursor = 'default';
+                    // If, after this, the element still has a pointer cursor:
+                    if (liveStyleDec.cursor === 'pointer') {
+                        // Add this to the operabilities of the element.
+                        opHow.push('pointer cursor');
+                    }
+                }
+            }
+            // If the element has a click event listener:
+            if (element.onclick) {
+                // Add this to the operabilities.
+                opHow.push('click listener');
+            }
+            // If the element has an operable explicit role:
+            const role = element.getAttribute('role');
+            if (opRoles.has(role)) {
+                // Add this to the operabilities.
+                opHow.push(`role ${role}`);
+            }
+            // If the element has an operable tagname:
+            const tagName = element.tagName;
+            if (opTags.has(tagName)) {
+                // Add this to the operabilities.
+                opHow.push(`tagname ${tagName}`);
+            }
+            const isOperable = opHow.length > 0;
+            // If the element is focusable but not operable:
+            if (isFocusable && !isOperable) {
+                // Return a severity and violation description.
+                return '2:Element is Tab-focusable but not operable';
+            }
+            // Otherwise, if it is operable but not focusable:
+            else if (isOperable && !isFocusable) {
+                // Return a severity and violation description.
+                return `3:Element is operable (${opHow.join(', ')}) but not Tab-focusable`;
+            }
         }
-      }
-      // If the element has a click event listener:
-      if (element.onclick) {
-        // Add this to the operabilities.
-        opHow.push('click listener');
-      }
-      // If the element has an operable explicit role:
-      const role = element.getAttribute('role');
-      if (opRoles.has(role)) {
-        // Add this to the operabilities.
-        opHow.push(`role ${role}`);
-      }
-      // If the element has an operable tagname:
-      const tagName = element.tagName;
-      if (opTags.has(tagName)) {
-        // Add this to the operabilities.
-        opHow.push(`tagname ${tagName}`);
-      }
-      const isOperable = opHow.length > 0;
-      // If the element is focusable but not operable:
-      if (isFocusable && ! isOperable) {
-        // Return a severity and violation description.
-        return '2:Element is Tab-focusable but not operable';
-      }
-      // Otherwise, if it is operable but not focusable:
-      else if (isOperable && ! isFocusable) {
-        // Return a severity and violation description.
-        return `3:Element is operable (${opHow.join(', ')}) but not Tab-focusable`;
-      }
-    }
-  };
-  const whats = 'Elements are Tab-focusable but not operable or vice versa';
-  return await doTest(
-    page, report, withItems, 'focAndOp', 'body, body *', whats, 2, getBadWhat.toString()
-  );
+    };
+    const whats = 'Elements are Tab-focusable but not operable or vice versa';
+    return await (0, testaro_1.doTest)(page, report, withItems, 'focAndOp', 'body, body *', whats, 2, getBadWhat.toString());
 };
+exports.reporter = reporter;

--- a/testaro/focAndOp.ts
+++ b/testaro/focAndOp.ts
@@ -1,0 +1,128 @@
+/*
+  © 2021–2024 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {doTest} from '../procs/testaro';
+import type {BadWhat, Report} from '../types';
+
+/*
+  focAndOp
+  Related to Tenon rule 190.
+
+  This test reports discrepancies between Tab-focusability and operability. The standard practice is to make focusable elements operable and operable elements focusable. If focusable elements are not operable, users are likely to be surprised that nothing happens when they try to operate such elements. Conversely, if operable elements are not focusable, users who navigate with a keyboard are prevented from operating those elements.  The test considers an element Tab-focusable if its tabIndex property has the value 0. The test considers an element operable if it has a non-inherited pointer cursor and is not a 'LABEL' element, has an operable tag name, has an interactive explicit role, or has an 'onclick' attribute.
+  Compiled to focAndOp.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Runs the test and returns the result.
+export const reporter = async (page: Page, report: Report, _: unknown, withItems: boolean) => {
+  // The candidate selector yields rendered HTML elements.
+  const getBadWhat = (element: HTMLElement): BadWhat => {
+    // Get whether the element is visible.
+    const isVisible = element.checkVisibility({
+      contentVisibilityAuto: true,
+      opacityProperty: true,
+      visibilityProperty: true
+    });
+    // If so:
+    if (isVisible) {
+      // Get whether it is focusable.
+      const isFocusable = element.tabIndex === 0;
+      // Get the operable tagnames.
+      const opTags = new Set(
+        ['A', 'BUTTON', 'IFRAME', 'INPUT','OPTION', 'SELECT', 'SUMMARY', 'TEXTAREA']
+      );
+      // Get the operable roles.
+      const opRoles = new Set([
+        'button',
+        'checkbox',
+        'combobox',
+        'composite',
+        'grid',
+        'gridcell',
+        'input',
+        'link',
+        'listbox',
+        'menu',
+        'menubar',
+        'menuitem',
+        'menuitemcheckbox',
+        'option',
+        'radio',
+        'radiogroup',
+        'scrollbar',
+        'searchbox',
+        'select',
+        'slider',
+        'spinbutton',
+        'switch',
+        'tab',
+        'tablist',
+        'textbox',
+        'tree',
+        'treegrid',
+        'treeitem',
+        'widget',
+      ]);
+      // Initialize the operabilities of the element.
+      const opHow = [];
+      // If the element is not a label:
+      if (element.tagName !== 'LABEL') {
+        const liveStyleDec = window.getComputedStyle(element);
+        // If it has a pointer cursor:
+        if (liveStyleDec.cursor === 'pointer') {
+          // Neutralize the cursor style of the parent element of the element.
+          element.parentElement!.style.cursor = 'default';
+          // If, after this, the element still has a pointer cursor:
+          if (liveStyleDec.cursor === 'pointer') {
+            // Add this to the operabilities of the element.
+            opHow.push('pointer cursor');
+          }
+        }
+      }
+      // If the element has a click event listener:
+      if (element.onclick) {
+        // Add this to the operabilities.
+        opHow.push('click listener');
+      }
+      // If the element has an operable explicit role:
+      const role = element.getAttribute('role');
+      if (opRoles.has(role as string)) {
+        // Add this to the operabilities.
+        opHow.push(`role ${role}`);
+      }
+      // If the element has an operable tagname:
+      const tagName = element.tagName;
+      if (opTags.has(tagName)) {
+        // Add this to the operabilities.
+        opHow.push(`tagname ${tagName}`);
+      }
+      const isOperable = opHow.length > 0;
+      // If the element is focusable but not operable:
+      if (isFocusable && ! isOperable) {
+        // Return a severity and violation description.
+        return '2:Element is Tab-focusable but not operable';
+      }
+      // Otherwise, if it is operable but not focusable:
+      else if (isOperable && ! isFocusable) {
+        // Return a severity and violation description.
+        return `3:Element is operable (${opHow.join(', ')}) but not Tab-focusable`;
+      }
+    }
+  };
+  const whats = 'Elements are Tab-focusable but not operable or vice versa';
+  return await doTest(
+    page, report, withItems, 'focAndOp', 'body, body *', whats, 2, getBadWhat.toString()
+  );
+};

--- a/testaro/focInd.d.ts
+++ b/testaro/focInd.d.ts
@@ -1,0 +1,3 @@
+import type { Page } from 'playwright';
+import type { Report } from '../types';
+export declare const reporter: (page: Page, report: Report, _: unknown, withItems: boolean) => Promise<import("../procs/testaro").RuleResult>;

--- a/testaro/focInd.js
+++ b/testaro/focInd.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2021–2023 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -8,7 +9,9 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const testaro_1 = require("../procs/testaro");
 /*
   focInd
 
@@ -19,74 +22,69 @@
   Solid outlines are the standard and thus most familiar focus indicator. Other focus indicators are likely to be misunderstood. For example, underlines may be mistaken for selection or link indicators.
 
   WARNING: This test fails to recognize outlines when run with firefox.
+  Compiled to focInd.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const {doTest} = require('../procs/testaro');
-
 // FUNCTIONS
-
 // Runs the test and returns the result.
-exports.reporter = async (page, report, _, withItems) => {
-  const getBadWhat = element => {
-    // Get whether the element is visible.
-    const isVisible = element.checkVisibility({
-      contentVisibilityAuto: true,
-      opacityProperty: true,
-      visibilityProperty: true
-    });
-    // If so:
-    if (isVisible) {
-      // Get whether it is focusable.
-      const isFocusable = element.tabIndex === 0;
-      // If so:
-      if (isFocusable) {
-        // Get its live style declaration.
-        const styleDec = window.getComputedStyle(element);
-        // If the element has a visible outline before being focused:
-        if (styleDec.outlineStyle !== 'none' && styleDec.outlineWidth !== '0px') {
-          // Return a violation description.
-          return 'Element is focusable but has an outline when blurred';
-        }
-        // Otherwise, i.e. if the element has no outline, focus the element.
-        element.focus({preventScroll: true});
-        // If it now has no outline:
-        if (styleDec.outlineWidth === '0px' || styleDec.outlineStyle === 'none') {
-          // Return a violation description.
-          return 'Element when focused has no outline';
-        }
-        // Otherwise, if it now has an outline thinner than 2 pixels:
-        if (Number.parseFloat(styleDec.outlineWidth) < 2 && styleDec.outlineStyle !== 'none') {
-          // Return a violation description.
-          return 'Element when focused has an outline thinner than 2 pixels';
-        }
-        // Otherwise, if it now has a transparent outline:
-        if (styleDec.outlineColor === 'rgba(0, 0, 0, 0)') {
-          // Return a violation description.
-          return 'Element when focused has a transparent outline';
-        }
-        // Otherwise, if it now has a non-solid outline:
-        if (styleDec.outlineStyle !== 'solid') {
-          // If the outline style exists:
-          if (styleDec.outlineStyle) {
-            // If the style is not delegated to the user agent:
-            if (styleDec.outlineStyle !== 'auto') {
-              // Return a violation description
-              return `Element when focused has an outline with the ${styleDec.outlineStyle} instead of solid style`;
+const reporter = async (page, report, _, withItems) => {
+    // The candidate selector yields rendered HTML elements.
+    const getBadWhat = (element) => {
+        // Get whether the element is visible.
+        const isVisible = element.checkVisibility({
+            contentVisibilityAuto: true,
+            opacityProperty: true,
+            visibilityProperty: true
+        });
+        // If so:
+        if (isVisible) {
+            // Get whether it is focusable.
+            const isFocusable = element.tabIndex === 0;
+            // If so:
+            if (isFocusable) {
+                // Get its live style declaration.
+                const styleDec = window.getComputedStyle(element);
+                // If the element has a visible outline before being focused:
+                if (styleDec.outlineStyle !== 'none' && styleDec.outlineWidth !== '0px') {
+                    // Return a violation description.
+                    return 'Element is focusable but has an outline when blurred';
+                }
+                // Otherwise, i.e. if the element has no outline, focus the element.
+                element.focus({ preventScroll: true });
+                // If it now has no outline:
+                if (styleDec.outlineWidth === '0px' || styleDec.outlineStyle === 'none') {
+                    // Return a violation description.
+                    return 'Element when focused has no outline';
+                }
+                // Otherwise, if it now has an outline thinner than 2 pixels:
+                if (Number.parseFloat(styleDec.outlineWidth) < 2 && styleDec.outlineStyle !== 'none') {
+                    // Return a violation description.
+                    return 'Element when focused has an outline thinner than 2 pixels';
+                }
+                // Otherwise, if it now has a transparent outline:
+                if (styleDec.outlineColor === 'rgba(0, 0, 0, 0)') {
+                    // Return a violation description.
+                    return 'Element when focused has a transparent outline';
+                }
+                // Otherwise, if it now has a non-solid outline:
+                if (styleDec.outlineStyle !== 'solid') {
+                    // If the outline style exists:
+                    if (styleDec.outlineStyle) {
+                        // If the style is not delegated to the user agent:
+                        if (styleDec.outlineStyle !== 'auto') {
+                            // Return a violation description
+                            return `Element when focused has an outline with the ${styleDec.outlineStyle} instead of solid style`;
+                        }
+                    }
+                    // Otherwise, i.e. if no outline style exists:
+                    else {
+                        // Return a violation description.
+                        return 'Element when focused has an outline with no instead of solid style';
+                    }
+                }
             }
-          }
-          // Otherwise, i.e. if no outline style exists:
-          else {
-            // Return a violation description.
-            return 'Element when focused has an outline with no instead of solid style';
-          }
         }
-      }
-    }
-  };
-  const whats = 'Elements fail to have standard focus indicators';
-  return await doTest(
-    page, report, withItems, 'focInd', 'body, body *', whats, 1, getBadWhat.toString()
-  );
+    };
+    const whats = 'Elements fail to have standard focus indicators';
+    return await (0, testaro_1.doTest)(page, report, withItems, 'focInd', 'body, body *', whats, 1, getBadWhat.toString());
 };
+exports.reporter = reporter;

--- a/testaro/focInd.ts
+++ b/testaro/focInd.ts
@@ -1,0 +1,96 @@
+/*
+  © 2021–2023 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {doTest} from '../procs/testaro';
+import type {BadWhat, Report} from '../types';
+
+/*
+  focInd
+
+  This test reports focusable elements without standard focus indicators. The standard focus indicator is deemed to be a solid outline with a line thickness of at least 2 pixels and a non-transparent color, and only if the element, when not focused, has no outline.
+
+  The focus indicator is checked immediately after the element is focused. Thus, a delayed focus indicator is ignored. Indication delayed is treated as indication denied. The bases for this treatment are that delayed indication interferes with rapid human or mechanized document consumption and also, if it must be respected, slows accessibility testing.
+
+  Solid outlines are the standard and thus most familiar focus indicator. Other focus indicators are likely to be misunderstood. For example, underlines may be mistaken for selection or link indicators.
+
+  WARNING: This test fails to recognize outlines when run with firefox.
+  Compiled to focInd.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Runs the test and returns the result.
+export const reporter = async (page: Page, report: Report, _: unknown, withItems: boolean) => {
+  // The candidate selector yields rendered HTML elements.
+  const getBadWhat = (element: HTMLElement): BadWhat => {
+    // Get whether the element is visible.
+    const isVisible = element.checkVisibility({
+      contentVisibilityAuto: true,
+      opacityProperty: true,
+      visibilityProperty: true
+    });
+    // If so:
+    if (isVisible) {
+      // Get whether it is focusable.
+      const isFocusable = element.tabIndex === 0;
+      // If so:
+      if (isFocusable) {
+        // Get its live style declaration.
+        const styleDec = window.getComputedStyle(element);
+        // If the element has a visible outline before being focused:
+        if (styleDec.outlineStyle !== 'none' && styleDec.outlineWidth !== '0px') {
+          // Return a violation description.
+          return 'Element is focusable but has an outline when blurred';
+        }
+        // Otherwise, i.e. if the element has no outline, focus the element.
+        element.focus({preventScroll: true});
+        // If it now has no outline:
+        if (styleDec.outlineWidth === '0px' || styleDec.outlineStyle === 'none') {
+          // Return a violation description.
+          return 'Element when focused has no outline';
+        }
+        // Otherwise, if it now has an outline thinner than 2 pixels:
+        if (Number.parseFloat(styleDec.outlineWidth) < 2 && styleDec.outlineStyle !== 'none') {
+          // Return a violation description.
+          return 'Element when focused has an outline thinner than 2 pixels';
+        }
+        // Otherwise, if it now has a transparent outline:
+        if (styleDec.outlineColor === 'rgba(0, 0, 0, 0)') {
+          // Return a violation description.
+          return 'Element when focused has a transparent outline';
+        }
+        // Otherwise, if it now has a non-solid outline:
+        if (styleDec.outlineStyle !== 'solid') {
+          // If the outline style exists:
+          if (styleDec.outlineStyle) {
+            // If the style is not delegated to the user agent:
+            if (styleDec.outlineStyle !== 'auto') {
+              // Return a violation description
+              return `Element when focused has an outline with the ${styleDec.outlineStyle} instead of solid style`;
+            }
+          }
+          // Otherwise, i.e. if no outline style exists:
+          else {
+            // Return a violation description.
+            return 'Element when focused has an outline with no instead of solid style';
+          }
+        }
+      }
+    }
+  };
+  const whats = 'Elements fail to have standard focus indicators';
+  return await doTest(
+    page, report, withItems, 'focInd', 'body, body *', whats, 1, getBadWhat.toString()
+  );
+};

--- a/testaro/focVis.d.ts
+++ b/testaro/focVis.d.ts
@@ -1,0 +1,3 @@
+import type { Page } from 'playwright';
+import type { Report } from '../types';
+export declare const reporter: (page: Page, report: Report, _: unknown, withItems: boolean) => Promise<import("../procs/testaro").RuleResult>;

--- a/testaro/focVis.js
+++ b/testaro/focVis.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2022–2025 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -8,41 +9,38 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const testaro_1 = require("../procs/testaro");
 /*
   focVis
   Derived from the bbc-a11y elementsMustBeVisibleOnFocus test.
   This test reports links that are at least partly off the display when focused.
+  Compiled to focVis.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const {doTest} = require('../procs/testaro');
-
 // FUNCTIONS
-
 // Runs the test and returns the result.
-exports.reporter = async (page, report, _, withItems) => {
-  const getBadWhat = element => {
-    const isVisible = element.checkVisibility({
-      contentVisibilityAuto: true,
-      opacityProperty: true,
-      visibilityProperty: true
-    });
-    // If the element is visible:
-    if (isVisible) {
-      // Focus it.
-      element.focus();
-      const box = element.getBoundingClientRect();
-      // If it violates the rule:
-      if (box.x < 0 || box.y < 0) {
-        // Return a violation description.
-        return 'Upper left corner of the element is above or to the left of the display';
-      }
-    }
-  };
-  const whats = 'Visible links are above or to the left of the display';
-  return await doTest(
-    page, report, withItems, 'focVis', 'body a', whats, 2, getBadWhat.toString()
-  );
+const reporter = async (page, report, _, withItems) => {
+    // The candidate selector guarantees focusable HTML elements.
+    const getBadWhat = (element) => {
+        const isVisible = element.checkVisibility({
+            contentVisibilityAuto: true,
+            opacityProperty: true,
+            visibilityProperty: true
+        });
+        // If the element is visible:
+        if (isVisible) {
+            // Focus it.
+            element.focus();
+            const box = element.getBoundingClientRect();
+            // If it violates the rule:
+            if (box.x < 0 || box.y < 0) {
+                // Return a violation description.
+                return 'Upper left corner of the element is above or to the left of the display';
+            }
+        }
+    };
+    const whats = 'Visible links are above or to the left of the display';
+    return await (0, testaro_1.doTest)(page, report, withItems, 'focVis', 'body a', whats, 2, getBadWhat.toString());
 };
+exports.reporter = reporter;

--- a/testaro/focVis.ts
+++ b/testaro/focVis.ts
@@ -1,0 +1,52 @@
+/*
+  © 2022–2025 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {doTest} from '../procs/testaro';
+import type {BadWhat, Report} from '../types';
+
+/*
+  focVis
+  Derived from the bbc-a11y elementsMustBeVisibleOnFocus test.
+  This test reports links that are at least partly off the display when focused.
+  Compiled to focVis.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Runs the test and returns the result.
+export const reporter = async (page: Page, report: Report, _: unknown, withItems: boolean) => {
+  // The candidate selector guarantees focusable HTML elements.
+  const getBadWhat = (element: HTMLElement): BadWhat => {
+    const isVisible = element.checkVisibility({
+      contentVisibilityAuto: true,
+      opacityProperty: true,
+      visibilityProperty: true
+    });
+    // If the element is visible:
+    if (isVisible) {
+      // Focus it.
+      element.focus();
+      const box = element.getBoundingClientRect();
+      // If it violates the rule:
+      if (box.x < 0 || box.y < 0) {
+        // Return a violation description.
+        return 'Upper left corner of the element is above or to the left of the display';
+      }
+    }
+  };
+  const whats = 'Visible links are above or to the left of the display';
+  return await doTest(
+    page, report, withItems, 'focVis', 'body a', whats, 2, getBadWhat.toString()
+  );
+};

--- a/testaro/headingAmb.d.ts
+++ b/testaro/headingAmb.d.ts
@@ -1,0 +1,3 @@
+import type { Page } from 'playwright';
+import type { Report } from '../types';
+export declare const reporter: (page: Page, report: Report, _: unknown, withItems: boolean) => Promise<import("../procs/testaro").RuleResult>;

--- a/testaro/headingAmb.js
+++ b/testaro/headingAmb.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2023–2024 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -7,70 +8,60 @@
 
   SPDX-License-Identifier: MIT
 */
-
-/*
-  headingAmb
-  Related to ASLint rule headings-sibling-unique.
-  This test reports adjacent headings with the same levels and text contents.
-*/
-
-// IMPORTS
-
-const {doTest} = require('../procs/testaro');
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const testaro_1 = require("../procs/testaro");
 // ########## FUNCTIONS
-
 // Runs the test and returns the result.
-exports.reporter = async (page, report, _, withItems) => {
-  const getBadWhat = element => {
-    const {tagName} = element;
-    const level = tagName[1];
-    const textContent = element.textContent.trim().replace(/\s+/g, ' ');
-    const headingTagNames = ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
-    // Initialize the inspected element as the previous element sibling of the element.
-    let inspectedElement = element.previousElementSibling;
-    // As long as the inspected element exists:
-    while (inspectedElement) {
-      const inspectedTagName = inspectedElement.tagName;
-      // If it is a heading:
-      if (headingTagNames.includes(inspectedTagName)) {
-        // If it is inferior to the element:
-        if (inspectedTagName[1] > level) {
-          // Stop inspecting it and start inspecting its previous sibling.
-          inspectedElement = inspectedElement.previousElementSibling;
-          continue;
+const reporter = async (page, report, _, withItems) => {
+    const getBadWhat = element => {
+        const { tagName } = element;
+        const level = tagName[1];
+        const textContent = element.textContent.trim().replace(/\s+/g, ' ');
+        const headingTagNames = ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
+        // Initialize the inspected element as the previous element sibling of the element.
+        let inspectedElement = element.previousElementSibling;
+        // As long as the inspected element exists:
+        while (inspectedElement) {
+            const inspectedTagName = inspectedElement.tagName;
+            // If it is a heading:
+            if (headingTagNames.includes(inspectedTagName)) {
+                // If it is inferior to the element:
+                if (inspectedTagName[1] > level) {
+                    // Stop inspecting it and start inspecting its previous sibling.
+                    inspectedElement = inspectedElement.previousElementSibling;
+                    continue;
+                }
+                // Otherwise, if its level is the same as that of the element:
+                else if (inspectedTagName === tagName) {
+                    const inspectedTextContent = inspectedElement.textContent.trim().replace(/\s+/g, ' ');
+                    // If they have identical text contents:
+                    if (inspectedTextContent === textContent) {
+                        // Return a violation description.
+                        return 'Heading has the same text as the prior same-level sibling heading';
+                    }
+                    // Otherwise, i.e. if they do not have identical text contents:
+                    else {
+                        // Stop inspecting.
+                        break;
+                    }
+                }
+                // Otherwise, i.e. if it is superior to the element:
+                else {
+                    // Stop inspecting.
+                    break;
+                }
+            }
+            // Otherwise, i.e. if it is not a heading:
+            else {
+                // Inspect its previous sibling.
+                inspectedElement = inspectedElement.previousElementSibling;
+            }
         }
-        // Otherwise, if its level is the same as that of the element:
-        else if (inspectedTagName === tagName) {
-          const inspectedTextContent = inspectedElement.textContent.trim().replace(/\s+/g, ' ');
-          // If they have identical text contents:
-          if (inspectedTextContent === textContent) {
-            // Return a violation description.
-            return 'Heading has the same text as the prior same-level sibling heading';
-          }
-          // Otherwise, i.e. if they do not have identical text contents:
-          else {
-            // Stop inspecting.
-            break;
-          }
-        }
-        // Otherwise, i.e. if it is superior to the element:
-        else {
-          // Stop inspecting.
-          break;
-        }
-      }
-      // Otherwise, i.e. if it is not a heading:
-      else {
-        // Inspect its previous sibling.
-        inspectedElement = inspectedElement.previousElementSibling;
-      }
-    }
-  };
-  const headingLevels = [1, 2, 3, 4, 5, 6];
-  const selector = headingLevels.map(level => `body h${level}`).join(', ');
-  const whats = 'Adjacent sibling same-level headings have the same text';
-  return await doTest(
-    page, report, withItems, 'headingAmb', selector, whats, 1, getBadWhat.toString()
-  );
+    };
+    const headingLevels = [1, 2, 3, 4, 5, 6];
+    const selector = headingLevels.map(level => `body h${level}`).join(', ');
+    const whats = 'Adjacent sibling same-level headings have the same text';
+    return await (0, testaro_1.doTest)(page, report, withItems, 'headingAmb', selector, whats, 1, getBadWhat.toString());
 };
+exports.reporter = reporter;

--- a/testaro/headingAmb.ts
+++ b/testaro/headingAmb.ts
@@ -1,0 +1,72 @@
+/*
+  © 2023–2024 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {doTest} from '../procs/testaro';
+import type {GetBadWhat, Report} from '../types';
+
+// ########## FUNCTIONS
+
+// Runs the test and returns the result.
+export const reporter = async (page: Page, report: Report, _: unknown, withItems: boolean) => {
+  const getBadWhat: GetBadWhat = element => {
+    const {tagName} = element;
+    const level = tagName[1];
+    const textContent = element.textContent.trim().replace(/\s+/g, ' ');
+    const headingTagNames = ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
+    // Initialize the inspected element as the previous element sibling of the element.
+    let inspectedElement = element.previousElementSibling;
+    // As long as the inspected element exists:
+    while (inspectedElement) {
+      const inspectedTagName = inspectedElement.tagName;
+      // If it is a heading:
+      if (headingTagNames.includes(inspectedTagName)) {
+        // If it is inferior to the element:
+        if (inspectedTagName[1] > level) {
+          // Stop inspecting it and start inspecting its previous sibling.
+          inspectedElement = inspectedElement.previousElementSibling;
+          continue;
+        }
+        // Otherwise, if its level is the same as that of the element:
+        else if (inspectedTagName === tagName) {
+          const inspectedTextContent = inspectedElement.textContent.trim().replace(/\s+/g, ' ');
+          // If they have identical text contents:
+          if (inspectedTextContent === textContent) {
+            // Return a violation description.
+            return 'Heading has the same text as the prior same-level sibling heading';
+          }
+          // Otherwise, i.e. if they do not have identical text contents:
+          else {
+            // Stop inspecting.
+            break;
+          }
+        }
+        // Otherwise, i.e. if it is superior to the element:
+        else {
+          // Stop inspecting.
+          break;
+        }
+      }
+      // Otherwise, i.e. if it is not a heading:
+      else {
+        // Inspect its previous sibling.
+        inspectedElement = inspectedElement.previousElementSibling;
+      }
+    }
+  };
+  const headingLevels = [1, 2, 3, 4, 5, 6];
+  const selector = headingLevels.map(level => `body h${level}`).join(', ');
+  const whats = 'Adjacent sibling same-level headings have the same text';
+  return await doTest(
+    page, report, withItems, 'headingAmb', selector, whats, 1, getBadWhat.toString()
+  );
+};

--- a/testaro/hovInd.d.ts
+++ b/testaro/hovInd.d.ts
@@ -1,0 +1,3 @@
+import type { Page } from 'playwright';
+import type { Report } from '../types';
+export declare const reporter: (page: Page, report: Report, _: unknown, withItems: boolean) => Promise<import("../procs/testaro").RuleResult>;

--- a/testaro/hovInd.js
+++ b/testaro/hovInd.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2023–2025 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -7,139 +8,126 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const testaro_1 = require("../procs/testaro");
 /*
   hovInd
   This test reports confusing hover indication.
+  Compiled to hovInd.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const {doTest} = require('../procs/testaro');
-
 // FUNCTIONS
-
 // Runs the test and returns the result.
-exports.reporter = async (page, report, _, withItems) => {
-  const getBadWhat = element => {
-    const violationTypes = [];
-    const isVisible = element.checkVisibility({
-      contentVisibilityAuto: true,
-      opacityProperty: true,
-      visibilityProperty: true
-    });
-    // If the element is visible:
-    if (isVisible) {
-      // Get its live style declaration.
-      const styleDec = window.getComputedStyle(element);
-      // FUNCTION DEFINITIONS START
-      // Returns hover-related style data on a trigger.
-      const getStyleData = () => {
-        const {
-          cursor,
-          borderColor,
-          borderStyle,
-          borderWidth,
-          outlineColor,
-          outlineStyle,
-          outlineWidth,
-          outlineOffset,
-          color,
-          backgroundColor
-        } = styleDec;
-        return {
-          tagName: element.tagName,
-          inputType: element.tagName === 'INPUT' ? element.getAttribute('type') || 'text' : null,
-          cursor: cursor.replace(/^.+, */, ''),
-          border: `${borderColor} ${borderStyle} ${borderWidth}`,
-          outline: `${outlineColor} ${outlineStyle} ${outlineWidth} ${outlineOffset}`,
-          color,
-          backgroundColor
-        };
-      };
-      // Returns whether the cursor is bad when the element is hovered over.
-      const cursorIsBad = hoverCursor => {
-        const {tagName, type} = element;
-        if (tagName === 'A' || tagName === 'INPUT' && type === 'image') {
-          return hoverCursor !== 'pointer';
+const reporter = async (page, report, _, withItems) => {
+    // The candidate selector yields rendered HTML elements.
+    const getBadWhat = (element) => {
+        const violationTypes = [];
+        const isVisible = element.checkVisibility({
+            contentVisibilityAuto: true,
+            opacityProperty: true,
+            visibilityProperty: true
+        });
+        // If the element is visible:
+        if (isVisible) {
+            // Get its live style declaration.
+            const styleDec = window.getComputedStyle(element);
+            // FUNCTION DEFINITIONS START
+            // Returns hover-related style data on a trigger.
+            const getStyleData = () => {
+                const { cursor, borderColor, borderStyle, borderWidth, outlineColor, outlineStyle, outlineWidth, outlineOffset, color, backgroundColor } = styleDec;
+                return {
+                    tagName: element.tagName,
+                    inputType: element.tagName === 'INPUT' ? element.getAttribute('type') || 'text' : null,
+                    cursor: cursor.replace(/^.+, */, ''),
+                    border: `${borderColor} ${borderStyle} ${borderWidth}`,
+                    outline: `${outlineColor} ${outlineStyle} ${outlineWidth} ${outlineOffset}`,
+                    color,
+                    backgroundColor
+                };
+            };
+            // Returns whether the cursor is bad when the element is hovered over.
+            const cursorIsBad = (hoverCursor) => {
+                // Only input elements reach the type read; the cast erases at emit.
+                const { tagName, type } = element;
+                if (tagName === 'A' || tagName === 'INPUT' && type === 'image') {
+                    return hoverCursor !== 'pointer';
+                }
+                if (tagName === 'INPUT') {
+                    if (['button', 'radio', 'reset', 'submit'].some(typeName => type === typeName)) {
+                        return hoverCursor !== 'default';
+                    }
+                    return hoverCursor !== 'text';
+                }
+                return !['auto', 'default'].includes(hoverCursor);
+            };
+            // Returns whether two hover styles are effectively identical.
+            const areAlike = (styles0, styles1) => {
+                // Return whether they are effectively identical.
+                const areAlike = ['cursor', 'backgroundColor', 'border', 'color', 'outline']
+                    .every(style => styles1[style] === styles0[style]);
+                return areAlike;
+            };
+            // FUNCTION DEFINITIONS END
+            // Get its style data when neither focused nor hovered over.
+            const defaultStyleData = getStyleData();
+            // Correct the cursor value.
+            defaultStyleData.cursor = 'default';
+            // Get its style data when only focused.
+            element.focus();
+            const focusStyleData = getStyleData();
+            // Correct the cursor value.
+            focusStyleData.cursor = 'default';
+            // Get its style data when only hovered over.
+            element.blur();
+            element.dispatchEvent(new MouseEvent('mouseenter'));
+            const hoverStyleData = getStyleData();
+            const data = {};
+            // If the cursor is confusing when the element is only hovered over:
+            if (cursorIsBad(hoverStyleData.cursor)) {
+                // Add this to the violation types.
+                violationTypes.push(`nonstandard mouse cursor (${hoverStyleData.cursor}) when hovered over`);
+            }
+            // If the neutral and hover styles are indistinguishable:
+            if (areAlike(defaultStyleData, hoverStyleData)) {
+                // Add this to the violation types.
+                violationTypes.push('normal and hover styles are indistinguishable');
+                // Add the details to the data.
+                data.n_h = {
+                    neutral: defaultStyleData,
+                    hover: hoverStyleData
+                };
+            }
+            // If the focus and hoverstyles are indistinguishable:
+            if (areAlike(focusStyleData, hoverStyleData)) {
+                // Add this to the violation types.
+                violationTypes.push('focus and hover styles are indistinguishable');
+                // Add the details to the data.
+                data.f_h = {
+                    focus: focusStyleData,
+                    hover: hoverStyleData
+                };
+            }
+            // If any violations occurred:
+            if (violationTypes.length) {
+                const description = `Element styles do not clearly indicate hovering: ${violationTypes.join('; ')}`;
+                // If there are additional data:
+                if (Object.keys(data).length) {
+                    // Return the violation description and data.
+                    return {
+                        description,
+                        data
+                    };
+                }
+                // Otherwise, i.e. if there are no additional data:
+                else {
+                    // Return the violation description.
+                    return description;
+                }
+            }
         }
-        if (tagName === 'INPUT') {
-          if (['button', 'radio', 'reset', 'submit'].some(typeName => type === typeName)) {
-            return hoverCursor !== 'default';
-          }
-          return hoverCursor !== 'text';
-        }
-        return ! ['auto', 'default'].includes(hoverCursor);
-      };
-      // Returns whether two hover styles are effectively identical.
-      const areAlike = (styles0, styles1) => {
-        // Return whether they are effectively identical.
-        const areAlike = ['cursor', 'backgroundColor', 'border', 'color', 'outline']
-        .every(style => styles1[style] === styles0[style]);
-        return areAlike;
-      };
-      // FUNCTION DEFINITIONS END
-      // Get its style data when neither focused nor hovered over.
-      const defaultStyleData = getStyleData();
-      // Correct the cursor value.
-      defaultStyleData.cursor = 'default';
-      // Get its style data when only focused.
-      element.focus();
-      const focusStyleData = getStyleData();
-      // Correct the cursor value.
-      focusStyleData.cursor = 'default';
-      // Get its style data when only hovered over.
-      element.blur();
-      element.dispatchEvent(new MouseEvent('mouseenter'));
-      const hoverStyleData = getStyleData();
-      const data = {};
-      // If the cursor is confusing when the element is only hovered over:
-      if (cursorIsBad(hoverStyleData.cursor)) {
-        // Add this to the violation types.
-        violationTypes.push(
-          `nonstandard mouse cursor (${hoverStyleData.cursor}) when hovered over`
-        );
-      }
-      // If the neutral and hover styles are indistinguishable:
-      if (areAlike(defaultStyleData, hoverStyleData)) {
-        // Add this to the violation types.
-        violationTypes.push('normal and hover styles are indistinguishable');
-        // Add the details to the data.
-        data.n_h = {
-          neutral: defaultStyleData,
-          hover: hoverStyleData
-        };
-      }
-      // If the focus and hoverstyles are indistinguishable:
-      if (areAlike(focusStyleData, hoverStyleData)) {
-        // Add this to the violation types.
-        violationTypes.push('focus and hover styles are indistinguishable');
-        // Add the details to the data.
-        data.f_h = {
-          focus: focusStyleData,
-          hover: hoverStyleData
-        };
-      }
-      // If any violations occurred:
-      if (violationTypes.length) {
-        const description = `Element styles do not clearly indicate hovering: ${violationTypes.join('; ')}`;
-        // If there are additional data:
-        if (Object.keys(data).length) {
-          // Return the violation description and data.
-          return {
-            description,
-            data
-          };
-        }
-        // Otherwise, i.e. if there are no additional data:
-        else {
-          // Return the violation description.
-          return description;
-        }
-      }
-    }
-  };
-  const selector = 'body a, body button, body input, body [onmouseenter], body [onmouseover]';
-  const whats = 'elements have confusing hover indicators';
-  return await doTest(page, report, withItems, 'hovInd', selector, whats, 1, getBadWhat.toString());
+    };
+    const selector = 'body a, body button, body input, body [onmouseenter], body [onmouseover]';
+    const whats = 'elements have confusing hover indicators';
+    return await (0, testaro_1.doTest)(page, report, withItems, 'hovInd', selector, whats, 1, getBadWhat.toString());
 };
+exports.reporter = reporter;

--- a/testaro/hovInd.ts
+++ b/testaro/hovInd.ts
@@ -1,0 +1,150 @@
+/*
+  © 2023–2025 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {doTest} from '../procs/testaro';
+import type {BadWhat, Report} from '../types';
+
+/*
+  hovInd
+  This test reports confusing hover indication.
+  Compiled to hovInd.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Runs the test and returns the result.
+export const reporter = async (page: Page, report: Report, _: unknown, withItems: boolean) => {
+  // The candidate selector yields rendered HTML elements.
+  const getBadWhat = (element: HTMLElement): BadWhat => {
+    const violationTypes = [];
+    const isVisible = element.checkVisibility({
+      contentVisibilityAuto: true,
+      opacityProperty: true,
+      visibilityProperty: true
+    });
+    // If the element is visible:
+    if (isVisible) {
+      // Get its live style declaration.
+      const styleDec = window.getComputedStyle(element);
+      // FUNCTION DEFINITIONS START
+      // Returns hover-related style data on a trigger.
+      const getStyleData = () => {
+        const {
+          cursor,
+          borderColor,
+          borderStyle,
+          borderWidth,
+          outlineColor,
+          outlineStyle,
+          outlineWidth,
+          outlineOffset,
+          color,
+          backgroundColor
+        } = styleDec;
+        return {
+          tagName: element.tagName,
+          inputType: element.tagName === 'INPUT' ? element.getAttribute('type') || 'text' : null,
+          cursor: cursor.replace(/^.+, */, ''),
+          border: `${borderColor} ${borderStyle} ${borderWidth}`,
+          outline: `${outlineColor} ${outlineStyle} ${outlineWidth} ${outlineOffset}`,
+          color,
+          backgroundColor
+        };
+      };
+      // Returns whether the cursor is bad when the element is hovered over.
+      const cursorIsBad = (hoverCursor: string) => {
+        // Only input elements reach the type read; the cast erases at emit.
+        const {tagName, type} = element as HTMLInputElement;
+        if (tagName === 'A' || tagName === 'INPUT' && type === 'image') {
+          return hoverCursor !== 'pointer';
+        }
+        if (tagName === 'INPUT') {
+          if (['button', 'radio', 'reset', 'submit'].some(typeName => type === typeName)) {
+            return hoverCursor !== 'default';
+          }
+          return hoverCursor !== 'text';
+        }
+        return ! ['auto', 'default'].includes(hoverCursor);
+      };
+      // Returns whether two hover styles are effectively identical.
+      const areAlike = (styles0: Record<string, unknown>, styles1: Record<string, unknown>) => {
+        // Return whether they are effectively identical.
+        const areAlike = ['cursor', 'backgroundColor', 'border', 'color', 'outline']
+        .every(style => styles1[style] === styles0[style]);
+        return areAlike;
+      };
+      // FUNCTION DEFINITIONS END
+      // Get its style data when neither focused nor hovered over.
+      const defaultStyleData = getStyleData();
+      // Correct the cursor value.
+      defaultStyleData.cursor = 'default';
+      // Get its style data when only focused.
+      element.focus();
+      const focusStyleData = getStyleData();
+      // Correct the cursor value.
+      focusStyleData.cursor = 'default';
+      // Get its style data when only hovered over.
+      element.blur();
+      element.dispatchEvent(new MouseEvent('mouseenter'));
+      const hoverStyleData = getStyleData();
+      const data: Record<string, unknown> = {};
+      // If the cursor is confusing when the element is only hovered over:
+      if (cursorIsBad(hoverStyleData.cursor)) {
+        // Add this to the violation types.
+        violationTypes.push(
+          `nonstandard mouse cursor (${hoverStyleData.cursor}) when hovered over`
+        );
+      }
+      // If the neutral and hover styles are indistinguishable:
+      if (areAlike(defaultStyleData, hoverStyleData)) {
+        // Add this to the violation types.
+        violationTypes.push('normal and hover styles are indistinguishable');
+        // Add the details to the data.
+        data.n_h = {
+          neutral: defaultStyleData,
+          hover: hoverStyleData
+        };
+      }
+      // If the focus and hoverstyles are indistinguishable:
+      if (areAlike(focusStyleData, hoverStyleData)) {
+        // Add this to the violation types.
+        violationTypes.push('focus and hover styles are indistinguishable');
+        // Add the details to the data.
+        data.f_h = {
+          focus: focusStyleData,
+          hover: hoverStyleData
+        };
+      }
+      // If any violations occurred:
+      if (violationTypes.length) {
+        const description = `Element styles do not clearly indicate hovering: ${violationTypes.join('; ')}`;
+        // If there are additional data:
+        if (Object.keys(data).length) {
+          // Return the violation description and data.
+          return {
+            description,
+            data
+          };
+        }
+        // Otherwise, i.e. if there are no additional data:
+        else {
+          // Return the violation description.
+          return description;
+        }
+      }
+    }
+  };
+  const selector = 'body a, body button, body input, body [onmouseenter], body [onmouseover]';
+  const whats = 'elements have confusing hover indicators';
+  return await doTest(page, report, withItems, 'hovInd', selector, whats, 1, getBadWhat.toString());
+};

--- a/testaro/imageLink.d.ts
+++ b/testaro/imageLink.d.ts
@@ -1,0 +1,3 @@
+import type { Page } from 'playwright';
+import type { Report } from '../types';
+export declare const reporter: (page: Page, report: Report, _: unknown, withItems: boolean) => Promise<import("../procs/testaro").RuleResult>;

--- a/testaro/imageLink.js
+++ b/testaro/imageLink.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2025 CVS Health and/or one of its affiliates. All rights reserved.
   © 2025 Juan S. Casado.
@@ -9,31 +10,27 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const testaro_1 = require("../procs/testaro");
 /*
   imageLink
   Clean-room rule.
   This test reports links whose destinations are image files.
+  Compiled to imageLink.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const {doTest} = require('../procs/testaro');
-
 // FUNCTIONS
-
 // Runs the test and returns the result.
-exports.reporter = async (page, report, _, withItems) => {
-  const getBadWhat = element => {
-    const href = element.getAttribute('href') || '';
-    // If the destination of the element is an image file:
-    if (/\.(?:png|jpe?g|gif|svg|webp|ico)(?:$|[?#])/i.test(href)) {
-      // Return a violation description.
-      return 'Link destination is an image file';
-    }
-  };
-  const whats = 'Links have image files as their destinations';
-  return await doTest(
-    page, report, withItems, 'imageLink', 'body  a[href]', whats, 0, getBadWhat.toString()
-  );
+const reporter = async (page, report, _, withItems) => {
+    const getBadWhat = element => {
+        const href = element.getAttribute('href') || '';
+        // If the destination of the element is an image file:
+        if (/\.(?:png|jpe?g|gif|svg|webp|ico)(?:$|[?#])/i.test(href)) {
+            // Return a violation description.
+            return 'Link destination is an image file';
+        }
+    };
+    const whats = 'Links have image files as their destinations';
+    return await (0, testaro_1.doTest)(page, report, withItems, 'imageLink', 'body  a[href]', whats, 0, getBadWhat.toString());
 };
+exports.reporter = reporter;

--- a/testaro/imageLink.ts
+++ b/testaro/imageLink.ts
@@ -1,0 +1,42 @@
+/*
+  © 2025 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2025 Juan S. Casado.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {doTest} from '../procs/testaro';
+import type {GetBadWhat, Report} from '../types';
+
+/*
+  imageLink
+  Clean-room rule.
+  This test reports links whose destinations are image files.
+  Compiled to imageLink.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Runs the test and returns the result.
+export const reporter = async (page: Page, report: Report, _: unknown, withItems: boolean) => {
+  const getBadWhat: GetBadWhat = element => {
+    const href = element.getAttribute('href') || '';
+    // If the destination of the element is an image file:
+    if (/\.(?:png|jpe?g|gif|svg|webp|ico)(?:$|[?#])/i.test(href)) {
+      // Return a violation description.
+      return 'Link destination is an image file';
+    }
+  };
+  const whats = 'Links have image files as their destinations';
+  return await doTest(
+    page, report, withItems, 'imageLink', 'body  a[href]', whats, 0, getBadWhat.toString()
+  );
+};

--- a/testaro/labClash.d.ts
+++ b/testaro/labClash.d.ts
@@ -1,0 +1,3 @@
+import type { Page } from 'playwright';
+import type { Report } from '../types';
+export declare const reporter: (page: Page, report: Report, _: unknown, withItems: boolean) => Promise<import("../procs/testaro").RuleResult>;

--- a/testaro/labClash.js
+++ b/testaro/labClash.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2021–2023 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -8,43 +9,40 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const testaro_1 = require("../procs/testaro");
 /*
   labClash
   This test reports redundant labeling of buttons, non-hidden inputs, select lists, and text areas. Redundant labels are labels that are superseded by other labels. Explicit and implicit (wrapped) labels are additive, not conflicting.
+  Compiled to labClash.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const {doTest} = require('../procs/testaro');
-
 // FUNCTIONS
-
 // Runs the test and returns the result.
-exports.reporter = async (page, report, _, withItems) => {
-  const getBadWhat = element => {
-    // Get the label types of the element.
-    const labelTypes = [];
-    // Attribute and reference labels.
-    ['aria-label', 'aria-labelledby'].forEach(type => {
-      if (element.hasAttribute(type)) {
-        labelTypes.push(type);
-      }
-    });
-    // Explicit and implicit labels.
-    const labels = Array.from(element.labels);
-    if (labels.length) {
-      labelTypes.push('label');
-    }
-    // If it has more than 1 label type:
-    if (labelTypes.length > 1) {
-      // Return a violation description.
-      return `Element has inconsistent label types (${labelTypes.join(', ')})`;
-    }
-  };
-  const selector = 'body button, body input:not([type=hidden]), body select, body textarea';
-  const whats = 'Elements have inconsistent label types';
-  return await doTest(
-    page, report, withItems, 'labClash', selector, whats, 2, getBadWhat.toString()
-  );
+const reporter = async (page, report, _, withItems) => {
+    // The candidate selector guarantees labelable form controls.
+    const getBadWhat = (element) => {
+        // Get the label types of the element.
+        const labelTypes = [];
+        // Attribute and reference labels.
+        ['aria-label', 'aria-labelledby'].forEach(type => {
+            if (element.hasAttribute(type)) {
+                labelTypes.push(type);
+            }
+        });
+        // Explicit and implicit labels.
+        const labels = Array.from(element.labels);
+        if (labels.length) {
+            labelTypes.push('label');
+        }
+        // If it has more than 1 label type:
+        if (labelTypes.length > 1) {
+            // Return a violation description.
+            return `Element has inconsistent label types (${labelTypes.join(', ')})`;
+        }
+    };
+    const selector = 'body button, body input:not([type=hidden]), body select, body textarea';
+    const whats = 'Elements have inconsistent label types';
+    return await (0, testaro_1.doTest)(page, report, withItems, 'labClash', selector, whats, 2, getBadWhat.toString());
 };
+exports.reporter = reporter;

--- a/testaro/labClash.ts
+++ b/testaro/labClash.ts
@@ -1,0 +1,54 @@
+/*
+  © 2021–2023 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {doTest} from '../procs/testaro';
+import type {BadWhat, Report} from '../types';
+
+/*
+  labClash
+  This test reports redundant labeling of buttons, non-hidden inputs, select lists, and text areas. Redundant labels are labels that are superseded by other labels. Explicit and implicit (wrapped) labels are additive, not conflicting.
+  Compiled to labClash.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Runs the test and returns the result.
+export const reporter = async (page: Page, report: Report, _: unknown, withItems: boolean) => {
+  // The candidate selector guarantees labelable form controls.
+  const getBadWhat = (element: HTMLInputElement): BadWhat => {
+    // Get the label types of the element.
+    const labelTypes = [];
+    // Attribute and reference labels.
+    ['aria-label', 'aria-labelledby'].forEach(type => {
+      if (element.hasAttribute(type)) {
+        labelTypes.push(type);
+      }
+    });
+    // Explicit and implicit labels.
+    const labels = Array.from(element.labels!);
+    if (labels.length) {
+      labelTypes.push('label');
+    }
+    // If it has more than 1 label type:
+    if (labelTypes.length > 1) {
+      // Return a violation description.
+      return `Element has inconsistent label types (${labelTypes.join(', ')})`;
+    }
+  };
+  const selector = 'body button, body input:not([type=hidden]), body select, body textarea';
+  const whats = 'Elements have inconsistent label types';
+  return await doTest(
+    page, report, withItems, 'labClash', selector, whats, 2, getBadWhat.toString()
+  );
+};


### PR DESCRIPTION
Phase 2, batch 2 of the migration on #73: 12 more `doTest`-shape rule modules, same contract as batch 1 (#103) — strict TypeScript, committed in-place emit, no behavior change.

## Converted

`adbID`, `allCapStyle`, `attVal`, `captionLoc`, `embAc`, `focAndOp`, `focInd`, `focVis`, `headingAmb`, `hovInd`, `imageLink`, `labClash`.

Pattern notes beyond batch 1:

- Rules whose predicates use focus/blur/tabIndex/labels type the predicate parameter as the narrower element their candidate selector yields (`HTMLElement` for `focAndOp`/`focInd`/`focVis`/`hovInd`, `HTMLInputElement` for `labClash`) with an explicit `BadWhat` return.
- `attVal`'s parameterized reporter gains types for its extra arguments (`attributeName: string, areLicit: boolean, values: string[]`).
- `hovInd`'s in-predicate helper functions (`getStyleData`, `cursorIsBad`, `areAlike`) get parameter types; they live inside the predicate body, so the serialized function remains self-contained.
- Pre-existing unguarded dereferences are documented with erasure-only `!` assertions (`adbID`'s `getAttribute('aria-describedby')!` under the `[aria-describedby]` selector, `embAc`'s `parentElement!`/`closest()!` under its embedding selector), leaving the emitted predicates textually unchanged.

## Verification

- `tsc` green; committed emit matches (CI drift gate); `node --check` sweep green.
- Emitted-vs-original token diffs reviewed for all 12: only type erasure, module plumbing, and line reflow (including `element =>` → `(element) =>`, inert for the `toString()`/`eval` predicate transport).
- End-to-end validators for `labClash` and `hovInd` (the most heavily annotated rule) on this branch vs current `main`: byte-identical output on both (timestamps and per-run timing strings normalized), including identical pre-existing expectation-failure sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
