### PR TITLE
TypeScript Phase 2 batch 6: focAll and styleDiff (#73)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -79,3 +79,7 @@ testaro/elements.js linguist-generated=true
 testaro/elements.d.ts linguist-generated=true
 testaro/allCaps.js linguist-generated=true
 testaro/allCaps.d.ts linguist-generated=true
+testaro/focAll.js linguist-generated=true
+testaro/focAll.d.ts linguist-generated=true
+testaro/styleDiff.js linguist-generated=true
+testaro/styleDiff.d.ts linguist-generated=true

--- a/testaro/focAll.d.ts
+++ b/testaro/focAll.d.ts
@@ -1,0 +1,13 @@
+import type { Page } from 'playwright';
+import type { Report, StandardInstance } from '../types';
+export declare const reporter: (page: Page, report: Report, _: unknown, withItems: boolean) => Promise<{
+    data: {
+        focusableCount: number;
+        tabFocused: number;
+        discrepancy: number;
+        unreachedCount: number;
+        unexpectedCount: number;
+    };
+    totals: number[];
+    standardInstances: StandardInstance[];
+}>;

--- a/testaro/focAll.js
+++ b/testaro/focAll.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2021–2023 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -7,206 +8,199 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const xPath_1 = require("../procs/xPath");
 /*
   focAll
   This test reports discrepancies between the visible focusable elements of a page and the elements actually reached with the Tab (or, in webkit, Option-Tab) key. The test first identifies and marks all the visible focusable elements, i.e. those with a nonnegative tabIndex, except elements that browsers exclude from Tab navigation (disabled elements, inert elements, and a and area elements without href attributes). Radio buttons are grouped as browsers group them: radio buttons sharing a name and a form owner belong to one group, and the group is reachable with one Tab keypress, but each radio button without a name is independently reachable. Then the test repeatedly presses the Tab (or Option-Tab) key until it has reached all the elements it can, marking each reached element. Finally, the test reports each focusable element that was never reached (for example, because keypresses cause surprising changes in content or focus) and each reached element that was not a visible focusable element when the page was loaded (for example, because it was revealed only during navigation or was invisible although Tab-focusable). Any such element can make navigation with the Tab key difficult or impossible.
+  Compiled to focAll.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const {getXPathCatalogIndex} = require('../procs/xPath');
-
 // FUNCTIONS
-
 // Runs the test and returns the result.
-exports.reporter = async (page, report, _, withItems) => {
-  // Get locators of visible elements.
-  const locAll = await page.locator('body *:visible');
-  // Mark the focusable elements and get the count of Tab stops among them.
-  const focusableCount = await locAll.evaluateAll(elements => {
-    // Get the focusable elements, i.e. those that can be reached with the Tab key.
-    const focusables = elements.filter(element => {
-      // If the element has a negative tabIndex, it is not focusable.
-      if (element.tabIndex < 0) {
-        return false;
-      }
-      // If the element or an ancestor is disabled or inert, it is not focusable.
-      if (element.matches(':disabled') || element.closest('[inert]')) {
-        return false;
-      }
-      // If the element is an a or area element without an href attribute, it is not focusable.
-      if (['A', 'AREA'].includes(element.tagName) && ! element.hasAttribute('href')) {
-        return false;
-      }
-      return true;
+const reporter = async (page, report, _, withItems) => {
+    // Get locators of visible elements.
+    const locAll = await page.locator('body *:visible');
+    // Mark the focusable elements and get the count of Tab stops among them.
+    const focusableCount = await locAll.evaluateAll(elements => {
+        // Get the focusable elements, i.e. those that can be reached with the Tab key.
+        const focusables = elements.filter(element => {
+            // If the element has a negative tabIndex, it is not focusable.
+            if (element.tabIndex < 0) {
+                return false;
+            }
+            // If the element or an ancestor is disabled or inert, it is not focusable.
+            if (element.matches(':disabled') || element.closest('[inert]')) {
+                return false;
+            }
+            // If the element is an a or area element without an href attribute, it is not focusable.
+            if (['A', 'AREA'].includes(element.tagName) && !element.hasAttribute('href')) {
+                return false;
+            }
+            return true;
+        });
+        // Mark them.
+        focusables.forEach(element => {
+            element.dataset.testarofocusable = 'true';
+        });
+        // Get the radio buttons among them that browsers group, i.e. those with names.
+        const namedRadios = focusables.filter((element) => element.tagName === 'INPUT' && element.type === 'radio'
+            && !!element.name);
+        // Get the identifiers (form owner and name) of their groups.
+        const groupIDs = new Set(namedRadios.map(radio => {
+            const formIndex = radio.form ? Array.prototype.indexOf.call(document.forms, radio.form) : -1;
+            return `${formIndex}:${radio.name}`;
+        }));
+        // Return the count of Tab stops, counting each radio-button group as only 1.
+        return focusables.length - namedRadios.length + groupIDs.size;
     });
-    // Mark them.
-    focusables.forEach(element => {
-      element.dataset.testarofocusable = 'true';
-    });
-    // Get the radio buttons among them that browsers group, i.e. those with names.
-    const namedRadios = focusables.filter(
-      element => element.tagName === 'INPUT' && element.type === 'radio' && element.name
-    );
-    // Get the identifiers (form owner and name) of their groups.
-    const groupIDs = new Set(namedRadios.map(radio => {
-      const formIndex = radio.form ? Array.prototype.indexOf.call(document.forms, radio.form) : -1;
-      return `${formIndex}:${radio.name}`;
-    }));
-    // Return the count of Tab stops, counting each radio-button group as only 1.
-    return focusables.length - namedRadios.length + groupIDs.size;
-  });
-  /*
-    Repeatedly perform a Tab or (in webkit) Opt-Tab keypress and count the focused elements.
-    Asumptions:
-      0. No page has more than 2000 focusable elements.
-      1. No shadow root that reports itself as the active element has more than 100 focusable
-        descendants.
-  */
-  let tabFocused = 0;
-  let refocused = 0;
-  const keyName = page.context().browser()?.browserType().name() === 'webkit' ? 'Alt+Tab' : 'Tab';
-  while (refocused < 100 && tabFocused < 2000) {
-    await page.keyboard.press(keyName);
-    const isNewFocus = await page.evaluate(() => {
-      let focus = document.activeElement;
-      // If the focus is in a shadow DOM, get the innermost focused element.
-      while (focus && focus.shadowRoot && focus.shadowRoot.activeElement) {
-        focus = focus.shadowRoot.activeElement;
-      }
-      if (focus === null || focus.tagName === 'BODY' || focus.dataset.testarofocused) {
-        return false;
-      }
-      else {
-        focus.dataset.testarofocused = 'true';
-        return true;
-      }
-    });
-    if (isNewFocus) {
-      tabFocused++;
+    /*
+      Repeatedly perform a Tab or (in webkit) Opt-Tab keypress and count the focused elements.
+      Asumptions:
+        0. No page has more than 2000 focusable elements.
+        1. No shadow root that reports itself as the active element has more than 100 focusable
+          descendants.
+    */
+    let tabFocused = 0;
+    let refocused = 0;
+    const keyName = page.context().browser()?.browserType().name() === 'webkit' ? 'Alt+Tab' : 'Tab';
+    while (refocused < 100 && tabFocused < 2000) {
+        await page.keyboard.press(keyName);
+        const isNewFocus = await page.evaluate(() => {
+            let focus = document.activeElement;
+            // If the focus is in a shadow DOM, get the innermost focused element.
+            while (focus && focus.shadowRoot && focus.shadowRoot.activeElement) {
+                focus = focus.shadowRoot.activeElement;
+            }
+            if (focus === null || focus.tagName === 'BODY' || focus.dataset.testarofocused) {
+                return false;
+            }
+            else {
+                focus.dataset.testarofocused = 'true';
+                return true;
+            }
+        });
+        if (isNewFocus) {
+            tabFocused++;
+        }
+        else {
+            refocused++;
+        }
     }
-    else {
-      refocused++;
+    // Get the XPaths of the elements violating the rule, in both directions.
+    const { unreached, unexpected } = await page.evaluate(() => {
+        // Get all elements, including any in open shadow roots.
+        const allElements = [];
+        const addElements = (root) => {
+            root.querySelectorAll('*').forEach(element => {
+                allElements.push(element);
+                if (element.shadowRoot) {
+                    addElements(element.shadowRoot);
+                }
+            });
+        };
+        addElements(document);
+        // Returns the identifier of the group of a radio button.
+        const getGroupID = (radio) => {
+            const formIndex = radio.form ? Array.prototype.indexOf.call(document.forms, radio.form) : -1;
+            return `${formIndex}:${radio.name}`;
+        };
+        // Get the identifiers of the radio-button groups with any reached member.
+        const reachedGroupIDs = new Set(allElements
+            .filter((element) => !!element.dataset.testarofocused
+            && element.tagName === 'INPUT'
+            && element.type === 'radio'
+            && !!element.name)
+            .map(getGroupID));
+        // Initialize the violation data.
+        const unreached = [];
+        const unexpected = [];
+        // For each element:
+        allElements.forEach(element => {
+            const wasFocusable = !!element.dataset.testarofocusable;
+            const wasFocused = !!element.dataset.testarofocused;
+            // If it was focusable but was never reached:
+            if (wasFocusable && !wasFocused) {
+                const isGroupedRadio = element.tagName === 'INPUT'
+                    && element.type === 'radio'
+                    && element.name;
+                // If it is not a member of a radio-button group with another reached member:
+                if (!(isGroupedRadio && reachedGroupIDs.has(getGroupID(element)))) {
+                    // Add its XPath to the violation data.
+                    unreached.push(window.getXPath(element) ?? '/html');
+                }
+            }
+            // Otherwise, if it was reached but was not a visible focusable element:
+            else if (wasFocused && !wasFocusable) {
+                // Get whether it is a scrollable container, which some browsers make Tab-focusable.
+                const styleDec = window.getComputedStyle(element);
+                const isScroller = ['auto', 'scroll'].includes(styleDec.overflowY)
+                    && element.scrollHeight > element.clientHeight
+                    || ['auto', 'scroll'].includes(styleDec.overflowX)
+                        && element.scrollWidth > element.clientWidth;
+                // If it is not a scrollable container made focusable by the browser alone:
+                if (!(isScroller && element.tabIndex < 0)) {
+                    // Add its XPath to the violation data.
+                    unexpected.push(window.getXPath(element) ?? '/html');
+                }
+            }
+            // Remove the marker attributes from the element.
+            delete element.dataset.testarofocusable;
+            delete element.dataset.testarofocused;
+        });
+        return { unreached, unexpected };
+    });
+    const count = unreached.length + unexpected.length;
+    const data = {
+        focusableCount,
+        tabFocused,
+        discrepancy: tabFocused - focusableCount,
+        unreachedCount: unreached.length,
+        unexpectedCount: unexpected.length
+    };
+    // Initialize the standard instances.
+    const standardInstances = [];
+    // If itemization is required:
+    if (withItems) {
+        // For each element that was focusable but was never reached:
+        unreached.forEach(xPath => {
+            // Add an instance to the standard instances.
+            standardInstances.push({
+                ruleID: 'focAll',
+                what: 'Element is focusable but was not reached by Tab navigation',
+                ordinalSeverity: 2,
+                count: 1,
+                catalogIndex: (0, xPath_1.getXPathCatalogIndex)(report, xPath)
+            });
+        });
+        // For each element that was reached but was not a visible focusable element:
+        unexpected.forEach(xPath => {
+            // Add an instance to the standard instances.
+            standardInstances.push({
+                ruleID: 'focAll',
+                what: 'Element was reached by Tab navigation but was not a visible focusable element',
+                ordinalSeverity: 2,
+                count: 1,
+                catalogIndex: (0, xPath_1.getXPathCatalogIndex)(report, xPath)
+            });
+        });
     }
-  }
-  // Get the XPaths of the elements violating the rule, in both directions.
-  const {unreached, unexpected} = await page.evaluate(() => {
-    // Get all elements, including any in open shadow roots.
-    const allElements = [];
-    const addElements = root => {
-      root.querySelectorAll('*').forEach(element => {
-        allElements.push(element);
-        if (element.shadowRoot) {
-          addElements(element.shadowRoot);
-        }
-      });
+    // Otherwise, if there were any violations:
+    else if (count) {
+        // Add a summary instance to the standard instances.
+        standardInstances.push({
+            ruleID: 'focAll',
+            what: 'Some focusable elements are not Tab-focusable or vice versa',
+            ordinalSeverity: 2,
+            count,
+            catalogIndex: (0, xPath_1.getXPathCatalogIndex)(report, '/html/body')
+        });
+    }
+    // Return the result.
+    return {
+        data,
+        totals: [0, 0, count, 0],
+        standardInstances
     };
-    addElements(document);
-    // Returns the identifier of the group of a radio button.
-    const getGroupID = radio => {
-      const formIndex = radio.form ? Array.prototype.indexOf.call(document.forms, radio.form) : -1;
-      return `${formIndex}:${radio.name}`;
-    };
-    // Get the identifiers of the radio-button groups with any reached member.
-    const reachedGroupIDs = new Set(
-      allElements
-      .filter(
-        element => element.dataset.testarofocused
-        && element.tagName === 'INPUT'
-        && element.type === 'radio'
-        && element.name
-      )
-      .map(getGroupID)
-    );
-    // Initialize the violation data.
-    const unreached = [];
-    const unexpected = [];
-    // For each element:
-    allElements.forEach(element => {
-      const wasFocusable = !! element.dataset.testarofocusable;
-      const wasFocused = !! element.dataset.testarofocused;
-      // If it was focusable but was never reached:
-      if (wasFocusable && ! wasFocused) {
-        const isGroupedRadio = element.tagName === 'INPUT'
-        && element.type === 'radio'
-        && element.name;
-        // If it is not a member of a radio-button group with another reached member:
-        if (! (isGroupedRadio && reachedGroupIDs.has(getGroupID(element)))) {
-          // Add its XPath to the violation data.
-          unreached.push(window.getXPath(element) ?? '/html');
-        }
-      }
-      // Otherwise, if it was reached but was not a visible focusable element:
-      else if (wasFocused && ! wasFocusable) {
-        // Get whether it is a scrollable container, which some browsers make Tab-focusable.
-        const styleDec = window.getComputedStyle(element);
-        const isScroller = ['auto', 'scroll'].includes(styleDec.overflowY)
-        && element.scrollHeight > element.clientHeight
-        || ['auto', 'scroll'].includes(styleDec.overflowX)
-        && element.scrollWidth > element.clientWidth;
-        // If it is not a scrollable container made focusable by the browser alone:
-        if (! (isScroller && element.tabIndex < 0)) {
-          // Add its XPath to the violation data.
-          unexpected.push(window.getXPath(element) ?? '/html');
-        }
-      }
-      // Remove the marker attributes from the element.
-      delete element.dataset.testarofocusable;
-      delete element.dataset.testarofocused;
-    });
-    return {unreached, unexpected};
-  });
-  const count = unreached.length + unexpected.length;
-  const data = {
-    focusableCount,
-    tabFocused,
-    discrepancy: tabFocused - focusableCount,
-    unreachedCount: unreached.length,
-    unexpectedCount: unexpected.length
-  };
-  // Initialize the standard instances.
-  const standardInstances = [];
-  // If itemization is required:
-  if (withItems) {
-    // For each element that was focusable but was never reached:
-    unreached.forEach(xPath => {
-      // Add an instance to the standard instances.
-      standardInstances.push({
-        ruleID: 'focAll',
-        what: 'Element is focusable but was not reached by Tab navigation',
-        ordinalSeverity: 2,
-        count: 1,
-        catalogIndex: getXPathCatalogIndex(report, xPath)
-      });
-    });
-    // For each element that was reached but was not a visible focusable element:
-    unexpected.forEach(xPath => {
-      // Add an instance to the standard instances.
-      standardInstances.push({
-        ruleID: 'focAll',
-        what: 'Element was reached by Tab navigation but was not a visible focusable element',
-        ordinalSeverity: 2,
-        count: 1,
-        catalogIndex: getXPathCatalogIndex(report, xPath)
-      });
-    });
-  }
-  // Otherwise, if there were any violations:
-  else if (count) {
-    // Add a summary instance to the standard instances.
-    standardInstances.push({
-      ruleID: 'focAll',
-      what: 'Some focusable elements are not Tab-focusable or vice versa',
-      ordinalSeverity: 2,
-      count,
-      catalogIndex: getXPathCatalogIndex(report, '/html/body')
-    });
-  }
-  // Return the result.
-  return {
-    data,
-    totals: [0, 0, count, 0],
-    standardInstances
-  };
 };
+exports.reporter = reporter;

--- a/testaro/focAll.ts
+++ b/testaro/focAll.ts
@@ -1,0 +1,217 @@
+/*
+  © 2021–2023 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {getXPathCatalogIndex} from '../procs/xPath';
+import type {Report, StandardInstance} from '../types';
+
+/*
+  focAll
+  This test reports discrepancies between the visible focusable elements of a page and the elements actually reached with the Tab (or, in webkit, Option-Tab) key. The test first identifies and marks all the visible focusable elements, i.e. those with a nonnegative tabIndex, except elements that browsers exclude from Tab navigation (disabled elements, inert elements, and a and area elements without href attributes). Radio buttons are grouped as browsers group them: radio buttons sharing a name and a form owner belong to one group, and the group is reachable with one Tab keypress, but each radio button without a name is independently reachable. Then the test repeatedly presses the Tab (or Option-Tab) key until it has reached all the elements it can, marking each reached element. Finally, the test reports each focusable element that was never reached (for example, because keypresses cause surprising changes in content or focus) and each reached element that was not a visible focusable element when the page was loaded (for example, because it was revealed only during navigation or was invisible although Tab-focusable). Any such element can make navigation with the Tab key difficult or impossible.
+  Compiled to focAll.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Runs the test and returns the result.
+export const reporter = async (page: Page, report: Report, _: unknown, withItems: boolean) => {
+  // Get locators of visible elements.
+  const locAll = await page.locator('body *:visible');
+  // Mark the focusable elements and get the count of Tab stops among them.
+  const focusableCount = await locAll.evaluateAll(elements => {
+    // Get the focusable elements, i.e. those that can be reached with the Tab key.
+    const focusables = elements.filter(element => {
+      // If the element has a negative tabIndex, it is not focusable.
+      if (element.tabIndex < 0) {
+        return false;
+      }
+      // If the element or an ancestor is disabled or inert, it is not focusable.
+      if (element.matches(':disabled') || element.closest('[inert]')) {
+        return false;
+      }
+      // If the element is an a or area element without an href attribute, it is not focusable.
+      if (['A', 'AREA'].includes(element.tagName) && ! element.hasAttribute('href')) {
+        return false;
+      }
+      return true;
+    });
+    // Mark them.
+    focusables.forEach(element => {
+      element.dataset.testarofocusable = 'true';
+    });
+    // Get the radio buttons among them that browsers group, i.e. those with names.
+    const namedRadios = focusables.filter(
+      (element): element is HTMLInputElement =>
+        element.tagName === 'INPUT' && (element as HTMLInputElement).type === 'radio'
+        && !! (element as HTMLInputElement).name
+    );
+    // Get the identifiers (form owner and name) of their groups.
+    const groupIDs = new Set(namedRadios.map(radio => {
+      const formIndex = radio.form ? Array.prototype.indexOf.call(document.forms, radio.form) : -1;
+      return `${formIndex}:${radio.name}`;
+    }));
+    // Return the count of Tab stops, counting each radio-button group as only 1.
+    return focusables.length - namedRadios.length + groupIDs.size;
+  });
+  /*
+    Repeatedly perform a Tab or (in webkit) Opt-Tab keypress and count the focused elements.
+    Asumptions:
+      0. No page has more than 2000 focusable elements.
+      1. No shadow root that reports itself as the active element has more than 100 focusable
+        descendants.
+  */
+  let tabFocused = 0;
+  let refocused = 0;
+  const keyName = page.context().browser()?.browserType().name() === 'webkit' ? 'Alt+Tab' : 'Tab';
+  while (refocused < 100 && tabFocused < 2000) {
+    await page.keyboard.press(keyName);
+    const isNewFocus = await page.evaluate(() => {
+      let focus = document.activeElement;
+      // If the focus is in a shadow DOM, get the innermost focused element.
+      while (focus && focus.shadowRoot && focus.shadowRoot.activeElement) {
+        focus = focus.shadowRoot.activeElement;
+      }
+      if (focus === null || focus.tagName === 'BODY' || (focus as HTMLElement).dataset.testarofocused) {
+        return false;
+      }
+      else {
+        (focus as HTMLElement).dataset.testarofocused = 'true';
+        return true;
+      }
+    });
+    if (isNewFocus) {
+      tabFocused++;
+    }
+    else {
+      refocused++;
+    }
+  }
+  // Get the XPaths of the elements violating the rule, in both directions.
+  const {unreached, unexpected} = await page.evaluate(() => {
+    // Get all elements, including any in open shadow roots.
+    const allElements: HTMLElement[] = [];
+    const addElements = (root: Document | ShadowRoot) => {
+      root.querySelectorAll<HTMLElement>('*').forEach(element => {
+        allElements.push(element);
+        if (element.shadowRoot) {
+          addElements(element.shadowRoot);
+        }
+      });
+    };
+    addElements(document);
+    // Returns the identifier of the group of a radio button.
+    const getGroupID = (radio: HTMLInputElement) => {
+      const formIndex = radio.form ? Array.prototype.indexOf.call(document.forms, radio.form) : -1;
+      return `${formIndex}:${radio.name}`;
+    };
+    // Get the identifiers of the radio-button groups with any reached member.
+    const reachedGroupIDs = new Set(
+      allElements
+      .filter(
+        (element): element is HTMLInputElement => !! element.dataset.testarofocused
+        && element.tagName === 'INPUT'
+        && (element as HTMLInputElement).type === 'radio'
+        && !! (element as HTMLInputElement).name
+      )
+      .map(getGroupID)
+    );
+    // Initialize the violation data.
+    const unreached: string[] = [];
+    const unexpected: string[] = [];
+    // For each element:
+    allElements.forEach(element => {
+      const wasFocusable = !! element.dataset.testarofocusable;
+      const wasFocused = !! element.dataset.testarofocused;
+      // If it was focusable but was never reached:
+      if (wasFocusable && ! wasFocused) {
+        const isGroupedRadio = element.tagName === 'INPUT'
+        && (element as HTMLInputElement).type === 'radio'
+        && (element as HTMLInputElement).name;
+        // If it is not a member of a radio-button group with another reached member:
+        if (! (isGroupedRadio && reachedGroupIDs.has(getGroupID(element as HTMLInputElement)))) {
+          // Add its XPath to the violation data.
+          unreached.push(window.getXPath(element) ?? '/html');
+        }
+      }
+      // Otherwise, if it was reached but was not a visible focusable element:
+      else if (wasFocused && ! wasFocusable) {
+        // Get whether it is a scrollable container, which some browsers make Tab-focusable.
+        const styleDec = window.getComputedStyle(element);
+        const isScroller = ['auto', 'scroll'].includes(styleDec.overflowY)
+        && element.scrollHeight > element.clientHeight
+        || ['auto', 'scroll'].includes(styleDec.overflowX)
+        && element.scrollWidth > element.clientWidth;
+        // If it is not a scrollable container made focusable by the browser alone:
+        if (! (isScroller && element.tabIndex < 0)) {
+          // Add its XPath to the violation data.
+          unexpected.push(window.getXPath(element) ?? '/html');
+        }
+      }
+      // Remove the marker attributes from the element.
+      delete element.dataset.testarofocusable;
+      delete element.dataset.testarofocused;
+    });
+    return {unreached, unexpected};
+  });
+  const count = unreached.length + unexpected.length;
+  const data = {
+    focusableCount,
+    tabFocused,
+    discrepancy: tabFocused - focusableCount,
+    unreachedCount: unreached.length,
+    unexpectedCount: unexpected.length
+  };
+  // Initialize the standard instances.
+  const standardInstances: StandardInstance[] = [];
+  // If itemization is required:
+  if (withItems) {
+    // For each element that was focusable but was never reached:
+    unreached.forEach(xPath => {
+      // Add an instance to the standard instances.
+      standardInstances.push({
+        ruleID: 'focAll',
+        what: 'Element is focusable but was not reached by Tab navigation',
+        ordinalSeverity: 2,
+        count: 1,
+        catalogIndex: getXPathCatalogIndex(report, xPath)
+      });
+    });
+    // For each element that was reached but was not a visible focusable element:
+    unexpected.forEach(xPath => {
+      // Add an instance to the standard instances.
+      standardInstances.push({
+        ruleID: 'focAll',
+        what: 'Element was reached by Tab navigation but was not a visible focusable element',
+        ordinalSeverity: 2,
+        count: 1,
+        catalogIndex: getXPathCatalogIndex(report, xPath)
+      });
+    });
+  }
+  // Otherwise, if there were any violations:
+  else if (count) {
+    // Add a summary instance to the standard instances.
+    standardInstances.push({
+      ruleID: 'focAll',
+      what: 'Some focusable elements are not Tab-focusable or vice versa',
+      ordinalSeverity: 2,
+      count,
+      catalogIndex: getXPathCatalogIndex(report, '/html/body')
+    });
+  }
+  // Return the result.
+  return {
+    data,
+    totals: [0, 0, count, 0],
+    standardInstances
+  };
+};

--- a/testaro/styleDiff.d.ts
+++ b/testaro/styleDiff.d.ts
@@ -1,0 +1,25 @@
+import type { Page } from 'playwright';
+import type { Report } from '../types';
+interface StyleDiffTotals {
+    total: number;
+    subtotals?: number[];
+}
+export declare const reporter: (page: Page, report: Report, _: unknown, withItems: boolean) => Promise<{
+    data: {
+        mainStyles: string[];
+        buttonStyles: string[];
+        headingStyles: string[];
+        listLinkStyles: string[];
+        totals: Record<string, StyleDiffTotals>;
+        items?: Record<string, Record<string, Record<string, string[]>>>;
+    };
+    totals: number[];
+    standardInstances: {
+        ruleID: string;
+        what: string;
+        ordinalSeverity: number;
+        count: number;
+        catalogIndex: string;
+    }[];
+}>;
+export {};

--- a/testaro/styleDiff.js
+++ b/testaro/styleDiff.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2021–2024 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -7,270 +8,268 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const xPath_1 = require("../procs/xPath");
 /*
   styleDiff
   This test reports style differences among links, buttons, and headings. It assumes that an accessible page employs few or only one style for adjacent links, and likewise for list links, buttons, and headings at each level. The test considers only particular style properties, listed in the 'mainStyles' and 'headingStyles' arrays.
+  Compiled to styleDiff.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const {getXPathCatalogIndex} = require('../procs/xPath');
-
 // FUNCTIONS
-
 // Returns an object classifying the links in a page by layout.
-const linksByType = async page => await page.evaluateHandle(() => {
-  // FUNCTION DEFINITIONS START
-  // Removes spacing characters from a text.
-  const despace = text => text.replace(/\s/g, '');
-  // Returns whether a list is a list entirely of links.
-  const isLinkList = list => {
-    const listItems = Array.from(list.children);
-    if (listItems.length > 1) {
-      return listItems.length > 1 && listItems.every(item => {
-        if (item.tagName === 'LI') {
-          const {children} = item;
-          if (children.length === 1) {
-            const link = children[0];
-            if (link.tagName === 'A') {
-              const itemText = despace(item.textContent);
-              const linkText = despace(link.textContent);
-              return itemText.length === linkText.length;
-            }
-            else {
-              return false;
-            }
-          }
-          else {
-            return false;
-          }
+const linksByType = async (page) => await page.evaluateHandle(() => {
+    // FUNCTION DEFINITIONS START
+    // Removes spacing characters from a text.
+    const despace = (text) => text.replace(/\s/g, '');
+    // Returns whether a list is a list entirely of links.
+    const isLinkList = (list) => {
+        const listItems = Array.from(list.children);
+        if (listItems.length > 1) {
+            return listItems.length > 1 && listItems.every(item => {
+                if (item.tagName === 'LI') {
+                    const { children } = item;
+                    if (children.length === 1) {
+                        const link = children[0];
+                        if (link.tagName === 'A') {
+                            const itemText = despace(item.textContent);
+                            const linkText = despace(link.textContent);
+                            return itemText.length === linkText.length;
+                        }
+                        else {
+                            return false;
+                        }
+                    }
+                    else {
+                        return false;
+                    }
+                }
+                else {
+                    return false;
+                }
+            });
         }
         else {
-          return false;
+            return false;
         }
-      });
-    }
-    else {
-      return false;
-    }
-  };
-  // FUNCTION DEFINITIONS END
-  // Identify the lists in the page.
-  const lists = Array.from(document.body.querySelectorAll('ul, ol'));
-  // Initialize an array of list links.
-  const listLinks = [];
-  // For each one:
-  lists.forEach(list => {
-    // If it is a list of links:
-    if (isLinkList(list)) {
-      // Choose one of the links randomly, assuming they have uniform styles.
-      const links = Array.from(list.querySelectorAll('a'));
-      const randomIndex = Math.floor(Math.random() * links.length);
-      const randomLink = links[randomIndex];
-      // Add it to the array.
-      listLinks.push(randomLink);
-    }
-  });
-  // Identify the inline links in the page.
-  const allLinks = Array.from(document.body.querySelectorAll('a'));
-  const inlineLinks = allLinks.filter(link => ! listLinks.includes(link));
-  // Return the data.
-  return {
-    adjacent: inlineLinks,
-    list: listLinks
-  };
+    };
+    // FUNCTION DEFINITIONS END
+    // Identify the lists in the page.
+    const lists = Array.from(document.body.querySelectorAll('ul, ol'));
+    // Initialize an array of list links.
+    const listLinks = [];
+    // For each one:
+    lists.forEach(list => {
+        // If it is a list of links:
+        if (isLinkList(list)) {
+            // Choose one of the links randomly, assuming they have uniform styles.
+            const links = Array.from(list.querySelectorAll('a'));
+            const randomIndex = Math.floor(Math.random() * links.length);
+            const randomLink = links[randomIndex];
+            // Add it to the array.
+            listLinks.push(randomLink);
+        }
+    });
+    // Identify the inline links in the page.
+    const allLinks = Array.from(document.body.querySelectorAll('a'));
+    const inlineLinks = allLinks.filter(link => !listLinks.includes(link));
+    // Return the data.
+    return {
+        adjacent: inlineLinks,
+        list: listLinks
+    };
 });
 // Runs the test and returns the result.
-exports.reporter = async (page, report, _, withItems) => {
-  // Get an object with arrays of list links and adjacent links as properties.
-  const linkTypes = await linksByType(page);
-  const catalogIndex = getXPathCatalogIndex(report, '/html/body');
-  return await page.evaluate(args => {
-    const [linkTypes, withItems, catalogIndex] = args;
-    const {body} = document;
-    // Identify the settable style properties to be compared for all tag names.
-    const mainStyles = [
-      'fontStyle',
-      'fontWeight',
-      'opacity',
-      'textDecorationLine',
-      'textDecorationStyle',
-      'textDecorationThickness'
-    ];
-    // Identify those only for buttons.
-    const buttonStyles = [
-      'borderStyle',
-      'borderWidth',
-      'height',
-      'lineHeight',
-      'maxHeight',
-      'maxWidth',
-      'minHeight',
-      'minWidth',
-      'outlineOffset',
-      'outlineStyle',
-      'outlineWidth'
-    ];
-    // Identify those for headings.
-    const headingStyles = [
-      'color',
-      'fontSize'
-    ];
-    // Identify those for list links.
-    const listLinkStyles = [
-      'color',
-      'fontSize',
-      'lineHeight'
-    ];
-    // Initialize the data to be returned.
-    const data = {
-      mainStyles,
-      buttonStyles,
-      headingStyles,
-      listLinkStyles,
-      totals: {}
-    };
-    if (withItems) {
-      data.items = {};
-    }
-    // Initialize an object of elements to be analyzed, including links.
-    const elements = {
-      buttons: [],
-      headings: {
-        h1: [],
-        h2: [],
-        h3: [],
-        h4: [],
-        h5: [],
-        h6: []
-      },
-      links: {
-        adjacent: linkTypes.adjacent,
-        list: linkTypes.list
-      }
-    };
-    // Identify the heading tag names to be analyzed.
-    const headingNames = Object.keys(elements.headings);
-    // Add the buttons to the object.
-    elements.buttons = Array.from(body.querySelectorAll('button, input[type=button]'));
-    // For each heading tag name:
-    headingNames.forEach(tagName => {
-      // Add its elements to the object.
-      elements.headings[tagName] = Array.from(body.getElementsByTagName(tagName));
-    });
-    // FUNCTION DEFINITION START
-    // Tabulates the distribution of style properties for elements of a type.
-    const tallyStyles = (typeName, elements, typeStyles, withItems) => {
-      // If there are any elements:
-      const elementCount = elements.length;
-      if (elementCount) {
-        const styleProps = {};
-        const styleTexts = {};
-        // For each element:
-        elements.forEach(element => {
-          // Get its values on the style properties to be compared.
-          const styleDec = window.getComputedStyle(element);
-          const style = {};
-          const styles = mainStyles.concat(typeStyles);
-          styles.forEach(styleName => {
-            style[styleName] = styleDec[styleName];
-          });
-          // Get a text representation of the style, limited to those properties.
-          const styleText = JSON.stringify(style);
-          // Increment the total of elements with that style.
-          styleTexts[styleText] = ++styleTexts[styleText] || 1;
-          // If details are to be reported:
-          if (withItems) {
-            // Add the element’s values and text to the style details.
-            if (! styleProps[typeName]) {
-              styleProps[typeName] = {};
-            }
-            const elementText = (element.textContent.trim() || element.outerHTML.trim())
-            .replace(/\s+/g, ' ')
-            .slice(0, 100);
-            // For each style property being compared:
-            styles.forEach(styleName => {
-              if (! styleProps[typeName][styleName]) {
-                styleProps[typeName][styleName] = {};
-              }
-              if (! styleProps[typeName][styleName][style[styleName]]) {
-                styleProps[typeName][styleName][style[styleName]] = [];
-              }
-              // Add the element text to the style details.
-              styleProps[typeName][styleName][style[styleName]].push(elementText);
-            });
-          }
-        });
-        // Add the total to the result.
-        data.totals[typeName] = {total: elementCount};
-        const styleCounts = Object.values(styleTexts);
-        // If the elements of the type differ in style:
-        if (styleCounts.length > 1) {
-          // Add the distribution of its style counts to the result.
-          data.totals[typeName].subtotals = styleCounts.sort((a, b) => b - a);
-          // If details are to be reported:
-          if (withItems) {
-            // Delete the data on uniform style properties.
-            Object.keys(styleProps[typeName]).forEach(styleName => {
-              if (Object.keys(styleProps[typeName][styleName]).length === 1) {
-                delete styleProps[typeName][styleName];
-              }
-            });
-            // Add the element values and texts to the result.
-            data.items[typeName] = styleProps[typeName];
-          }
+const reporter = async (page, report, _, withItems) => {
+    // Get an object with arrays of list links and adjacent links as properties.
+    const linkTypes = await linksByType(page);
+    const catalogIndex = (0, xPath_1.getXPathCatalogIndex)(report, '/html/body');
+    return await page.evaluate(args => {
+        const [linkTypes, withItems, catalogIndex] = args;
+        const { body } = document;
+        // Identify the settable style properties to be compared for all tag names.
+        const mainStyles = [
+            'fontStyle',
+            'fontWeight',
+            'opacity',
+            'textDecorationLine',
+            'textDecorationStyle',
+            'textDecorationThickness'
+        ];
+        // Identify those only for buttons.
+        const buttonStyles = [
+            'borderStyle',
+            'borderWidth',
+            'height',
+            'lineHeight',
+            'maxHeight',
+            'maxWidth',
+            'minHeight',
+            'minWidth',
+            'outlineOffset',
+            'outlineStyle',
+            'outlineWidth'
+        ];
+        // Identify those for headings.
+        const headingStyles = [
+            'color',
+            'fontSize'
+        ];
+        // Identify those for list links.
+        const listLinkStyles = [
+            'color',
+            'fontSize',
+            'lineHeight'
+        ];
+        // Initialize the data to be returned.
+        const data = {
+            mainStyles,
+            buttonStyles,
+            headingStyles,
+            listLinkStyles,
+            totals: {}
+        };
+        if (withItems) {
+            data.items = {};
         }
-      }
-    };
-    // FUNCTION DEFINITION END
-    // Report the style-property distributions for the element types.
-    tallyStyles('button', elements.buttons, buttonStyles, withItems);
-    tallyStyles('adjacentLink', elements.links.adjacent, [], withItems);
-    tallyStyles('listLink', elements.links.list, listLinkStyles, withItems);
-    headingNames.forEach(headingName => {
-      tallyStyles(headingName, elements.headings[headingName], headingStyles, withItems);
-    });
-    // Report the standandardized data.
-    const totals = [0, 0, 0, 0];
-    const standardInstances = [];
-    const elementData = {
-      adjacentLink: [0, 'In-line links', 'A'],
-      listLink: [1, 'Links in columns', 'A'],
-      button: [2, 'Buttons', 'BUTTON'],
-      h1: [3, 'Level-1 headings', 'H1'],
-      h2: [3, 'Level-2 headings', 'H2'],
-      h3: [3, 'Level-3 headings', 'H3'],
-      h4: [3, 'Level-4 headings', 'H4'],
-      h5: [3, 'Level-5 headings', 'H5'],
-      h6: [3, 'Level-6 headings', 'H6'],
-    };
-    // For each eligible element type:
-    Object.keys(elementData).forEach(elementName => {
-      // If it has more than 1 style:
-      const elementTotal = data.totals[elementName];
-      if (elementTotal && elementTotal.subtotals) {
-        const currentData = elementData[elementName];
-        const severity = currentData[0];
-        const elementSubtotals = elementTotal.subtotals;
-        // Treat the count of its styles in excess of 1 as the instance count for that element type.
-        const extraCount = elementSubtotals.length - 1;
-        totals[severity] += extraCount;
-        // Add a summary standard instance for that element type.
-        standardInstances.push({
-          ruleID: 'styleDiff',
-          what: `${currentData[1]} have ${elementSubtotals.length} different styles`,
-          ordinalSeverity: severity,
-          count: extraCount,
-          catalogIndex
+        // Initialize an object of elements to be analyzed, including links.
+        const elements = {
+            buttons: [],
+            headings: {
+                h1: [],
+                h2: [],
+                h3: [],
+                h4: [],
+                h5: [],
+                h6: []
+            },
+            links: {
+                adjacent: linkTypes.adjacent,
+                list: linkTypes.list
+            }
+        };
+        // Identify the heading tag names to be analyzed.
+        const headingNames = Object.keys(elements.headings);
+        // Add the buttons to the object.
+        elements.buttons = Array.from(body.querySelectorAll('button, input[type=button]'));
+        // For each heading tag name:
+        headingNames.forEach(tagName => {
+            // Add its elements to the object.
+            elements.headings[tagName] = Array.from(body.getElementsByTagName(tagName));
         });
-      }
-    });
-    // Return the result.
-    return {
-      data,
-      totals,
-      standardInstances
-    };
-  }, [linkTypes, withItems, catalogIndex]);
+        // FUNCTION DEFINITION START
+        // Tabulates the distribution of style properties for elements of a type.
+        const tallyStyles = (typeName, elements, typeStyles, withItems) => {
+            // If there are any elements:
+            const elementCount = elements.length;
+            if (elementCount) {
+                const styleProps = {};
+                const styleTexts = {};
+                // For each element:
+                elements.forEach(element => {
+                    // Get its values on the style properties to be compared.
+                    const styleDec = window.getComputedStyle(element);
+                    const style = {};
+                    const styles = mainStyles.concat(typeStyles);
+                    styles.forEach(styleName => {
+                        style[styleName] = styleDec[styleName];
+                    });
+                    // Get a text representation of the style, limited to those properties.
+                    const styleText = JSON.stringify(style);
+                    // Increment the total of elements with that style.
+                    styleTexts[styleText] = ++styleTexts[styleText] || 1;
+                    // If details are to be reported:
+                    if (withItems) {
+                        // Add the element’s values and text to the style details.
+                        if (!styleProps[typeName]) {
+                            styleProps[typeName] = {};
+                        }
+                        const elementText = (element.textContent.trim() || element.outerHTML.trim())
+                            .replace(/\s+/g, ' ')
+                            .slice(0, 100);
+                        // For each style property being compared:
+                        styles.forEach(styleName => {
+                            if (!styleProps[typeName][styleName]) {
+                                styleProps[typeName][styleName] = {};
+                            }
+                            if (!styleProps[typeName][styleName][style[styleName]]) {
+                                styleProps[typeName][styleName][style[styleName]] = [];
+                            }
+                            // Add the element text to the style details.
+                            styleProps[typeName][styleName][style[styleName]].push(elementText);
+                        });
+                    }
+                });
+                // Add the total to the result.
+                data.totals[typeName] = { total: elementCount };
+                const styleCounts = Object.values(styleTexts);
+                // If the elements of the type differ in style:
+                if (styleCounts.length > 1) {
+                    // Add the distribution of its style counts to the result.
+                    data.totals[typeName].subtotals = styleCounts.sort((a, b) => b - a);
+                    // If details are to be reported:
+                    if (withItems) {
+                        // Delete the data on uniform style properties.
+                        Object.keys(styleProps[typeName]).forEach(styleName => {
+                            if (Object.keys(styleProps[typeName][styleName]).length === 1) {
+                                delete styleProps[typeName][styleName];
+                            }
+                        });
+                        // Add the element values and texts to the result.
+                        data.items[typeName] = styleProps[typeName];
+                    }
+                }
+            }
+        };
+        // FUNCTION DEFINITION END
+        // Report the style-property distributions for the element types.
+        tallyStyles('button', elements.buttons, buttonStyles, withItems);
+        tallyStyles('adjacentLink', elements.links.adjacent, [], withItems);
+        tallyStyles('listLink', elements.links.list, listLinkStyles, withItems);
+        headingNames.forEach(headingName => {
+            tallyStyles(headingName, elements.headings[headingName], headingStyles, withItems);
+        });
+        // Report the standandardized data.
+        const totals = [0, 0, 0, 0];
+        const standardInstances = [];
+        const elementData = {
+            adjacentLink: [0, 'In-line links', 'A'],
+            listLink: [1, 'Links in columns', 'A'],
+            button: [2, 'Buttons', 'BUTTON'],
+            h1: [3, 'Level-1 headings', 'H1'],
+            h2: [3, 'Level-2 headings', 'H2'],
+            h3: [3, 'Level-3 headings', 'H3'],
+            h4: [3, 'Level-4 headings', 'H4'],
+            h5: [3, 'Level-5 headings', 'H5'],
+            h6: [3, 'Level-6 headings', 'H6'],
+        };
+        // For each eligible element type:
+        Object.keys(elementData).forEach(elementName => {
+            // If it has more than 1 style:
+            const elementTotal = data.totals[elementName];
+            if (elementTotal && elementTotal.subtotals) {
+                const currentData = elementData[elementName];
+                const severity = currentData[0];
+                const elementSubtotals = elementTotal.subtotals;
+                // Treat the count of its styles in excess of 1 as the instance count for that element type.
+                const extraCount = elementSubtotals.length - 1;
+                totals[severity] += extraCount;
+                // Add a summary standard instance for that element type.
+                standardInstances.push({
+                    ruleID: 'styleDiff',
+                    what: `${currentData[1]} have ${elementSubtotals.length} different styles`,
+                    ordinalSeverity: severity,
+                    count: extraCount,
+                    catalogIndex
+                });
+            }
+        });
+        // Return the result.
+        return {
+            data,
+            totals,
+            standardInstances
+        };
+    }, [linkTypes, withItems, catalogIndex]);
 };
+exports.reporter = reporter;

--- a/testaro/styleDiff.ts
+++ b/testaro/styleDiff.ts
@@ -1,0 +1,306 @@
+/*
+  © 2021–2024 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {getXPathCatalogIndex} from '../procs/xPath';
+import type {Report} from '../types';
+
+// TYPES
+
+// Style-count totals for one element type.
+interface StyleDiffTotals {
+  total: number;
+  subtotals?: number[];
+}
+
+/*
+  styleDiff
+  This test reports style differences among links, buttons, and headings. It assumes that an accessible page employs few or only one style for adjacent links, and likewise for list links, buttons, and headings at each level. The test considers only particular style properties, listed in the 'mainStyles' and 'headingStyles' arrays.
+  Compiled to styleDiff.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Returns an object classifying the links in a page by layout.
+const linksByType = async (page: Page) => await page.evaluateHandle(() => {
+  // FUNCTION DEFINITIONS START
+  // Removes spacing characters from a text.
+  const despace = (text: string) => text.replace(/\s/g, '');
+  // Returns whether a list is a list entirely of links.
+  const isLinkList = (list: Element) => {
+    const listItems = Array.from(list.children);
+    if (listItems.length > 1) {
+      return listItems.length > 1 && listItems.every(item => {
+        if (item.tagName === 'LI') {
+          const {children} = item;
+          if (children.length === 1) {
+            const link = children[0];
+            if (link.tagName === 'A') {
+              const itemText = despace(item.textContent!);
+              const linkText = despace(link.textContent!);
+              return itemText.length === linkText.length;
+            }
+            else {
+              return false;
+            }
+          }
+          else {
+            return false;
+          }
+        }
+        else {
+          return false;
+        }
+      });
+    }
+    else {
+      return false;
+    }
+  };
+  // FUNCTION DEFINITIONS END
+  // Identify the lists in the page.
+  const lists = Array.from(document.body.querySelectorAll('ul, ol'));
+  // Initialize an array of list links.
+  const listLinks: HTMLAnchorElement[] = [];
+  // For each one:
+  lists.forEach(list => {
+    // If it is a list of links:
+    if (isLinkList(list)) {
+      // Choose one of the links randomly, assuming they have uniform styles.
+      const links = Array.from(list.querySelectorAll('a'));
+      const randomIndex = Math.floor(Math.random() * links.length);
+      const randomLink = links[randomIndex];
+      // Add it to the array.
+      listLinks.push(randomLink);
+    }
+  });
+  // Identify the inline links in the page.
+  const allLinks = Array.from(document.body.querySelectorAll('a'));
+  const inlineLinks = allLinks.filter(link => ! listLinks.includes(link));
+  // Return the data.
+  return {
+    adjacent: inlineLinks,
+    list: listLinks
+  };
+});
+// Runs the test and returns the result.
+export const reporter = async (page: Page, report: Report, _: unknown, withItems: boolean) => {
+  // Get an object with arrays of list links and adjacent links as properties.
+  const linkTypes = await linksByType(page);
+  const catalogIndex = getXPathCatalogIndex(report, '/html/body');
+  return await page.evaluate(args => {
+    const [linkTypes, withItems, catalogIndex] = args;
+    const {body} = document;
+    // Identify the settable style properties to be compared for all tag names.
+    const mainStyles = [
+      'fontStyle',
+      'fontWeight',
+      'opacity',
+      'textDecorationLine',
+      'textDecorationStyle',
+      'textDecorationThickness'
+    ];
+    // Identify those only for buttons.
+    const buttonStyles = [
+      'borderStyle',
+      'borderWidth',
+      'height',
+      'lineHeight',
+      'maxHeight',
+      'maxWidth',
+      'minHeight',
+      'minWidth',
+      'outlineOffset',
+      'outlineStyle',
+      'outlineWidth'
+    ];
+    // Identify those for headings.
+    const headingStyles = [
+      'color',
+      'fontSize'
+    ];
+    // Identify those for list links.
+    const listLinkStyles = [
+      'color',
+      'fontSize',
+      'lineHeight'
+    ];
+    // Initialize the data to be returned.
+    const data: {
+      mainStyles: string[];
+      buttonStyles: string[];
+      headingStyles: string[];
+      listLinkStyles: string[];
+      totals: Record<string, StyleDiffTotals>;
+      items?: Record<string, Record<string, Record<string, string[]>>>;
+    } = {
+      mainStyles,
+      buttonStyles,
+      headingStyles,
+      listLinkStyles,
+      totals: {}
+    };
+    if (withItems) {
+      data.items = {};
+    }
+    // Initialize an object of elements to be analyzed, including links.
+    const elements: {
+      buttons: Element[];
+      headings: Record<string, Element[]>;
+      links: {adjacent: Element[]; list: Element[]};
+    } = {
+      buttons: [],
+      headings: {
+        h1: [],
+        h2: [],
+        h3: [],
+        h4: [],
+        h5: [],
+        h6: []
+      },
+      links: {
+        adjacent: linkTypes.adjacent,
+        list: linkTypes.list
+      }
+    };
+    // Identify the heading tag names to be analyzed.
+    const headingNames = Object.keys(elements.headings);
+    // Add the buttons to the object.
+    elements.buttons = Array.from(body.querySelectorAll('button, input[type=button]'));
+    // For each heading tag name:
+    headingNames.forEach(tagName => {
+      // Add its elements to the object.
+      elements.headings[tagName] = Array.from(body.getElementsByTagName(tagName));
+    });
+    // FUNCTION DEFINITION START
+    // Tabulates the distribution of style properties for elements of a type.
+    const tallyStyles = (
+      typeName: string, elements: Element[], typeStyles: string[], withItems: boolean
+    ) => {
+      // If there are any elements:
+      const elementCount = elements.length;
+      if (elementCount) {
+        const styleProps: Record<string, Record<string, Record<string, string[]>>> = {};
+        const styleTexts: Record<string, number> = {};
+        // For each element:
+        elements.forEach(element => {
+          // Get its values on the style properties to be compared.
+          const styleDec = window.getComputedStyle(element);
+          const style: Record<string, string> = {};
+          const styles = mainStyles.concat(typeStyles);
+          styles.forEach(styleName => {
+            style[styleName] = (styleDec as unknown as Record<string, string>)[styleName];
+          });
+          // Get a text representation of the style, limited to those properties.
+          const styleText = JSON.stringify(style);
+          // Increment the total of elements with that style.
+          styleTexts[styleText] = ++styleTexts[styleText] || 1;
+          // If details are to be reported:
+          if (withItems) {
+            // Add the element’s values and text to the style details.
+            if (! styleProps[typeName]) {
+              styleProps[typeName] = {};
+            }
+            const elementText = (element.textContent!.trim() || element.outerHTML.trim())
+            .replace(/\s+/g, ' ')
+            .slice(0, 100);
+            // For each style property being compared:
+            styles.forEach(styleName => {
+              if (! styleProps[typeName][styleName]) {
+                styleProps[typeName][styleName] = {};
+              }
+              if (! styleProps[typeName][styleName][style[styleName]]) {
+                styleProps[typeName][styleName][style[styleName]] = [];
+              }
+              // Add the element text to the style details.
+              styleProps[typeName][styleName][style[styleName]].push(elementText);
+            });
+          }
+        });
+        // Add the total to the result.
+        data.totals[typeName] = {total: elementCount};
+        const styleCounts = Object.values(styleTexts);
+        // If the elements of the type differ in style:
+        if (styleCounts.length > 1) {
+          // Add the distribution of its style counts to the result.
+          data.totals[typeName].subtotals = styleCounts.sort((a, b) => b - a);
+          // If details are to be reported:
+          if (withItems) {
+            // Delete the data on uniform style properties.
+            Object.keys(styleProps[typeName]).forEach(styleName => {
+              if (Object.keys(styleProps[typeName][styleName]).length === 1) {
+                delete styleProps[typeName][styleName];
+              }
+            });
+            // Add the element values and texts to the result.
+            data.items![typeName] = styleProps[typeName];
+          }
+        }
+      }
+    };
+    // FUNCTION DEFINITION END
+    // Report the style-property distributions for the element types.
+    tallyStyles('button', elements.buttons, buttonStyles, withItems);
+    tallyStyles('adjacentLink', elements.links.adjacent, [], withItems);
+    tallyStyles('listLink', elements.links.list, listLinkStyles, withItems);
+    headingNames.forEach(headingName => {
+      tallyStyles(headingName, elements.headings[headingName], headingStyles, withItems);
+    });
+    // Report the standandardized data.
+    const totals = [0, 0, 0, 0];
+    const standardInstances: {
+      ruleID: string;
+      what: string;
+      ordinalSeverity: number;
+      count: number;
+      catalogIndex: string;
+    }[] = [];
+    const elementData: Record<string, [number, string, string]> = {
+      adjacentLink: [0, 'In-line links', 'A'],
+      listLink: [1, 'Links in columns', 'A'],
+      button: [2, 'Buttons', 'BUTTON'],
+      h1: [3, 'Level-1 headings', 'H1'],
+      h2: [3, 'Level-2 headings', 'H2'],
+      h3: [3, 'Level-3 headings', 'H3'],
+      h4: [3, 'Level-4 headings', 'H4'],
+      h5: [3, 'Level-5 headings', 'H5'],
+      h6: [3, 'Level-6 headings', 'H6'],
+    };
+    // For each eligible element type:
+    Object.keys(elementData).forEach(elementName => {
+      // If it has more than 1 style:
+      const elementTotal = data.totals[elementName];
+      if (elementTotal && elementTotal.subtotals) {
+        const currentData = elementData[elementName];
+        const severity = currentData[0];
+        const elementSubtotals = elementTotal.subtotals;
+        // Treat the count of its styles in excess of 1 as the instance count for that element type.
+        const extraCount = elementSubtotals.length - 1;
+        totals[severity] += extraCount;
+        // Add a summary standard instance for that element type.
+        standardInstances.push({
+          ruleID: 'styleDiff',
+          what: `${currentData[1]} have ${elementSubtotals.length} different styles`,
+          ordinalSeverity: severity,
+          count: extraCount,
+          catalogIndex
+        });
+      }
+    });
+    // Return the result.
+    return {
+      data,
+      totals,
+      standardInstances
+    };
+  }, [linkTypes, withItems, catalogIndex] as const);
+};


### PR DESCRIPTION
Phase 2, batch 6 of the migration on #73: `focAll` and `styleDiff`, two of the four largest bespoke reporters. Same contract as #103–#107: strict TypeScript, committed in-place emit, no behavior change.

Pattern notes:

- `focAll`'s radio-group filters become type-predicate arrows (`(element): element is HTMLInputElement => …`), which erase at emit except that predicate signatures require boolean returns, so `&& element.name` gains a `!!`. Inside `.filter()` the truthiness result is unchanged, so the emitted difference is inert.
- `styleDiff`'s `evaluateHandle` → `evaluate` handle-passing keeps its exact runtime shape; Playwright's `Unboxed` typing carries the element arrays across the boundary. `CSSStyleDeclaration` string indexing is documented with one erased cast.
- Nested tally structures (`styleProps[typeName][styleName][value] → string[]`) are typed as nested `Record`s; the in-page `data` object gets an explicit shape including the optional `items`.

## Verification

- `tsc` green; committed emit matches (CI drift gate); `node --check` sweep green.
- Emitted-vs-original token diffs reviewed for both.
- End-to-end validators: `focAll` byte-identical branch-vs-main. `styleDiff` initially appeared to differ deterministically (three runs per side landing on opposite outcomes), but driving the branch's emitted reporter directly against `bad.html` eight times produced **both** outcomes (`2+1` and `1+1+1` adjacent-link subtotals) — the divergence is the rule's own random list-link sampling (`Math.random` in `linksByType`), and the six-run streak was a ~3% coincidence. The emitted sampling code is byte-identical to the original. Side-finding for the validator-modernization work: the `styleDiff` validator's expectations are tuned to one side of that coin, so it flakes on `main` by design roughly half the time.

Remaining in Phase 2: `buttonMenu` and `tabNav`, then the typed rule registry with the `tests/testaro.js` conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
