### PR TITLE
TypeScript Phase 2 batch 7: buttonMenu and tabNav — all 52 rule modules converted (#73)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -83,3 +83,7 @@ testaro/focAll.js linguist-generated=true
 testaro/focAll.d.ts linguist-generated=true
 testaro/styleDiff.js linguist-generated=true
 testaro/styleDiff.d.ts linguist-generated=true
+testaro/buttonMenu.js linguist-generated=true
+testaro/buttonMenu.d.ts linguist-generated=true
+testaro/tabNav.js linguist-generated=true
+testaro/tabNav.d.ts linguist-generated=true

--- a/testaro/buttonMenu.d.ts
+++ b/testaro/buttonMenu.d.ts
@@ -1,0 +1,9 @@
+import type { Page } from 'playwright';
+import type { Report, StandardInstance } from '../types';
+export declare const reporter: (page: Page, report: Report, _0: unknown, withItems: boolean, trialKeySpecs?: string[]) => Promise<{
+    data: {
+        trialKeys?: string[];
+    };
+    totals: number[];
+    standardInstances: StandardInstance[];
+}>;

--- a/testaro/buttonMenu.js
+++ b/testaro/buttonMenu.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2023–2024 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -8,356 +9,353 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const xPath_1 = require("../procs/xPath");
 /*
   buttonMenu
   This test reports nonstandard navigation among menu items of button-controlled menus. Standards are based on https://www.w3.org/TR/wai-aria-practices-1.1/#menu. The trialKeys argument is an array of strings, each of which may be 'Home', 'End', '+', or '-'. The '+' string represents the ArrowDown or ArrowRight key, and the '-' string represents the ArrowUp or ArrowLeft key, depending on the orientation of the current menu. When the trialKeys argument is missing or is an empty array, 12 keys are selected at random.
+  Compiled to buttonMenu.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const {getXPathCatalogIndex} = require('../procs/xPath');
-
 // ########## FUNCTIONS
-
 // Returns data about the element referenced by a locator.
-const getLocatorData = async loc => {
-  const locCount = await loc.count();
-  // If the locator identifies exactly 1 element:
-  if (locCount === 1) {
-    // Get the facts obtainable from the browser.
-    const data = await loc.evaluate(element => {
-      // Tag name.
-      const tagName = element.tagName;
-      // ID.
-      const id = element.id || '';
-      // Texts.
-      const {textContent} = element;
-      const alts = Array.from(element.querySelectorAll('img[alt]:not([alt=""])'));
-      const altTexts = alts.map(alt => alt.getAttribute('alt'));
-      const altsText = altTexts.join(' ');
-      const ariaLabelText = element.ariaLabel || '';
-      const refLabelID = element.getAttribute('aria-labelledby');
-      const refLabel = refLabelID ? document.getElementById(refLabelID) : '';
-      const refLabelText = refLabel ? refLabel.textContent : '';
-      let labelsText = '';
-      if (tagName === 'INPUT') {
-        const labels = element.labels || [];
-        const labelTexts = [];
-        labels.forEach(label => {
-          labelTexts.push(label.textContent);
+const getLocatorData = async (loc) => {
+    const locCount = await loc.count();
+    // If the locator identifies exactly 1 element:
+    if (locCount === 1) {
+        // Get the facts obtainable from the browser.
+        const data = await loc.evaluate((element) => {
+            // Tag name.
+            const tagName = element.tagName;
+            // ID.
+            const id = element.id || '';
+            // Texts.
+            const { textContent } = element;
+            const alts = Array.from(element.querySelectorAll('img[alt]:not([alt=""])'));
+            const altTexts = alts.map(alt => alt.getAttribute('alt'));
+            const altsText = altTexts.join(' ');
+            const ariaLabelText = element.ariaLabel || '';
+            const refLabelID = element.getAttribute('aria-labelledby');
+            const refLabel = refLabelID ? document.getElementById(refLabelID) : '';
+            const refLabelText = refLabel ? refLabel.textContent : '';
+            let labelsText = '';
+            if (tagName === 'INPUT') {
+                const labels = element.labels || [];
+                const labelTexts = [];
+                labels.forEach(label => {
+                    labelTexts.push(label.textContent);
+                });
+                labelsText = labelTexts.join(' ');
+            }
+            let text = [textContent, altsText, ariaLabelText, refLabelText, labelsText]
+                .join(' ')
+                .replace(/\s+/g, ' ')
+                .trim();
+            if (!text) {
+                text = element.outerHTML.replace(/\s+/g, ' ').trim();
+            }
+            if (/^<[^<>]+>$/.test(text)) {
+                text = element.parentElement.outerHTML.replace(/\s+/g, ' ').trim();
+            }
+            // Location.
+            let location = {
+                doc: 'dom',
+                type: 'box',
+                spec: {}
+            };
+            if (id) {
+                location.type = 'selector';
+                location.spec = `#${id}`;
+            }
+            // Return the data.
+            return {
+                tagName,
+                id,
+                location,
+                excerpt: text
+            };
         });
-        labelsText = labelTexts.join(' ');
-      }
-      let text = [textContent, altsText, ariaLabelText, refLabelText, labelsText]
-      .join(' ')
-      .replace(/\s+/g, ' ')
-      .trim();
-      if (! text) {
-        text = element.outerHTML.replace(/\s+/g, ' ').trim();
-      }
-      if (/^<[^<>]+>$/.test(text)) {
-        text = element.parentElement.outerHTML.replace(/\s+/g, ' ').trim();
-      }
-      // Location.
-      let location = {
-        doc: 'dom',
-        type: 'box',
-        spec: {}
-      };
-      if (id) {
-        location.type = 'selector';
-        location.spec = `#${id}`;
-      }
-      // Return the data.
-      return {
-        tagName,
-        id,
-        location,
-        excerpt: text
-      };
-    });
-    // If an ID-based selector could not be defined:
-    if (data.location.type === 'box') {
-      // Define a bounding-box-based location.
-      const rawSpec = await loc.boundingBox();
-      // If there is a bounding box (i.e. the element is visible):
-      if (rawSpec) {
-        // Populate the location.
-        Object.keys(rawSpec).forEach(specName => {
-          data.location.spec[specName] = Math.round(rawSpec[specName]);
-        });
-      }
-      // Otherwise, i.e. if there is no bounding box:
-      else {
-        // Empty the location.
-        data.location.doc = '';
-        data.location.type = '';
-        data.location.spec = '';
-      }
+        // If an ID-based selector could not be defined:
+        if (data.location.type === 'box') {
+            // Define a bounding-box-based location.
+            const rawSpec = await loc.boundingBox();
+            // If there is a bounding box (i.e. the element is visible):
+            if (rawSpec) {
+                // Populate the location.
+                Object.keys(rawSpec).forEach(specName => {
+                    data.location.spec[specName] = Math.round(rawSpec[specName]);
+                });
+            }
+            // Otherwise, i.e. if there is no bounding box:
+            else {
+                // Empty the location.
+                data.location.doc = '';
+                data.location.type = '';
+                data.location.spec = '';
+            }
+        }
+        // If the text is long:
+        if (data.excerpt.length > 400) {
+            // Truncate its middle.
+            data.excerpt = `${data.excerpt.slice(0, 200)} … ${data.excerpt.slice(-200)}`;
+        }
+        // Return the data.
+        return data;
     }
-    // If the text is long:
-    if (data.excerpt.length > 400) {
-      // Truncate its middle.
-      data.excerpt = `${data.excerpt.slice(0, 200)} … ${data.excerpt.slice(-200)}`;
+    // Otherwise, i.e. if it does not identify exactly 1 element:
+    else {
+        // Report this.
+        console.log(`ERROR: Locator count to get data from is ${locCount} instead of 1`);
+        return null;
     }
-    // Return the data.
-    return data;
-  }
-  // Otherwise, i.e. if it does not identify exactly 1 element:
-  else {
-    // Report this.
-    console.log(`ERROR: Locator count to get data from is ${locCount} instead of 1`);
-    return null;
-  }
 };
 // Returns an adjacent index, with wrapping.
 const getAdjacentIndexWithWrap = (groupSize, startIndex, increment) => {
-  let newIndex = startIndex + increment;
-  if (newIndex < 0) {
-    newIndex = groupSize - 1;
-  }
-  else if (newIndex > groupSize - 1) {
-    newIndex = 0;
-  }
-  return newIndex;
+    let newIndex = startIndex + increment;
+    if (newIndex < 0) {
+        newIndex = groupSize - 1;
+    }
+    else if (newIndex > groupSize - 1) {
+        newIndex = 0;
+    }
+    return newIndex;
 };
 // Returns whether a key created the expected effective focus.
 const focusSuccess = async (miLocsDir, priorIndex, key, isPseudo) => {
-  // Initialize the result.
-  const result = {
-    isOK: false,
-    newFocIndex: null
-  };
-  // For each of the menu items directly descending from the menu:
-  for (const miLocDir of miLocsDir) {
-    // Get whether it is effectively focused.
-    const hasFocus = await miLocDir.evaluate((el, isPseudo) => {
-      if (isPseudo) {
-        const effectiveID = document.activeElement.getAttribute('aria-activeDescendant');
-        if (effectiveID) {
-          const effectiveEl = document.getElementById(effectiveID);
-          return effectiveEl === el;
+    // Initialize the result.
+    const result = {
+        isOK: false,
+        newFocIndex: null
+    };
+    // For each of the menu items directly descending from the menu:
+    for (const miLocDir of miLocsDir) {
+        // Get whether it is effectively focused.
+        const hasFocus = await miLocDir.evaluate((el, isPseudo) => {
+            if (isPseudo) {
+                // The page has an active element whenever this runs; verbatim from the original.
+                const effectiveID = document.activeElement.getAttribute('aria-activeDescendant');
+                if (effectiveID) {
+                    const effectiveEl = document.getElementById(effectiveID);
+                    return effectiveEl === el;
+                }
+                else {
+                    return false;
+                }
+            }
+            else {
+                return document.activeElement === el;
+            }
+        }, isPseudo);
+        // If it is:
+        if (hasFocus) {
+            // Get whether the effective focus is as expected and update the result.
+            const miFocIndex = miLocsDir.indexOf(miLocDir);
+            const miCount = miLocsDir.length;
+            if (key === 'Home' && miFocIndex === 0) {
+                result.isOK = true;
+                result.newFocIndex = 0;
+            }
+            else if (key === 'End' && miFocIndex === miCount - 1) {
+                result.isOK = true;
+                result.newFocIndex = miCount - 1;
+            }
+            else if (['ArrowLeft', 'ArrowUp'].includes(key)) {
+                const expectedIndex = getAdjacentIndexWithWrap(miCount, priorIndex, -1);
+                if (miFocIndex === expectedIndex) {
+                    result.isOK = true;
+                    result.newFocIndex = expectedIndex;
+                }
+            }
+            else if (['ArrowRight', 'ArrowDown'].includes(key)) {
+                const expectedIndex = getAdjacentIndexWithWrap(miCount, priorIndex, 1);
+                if (miFocIndex === expectedIndex) {
+                    result.isOK = true;
+                    result.newFocIndex = expectedIndex;
+                }
+            }
+            break;
         }
-        else {
-          return false;
-        }
-      }
-      else {
-        return document.activeElement === el;
-      }
-    }, isPseudo);
-    // If it is:
-    if (hasFocus) {
-      // Get whether the effective focus is as expected and update the result.
-      const miFocIndex = miLocsDir.indexOf(miLocDir);
-      const miCount = miLocsDir.length;
-      if (key === 'Home' && miFocIndex === 0) {
-        result.isOK = true;
-        result.newFocIndex = 0;
-      }
-      else if (key === 'End' && miFocIndex === miCount - 1) {
-        result.isOK = true;
-        result.newFocIndex = miCount - 1;
-      }
-      else if (['ArrowLeft', 'ArrowUp'].includes(key)) {
-        const expectedIndex = getAdjacentIndexWithWrap(miCount, priorIndex, -1);
-        if (miFocIndex === expectedIndex) {
-          result.isOK = true;
-          result.newFocIndex = expectedIndex;
-        }
-      }
-      else if (['ArrowRight', 'ArrowDown'].includes(key)) {
-        const expectedIndex = getAdjacentIndexWithWrap(miCount, priorIndex, 1);
-        if (miFocIndex === expectedIndex) {
-          result.isOK = true;
-          result.newFocIndex = expectedIndex;
-        }
-      }
-      break;
     }
-  }
-  // Return the result.
-  return result;
+    // Return the result.
+    return result;
 };
 // Performs the test and reports the result.
-exports.reporter = async (page, report, _0, withItems, trialKeySpecs = []) => {
-  // Initialize the result.
-  const data = {};
-  const totals = [0, 0, 0, 0];
-  const standardInstances = [];
-  // Get locators for all menu buttons.
-  const mbLocAll = page.locator(
-    'button[aria-controls][aria-expanded][aria-haspopup=true], button[aria-controls][aria-expanded][aria-haspopup=menu]'
-  );
-  const mbLocsAll = await mbLocAll.all();
-  // For each menu button:
-  for (const mbLoc of mbLocsAll) {
-    // Get a locator for its menu.
-    const menuID = await mbLoc.getAttribute('aria-controls');
-    const menuLoc = page.locator(`[id=${menuID}][role=menu], [id=${menuID}][role=menubar]`);
-    // If the button controls exactly 1 menu:
-    if (menuLoc && await menuLoc.count() === 1) {
-      // Get data on the menu.
-      const elData = await getLocatorData(menuLoc);
-      // If data were obtained:
-      if (elData) {
-        // Get the orientation and focus-management type of the menu.
-        const extraData = await menuLoc.evaluate(element => {
-          const extraData = {};
-          let orientation = element.getAttribute('aria-orientation');
-          if (! orientation) {
-            const role = element.getAttribute('role');
-            if (role === 'menubar') {
-              orientation = 'horizontal';
+const reporter = async (page, report, _0, withItems, trialKeySpecs = []) => {
+    // Initialize the result.
+    const data = {};
+    const totals = [0, 0, 0, 0];
+    const standardInstances = [];
+    // Get locators for all menu buttons.
+    const mbLocAll = page.locator('button[aria-controls][aria-expanded][aria-haspopup=true], button[aria-controls][aria-expanded][aria-haspopup=menu]');
+    const mbLocsAll = await mbLocAll.all();
+    // For each menu button:
+    for (const mbLoc of mbLocsAll) {
+        // Get a locator for its menu.
+        const menuID = await mbLoc.getAttribute('aria-controls');
+        const menuLoc = page.locator(`[id=${menuID}][role=menu], [id=${menuID}][role=menubar]`);
+        // If the button controls exactly 1 menu:
+        if (menuLoc && await menuLoc.count() === 1) {
+            // Get data on the menu.
+            const elData = await getLocatorData(menuLoc);
+            // If data were obtained:
+            if (elData) {
+                // Get the orientation and focus-management type of the menu.
+                const extraData = await menuLoc.evaluate(element => {
+                    const extraData = {};
+                    let orientation = element.getAttribute('aria-orientation');
+                    if (!orientation) {
+                        const role = element.getAttribute('role');
+                        if (role === 'menubar') {
+                            orientation = 'horizontal';
+                        }
+                        else if (role === 'menu') {
+                            orientation = 'vertical';
+                        }
+                        else {
+                            orientation = null;
+                        }
+                    }
+                    extraData.orientation = orientation;
+                    const isPseudo = !!element.getAttribute('aria-activedescendant');
+                    extraData.isPseudo = isPseudo;
+                    return extraData;
+                });
+                // If they were obtained:
+                if (extraData) {
+                    // Get locators for its descendant non-menu menu items.
+                    const miLocAll = menuLoc.locator('[role=menuitem]:not([role=menu], [role=menubar])');
+                    // Get which of them are direct descendants.
+                    const areDirect = await miLocAll.evaluateAll((els, menuID) => {
+                        return els.map(el => {
+                            // Menu items are inside a menu by definition; verbatim from the original.
+                            const itsMenu = el.closest('[role=menu], [role=menubar]');
+                            return itsMenu.id && itsMenu.id === menuID;
+                        });
+                    }, menuID);
+                    const miLocsAll = await miLocAll.all();
+                    const miLocsDir = miLocsAll.filter((loc, index) => areDirect[index]);
+                    // If there are at least 2 of them:
+                    if (miLocsDir.length > 1) {
+                        // Ensure that the menu is collapsed.
+                        await menuLoc.evaluate(element => {
+                            // The boolean is coerced to 'false' at runtime; verbatim from the original.
+                            element.setAttribute('aria-expanded', false);
+                        });
+                        // Focus the menu button and press the key that opens its menu from the top.
+                        await mbLoc.press(extraData.orientation === 'horizontal' ? 'ArrowRight' : 'ArrowDown');
+                        // If trial keys have been specified:
+                        const trialKeys = [];
+                        if (trialKeySpecs.length) {
+                            // Implement them.
+                            trialKeySpecs.forEach(spec => {
+                                if (['Home', 'End'].includes(spec)) {
+                                    trialKeys.push(spec);
+                                }
+                                else if (spec === '-') {
+                                    trialKeys.push(extraData.orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp');
+                                }
+                                else if (spec === '+') {
+                                    trialKeys.push(extraData.orientation === 'horizontal' ? 'ArrowtRight' : 'ArrowDown');
+                                }
+                            });
+                        }
+                        // Otherwise, i.e. if trial keys have not been specified:
+                        else {
+                            // Randomly draw 12 keys from Home, End, and the applicable arrow keys.
+                            const keys = ['Home', 'End'];
+                            if (extraData.orientation === 'horizontal') {
+                                keys.push('ArrowLeft', 'ArrowRight');
+                            }
+                            else {
+                                keys.push('ArrowUp', 'ArrowDown');
+                            }
+                            let trialKeyCount = 0;
+                            while (trialKeyCount++ < 12) {
+                                trialKeys.push(keys[Math.floor(4 * Math.random())]);
+                            }
+                        }
+                        // Add the list of trial keys to the result.
+                        data.trialKeys = trialKeys;
+                        let focIndex = 0;
+                        // For each key in the trial:
+                        for (const key of trialKeys) {
+                            // Press it.
+                            await page.keyboard.press(key);
+                            // Get whether the expected focus occurred.
+                            const focData = await focusSuccess(miLocsDir, focIndex, key, extraData.isPseudo);
+                            // If so:
+                            if (focData.isOK) {
+                                // Update the index of the effective focus.
+                                focIndex = focData.newFocIndex;
+                            }
+                            // Otherwise, i.e. if the expected focus did not occur:
+                            else {
+                                // Add to the totals.
+                                totals[2]++;
+                                // If itemization is required:
+                                if (withItems) {
+                                    // Get the XPath of the menu button.
+                                    const mbXPath = await mbLoc.evaluate(element => window.getXPath(element));
+                                    // Add an instance to the standard instances.
+                                    standardInstances.push({
+                                        ruleID: 'buttonMenu',
+                                        what: `Menu responds nonstandardly to the ${key} key`,
+                                        ordinalSeverity: 2,
+                                        count: 1,
+                                        catalogIndex: (0, xPath_1.getXPathCatalogIndex)(report, mbXPath)
+                                    });
+                                }
+                                // Stop testing the menu button.
+                                break;
+                            }
+                        }
+                    }
+                }
+                // Otherwise, i.e. if the orientation and focus-management type were not obtained:
+                else {
+                    // Report this.
+                    console.log('ERROR: Menu orientation and focus-management type not obtained');
+                }
             }
-            else if (role === 'menu') {
-              orientation = 'vertical';
-            }
+            // Otherwise, i.e. if the data were not obtained:
             else {
-              orientation = null;
+                // Report this.
+                console.log('ERROR: Menu data not obtained');
             }
-          }
-          extraData.orientation = orientation;
-          const isPseudo = !! element.getAttribute('aria-activedescendant');
-          extraData.isPseudo = isPseudo;
-          return extraData;
-        });
-        // If they were obtained:
-        if (extraData) {
-          // Get locators for its descendant non-menu menu items.
-          const miLocAll = menuLoc.locator('[role=menuitem]:not([role=menu], [role=menubar])');
-          // Get which of them are direct descendants.
-          const areDirect = await miLocAll.evaluateAll((els, menuID) => {
-            return els.map(el => {
-              const itsMenu = el.closest('[role=menu], [role=menubar]');
-              return itsMenu.id && itsMenu.id === menuID;
-            });
-          }, menuID);
-          const miLocsAll = await miLocAll.all();
-          const miLocsDir = miLocsAll.filter((loc, index) => areDirect[index]);
-          // If there are at least 2 of them:
-          if (miLocsDir.length > 1) {
-            // Ensure that the menu is collapsed.
-            await menuLoc.evaluate(element => {
-              element.setAttribute('aria-expanded', false);
-            });
-            // Focus the menu button and press the key that opens its menu from the top.
-            await mbLoc.press(extraData.orientation === 'horizontal' ? 'ArrowRight' : 'ArrowDown');
-            // If trial keys have been specified:
-            const trialKeys = [];
-            if (trialKeySpecs.length) {
-              // Implement them.
-              trialKeySpecs.forEach(spec => {
-                if (['Home', 'End'].includes(spec)) {
-                  trialKeys.push(spec);
-                }
-                else if (spec === '-') {
-                  trialKeys.push(extraData.orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp');
-                }
-                else if (spec === '+') {
-                  trialKeys.push(
-                    extraData.orientation === 'horizontal' ? 'ArrowtRight' : 'ArrowDown'
-                  );
-                }
-              });
-            }
-            // Otherwise, i.e. if trial keys have not been specified:
-            else {
-              // Randomly draw 12 keys from Home, End, and the applicable arrow keys.
-              const keys = ['Home', 'End'];
-              if (extraData.orientation === 'horizontal') {
-                keys.push('ArrowLeft', 'ArrowRight');
-              }
-              else {
-                keys.push('ArrowUp', 'ArrowDown');
-              }
-              let trialKeyCount = 0;
-              while (trialKeyCount++ < 12) {
-                trialKeys.push(keys[Math.floor(4 * Math.random())]);
-              }
-            }
-            // Add the list of trial keys to the result.
-            data.trialKeys = trialKeys;
-            let focIndex = 0;
-            // For each key in the trial:
-            for (const key of trialKeys) {
-              // Press it.
-              await page.keyboard.press(key);
-              // Get whether the expected focus occurred.
-              const focData = await focusSuccess(miLocsDir, focIndex, key, extraData.isPseudo);
-              // If so:
-              if (focData.isOK) {
-                // Update the index of the effective focus.
-                focIndex = focData.newFocIndex;
-              }
-              // Otherwise, i.e. if the expected focus did not occur:
-              else {
-                // Add to the totals.
-                totals[2]++;
-                // If itemization is required:
-                if (withItems) {
-                  // Get the XPath of the menu button.
-                  const mbXPath = await mbLoc.evaluate(element => window.getXPath(element));
-                  // Add an instance to the standard instances.
-                  standardInstances.push({
+        }
+        // Otherwise, i.e. if it does not control exactly 1 menu:
+        else {
+            // Add to the totals.
+            totals[2]++;
+            // If itemization is required:
+            if (withItems) {
+                // Get the XPath of the menu button.
+                const mbXPath = await mbLoc.evaluate(element => window.getXPath(element));
+                // Add an instance to the standard instances.
+                standardInstances.push({
                     ruleID: 'buttonMenu',
-                    what: `Menu responds nonstandardly to the ${key} key`,
+                    what: 'Menu button does not control exactly 1 menu',
                     ordinalSeverity: 2,
                     count: 1,
-                    catalogIndex: getXPathCatalogIndex(report, mbXPath)
-                  });
-                }
-                // Stop testing the menu button.
-                break;
-              }
+                    catalogIndex: (0, xPath_1.getXPathCatalogIndex)(report, mbXPath)
+                });
             }
-          }
         }
-        // Otherwise, i.e. if the orientation and focus-management type were not obtained:
-        else {
-          // Report this.
-          console.log('ERROR: Menu orientation and focus-management type not obtained');
-        }
-      }
-      // Otherwise, i.e. if the data were not obtained:
-      else {
-        // Report this.
-        console.log('ERROR: Menu data not obtained');
-      }
     }
-    // Otherwise, i.e. if it does not control exactly 1 menu:
-    else {
-      // Add to the totals.
-      totals[2]++;
-      // If itemization is required:
-      if (withItems) {
-        // Get the XPath of the menu button.
-        const mbXPath = await mbLoc.evaluate(element => window.getXPath(element));
-        // Add an instance to the standard instances.
+    // If itemization is not required and there are any instances:
+    if (!withItems && totals[2]) {
+        // Add a summary instance to the result.
         standardInstances.push({
-          ruleID: 'buttonMenu',
-          what: 'Menu button does not control exactly 1 menu',
-          ordinalSeverity: 2,
-          count: 1,
-          catalogIndex: getXPathCatalogIndex(report, mbXPath)
+            ruleID: 'buttonMenu',
+            what: 'Menu buttons and menus behave nonstandardly',
+            count: totals[2],
+            ordinalSeverity: 2
         });
-      }
     }
-  }
-  // If itemization is not required and there are any instances:
-  if (! withItems && totals[2]) {
-    // Add a summary instance to the result.
-    standardInstances.push({
-      ruleID: 'buttonMenu',
-      what: 'Menu buttons and menus behave nonstandardly',
-      count: totals[2],
-      ordinalSeverity: 2
-    });
-  }
-  return {
-    data,
-    totals,
-    standardInstances
-  };
+    return {
+        data,
+        totals,
+        standardInstances
+    };
 };
+exports.reporter = reporter;

--- a/testaro/buttonMenu.ts
+++ b/testaro/buttonMenu.ts
@@ -1,0 +1,391 @@
+/*
+  © 2023–2024 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Locator, Page} from 'playwright';
+import {getXPathCatalogIndex} from '../procs/xPath';
+import type {Report, StandardInstance} from '../types';
+
+// TYPES
+
+// Location of an element, as recorded in locator data.
+interface LocatorLocation {
+  doc: string;
+  type: string;
+  spec: string | Record<string, number>;
+}
+// Data on the element referenced by a locator.
+interface LocatorData {
+  tagName: string;
+  id: string;
+  location: LocatorLocation;
+  excerpt: string;
+}
+
+/*
+  buttonMenu
+  This test reports nonstandard navigation among menu items of button-controlled menus. Standards are based on https://www.w3.org/TR/wai-aria-practices-1.1/#menu. The trialKeys argument is an array of strings, each of which may be 'Home', 'End', '+', or '-'. The '+' string represents the ArrowDown or ArrowRight key, and the '-' string represents the ArrowUp or ArrowLeft key, depending on the orientation of the current menu. When the trialKeys argument is missing or is an empty array, 12 keys are selected at random.
+  Compiled to buttonMenu.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// ########## FUNCTIONS
+
+// Returns data about the element referenced by a locator.
+const getLocatorData = async (loc: Locator): Promise<LocatorData | null> => {
+  const locCount = await loc.count();
+  // If the locator identifies exactly 1 element:
+  if (locCount === 1) {
+    // Get the facts obtainable from the browser.
+    const data = await loc.evaluate((element): LocatorData => {
+      // Tag name.
+      const tagName = element.tagName;
+      // ID.
+      const id = element.id || '';
+      // Texts.
+      const {textContent} = element;
+      const alts = Array.from(element.querySelectorAll('img[alt]:not([alt=""])'));
+      const altTexts = alts.map(alt => alt.getAttribute('alt'));
+      const altsText = altTexts.join(' ');
+      const ariaLabelText = element.ariaLabel || '';
+      const refLabelID = element.getAttribute('aria-labelledby');
+      const refLabel = refLabelID ? document.getElementById(refLabelID) : '';
+      const refLabelText = refLabel ? refLabel.textContent : '';
+      let labelsText = '';
+      if (tagName === 'INPUT') {
+        const labels = (element as HTMLInputElement).labels || [];
+        const labelTexts: (string | null)[] = [];
+        labels.forEach(label => {
+          labelTexts.push(label.textContent);
+        });
+        labelsText = labelTexts.join(' ');
+      }
+      let text = [textContent, altsText, ariaLabelText, refLabelText, labelsText]
+      .join(' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+      if (! text) {
+        text = element.outerHTML.replace(/\s+/g, ' ').trim();
+      }
+      if (/^<[^<>]+>$/.test(text)) {
+        text = element.parentElement!.outerHTML.replace(/\s+/g, ' ').trim();
+      }
+      // Location.
+      let location: LocatorLocation = {
+        doc: 'dom',
+        type: 'box',
+        spec: {}
+      };
+      if (id) {
+        location.type = 'selector';
+        location.spec = `#${id}`;
+      }
+      // Return the data.
+      return {
+        tagName,
+        id,
+        location,
+        excerpt: text
+      };
+    });
+    // If an ID-based selector could not be defined:
+    if (data.location.type === 'box') {
+      // Define a bounding-box-based location.
+      const rawSpec = await loc.boundingBox();
+      // If there is a bounding box (i.e. the element is visible):
+      if (rawSpec) {
+        // Populate the location.
+        Object.keys(rawSpec).forEach(specName => {
+          (data.location.spec as Record<string, number>)[specName] = Math.round(
+            rawSpec[specName as keyof typeof rawSpec]
+          );
+        });
+      }
+      // Otherwise, i.e. if there is no bounding box:
+      else {
+        // Empty the location.
+        data.location.doc = '';
+        data.location.type = '';
+        data.location.spec = '';
+      }
+    }
+    // If the text is long:
+    if (data.excerpt.length > 400) {
+      // Truncate its middle.
+      data.excerpt = `${data.excerpt.slice(0, 200)} … ${data.excerpt.slice(-200)}`;
+    }
+    // Return the data.
+    return data;
+  }
+  // Otherwise, i.e. if it does not identify exactly 1 element:
+  else {
+    // Report this.
+    console.log(`ERROR: Locator count to get data from is ${locCount} instead of 1`);
+    return null;
+  }
+};
+// Returns an adjacent index, with wrapping.
+const getAdjacentIndexWithWrap = (groupSize: number, startIndex: number, increment: number) => {
+  let newIndex = startIndex + increment;
+  if (newIndex < 0) {
+    newIndex = groupSize - 1;
+  }
+  else if (newIndex > groupSize - 1) {
+    newIndex = 0;
+  }
+  return newIndex;
+};
+// Returns whether a key created the expected effective focus.
+const focusSuccess = async (
+  miLocsDir: Locator[], priorIndex: number, key: string, isPseudo: boolean
+) => {
+  // Initialize the result.
+  const result: {isOK: boolean; newFocIndex: number | null} = {
+    isOK: false,
+    newFocIndex: null
+  };
+  // For each of the menu items directly descending from the menu:
+  for (const miLocDir of miLocsDir) {
+    // Get whether it is effectively focused.
+    const hasFocus = await miLocDir.evaluate((el, isPseudo) => {
+      if (isPseudo) {
+        // The page has an active element whenever this runs; verbatim from the original.
+        const effectiveID = document.activeElement!.getAttribute('aria-activeDescendant');
+        if (effectiveID) {
+          const effectiveEl = document.getElementById(effectiveID);
+          return effectiveEl === el;
+        }
+        else {
+          return false;
+        }
+      }
+      else {
+        return document.activeElement === el;
+      }
+    }, isPseudo);
+    // If it is:
+    if (hasFocus) {
+      // Get whether the effective focus is as expected and update the result.
+      const miFocIndex = miLocsDir.indexOf(miLocDir);
+      const miCount = miLocsDir.length;
+      if (key === 'Home' && miFocIndex === 0) {
+        result.isOK = true;
+        result.newFocIndex = 0;
+      }
+      else if (key === 'End' && miFocIndex === miCount - 1) {
+        result.isOK = true;
+        result.newFocIndex = miCount - 1;
+      }
+      else if (['ArrowLeft', 'ArrowUp'].includes(key)) {
+        const expectedIndex = getAdjacentIndexWithWrap(miCount, priorIndex, -1);
+        if (miFocIndex === expectedIndex) {
+          result.isOK = true;
+          result.newFocIndex = expectedIndex;
+        }
+      }
+      else if (['ArrowRight', 'ArrowDown'].includes(key)) {
+        const expectedIndex = getAdjacentIndexWithWrap(miCount, priorIndex, 1);
+        if (miFocIndex === expectedIndex) {
+          result.isOK = true;
+          result.newFocIndex = expectedIndex;
+        }
+      }
+      break;
+    }
+  }
+  // Return the result.
+  return result;
+};
+// Performs the test and reports the result.
+export const reporter = async (
+  page: Page, report: Report, _0: unknown, withItems: boolean, trialKeySpecs: string[] = []
+) => {
+  // Initialize the result.
+  const data: {trialKeys?: string[]} = {};
+  const totals = [0, 0, 0, 0];
+  const standardInstances: StandardInstance[] = [];
+  // Get locators for all menu buttons.
+  const mbLocAll = page.locator(
+    'button[aria-controls][aria-expanded][aria-haspopup=true], button[aria-controls][aria-expanded][aria-haspopup=menu]'
+  );
+  const mbLocsAll = await mbLocAll.all();
+  // For each menu button:
+  for (const mbLoc of mbLocsAll) {
+    // Get a locator for its menu.
+    const menuID = await mbLoc.getAttribute('aria-controls');
+    const menuLoc = page.locator(`[id=${menuID}][role=menu], [id=${menuID}][role=menubar]`);
+    // If the button controls exactly 1 menu:
+    if (menuLoc && await menuLoc.count() === 1) {
+      // Get data on the menu.
+      const elData = await getLocatorData(menuLoc);
+      // If data were obtained:
+      if (elData) {
+        // Get the orientation and focus-management type of the menu.
+        const extraData = await menuLoc.evaluate(element => {
+          const extraData: {orientation?: string | null; isPseudo?: boolean} = {};
+          let orientation = element.getAttribute('aria-orientation');
+          if (! orientation) {
+            const role = element.getAttribute('role');
+            if (role === 'menubar') {
+              orientation = 'horizontal';
+            }
+            else if (role === 'menu') {
+              orientation = 'vertical';
+            }
+            else {
+              orientation = null;
+            }
+          }
+          extraData.orientation = orientation;
+          const isPseudo = !! element.getAttribute('aria-activedescendant');
+          extraData.isPseudo = isPseudo;
+          return extraData;
+        });
+        // If they were obtained:
+        if (extraData) {
+          // Get locators for its descendant non-menu menu items.
+          const miLocAll = menuLoc.locator('[role=menuitem]:not([role=menu], [role=menubar])');
+          // Get which of them are direct descendants.
+          const areDirect = await miLocAll.evaluateAll((els, menuID) => {
+            return els.map(el => {
+              // Menu items are inside a menu by definition; verbatim from the original.
+              const itsMenu = el.closest('[role=menu], [role=menubar]')!;
+              return itsMenu.id && itsMenu.id === menuID;
+            });
+          }, menuID);
+          const miLocsAll = await miLocAll.all();
+          const miLocsDir = miLocsAll.filter((loc, index) => areDirect[index]);
+          // If there are at least 2 of them:
+          if (miLocsDir.length > 1) {
+            // Ensure that the menu is collapsed.
+            await menuLoc.evaluate(element => {
+              // The boolean is coerced to 'false' at runtime; verbatim from the original.
+              element.setAttribute('aria-expanded', false as unknown as string);
+            });
+            // Focus the menu button and press the key that opens its menu from the top.
+            await mbLoc.press(extraData.orientation === 'horizontal' ? 'ArrowRight' : 'ArrowDown');
+            // If trial keys have been specified:
+            const trialKeys: string[] = [];
+            if (trialKeySpecs.length) {
+              // Implement them.
+              trialKeySpecs.forEach(spec => {
+                if (['Home', 'End'].includes(spec)) {
+                  trialKeys.push(spec);
+                }
+                else if (spec === '-') {
+                  trialKeys.push(extraData.orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp');
+                }
+                else if (spec === '+') {
+                  trialKeys.push(
+                    extraData.orientation === 'horizontal' ? 'ArrowtRight' : 'ArrowDown'
+                  );
+                }
+              });
+            }
+            // Otherwise, i.e. if trial keys have not been specified:
+            else {
+              // Randomly draw 12 keys from Home, End, and the applicable arrow keys.
+              const keys = ['Home', 'End'];
+              if (extraData.orientation === 'horizontal') {
+                keys.push('ArrowLeft', 'ArrowRight');
+              }
+              else {
+                keys.push('ArrowUp', 'ArrowDown');
+              }
+              let trialKeyCount = 0;
+              while (trialKeyCount++ < 12) {
+                trialKeys.push(keys[Math.floor(4 * Math.random())]);
+              }
+            }
+            // Add the list of trial keys to the result.
+            data.trialKeys = trialKeys;
+            let focIndex = 0;
+            // For each key in the trial:
+            for (const key of trialKeys) {
+              // Press it.
+              await page.keyboard.press(key);
+              // Get whether the expected focus occurred.
+              const focData = await focusSuccess(miLocsDir, focIndex, key, extraData.isPseudo!);
+              // If so:
+              if (focData.isOK) {
+                // Update the index of the effective focus.
+                focIndex = focData.newFocIndex as number;
+              }
+              // Otherwise, i.e. if the expected focus did not occur:
+              else {
+                // Add to the totals.
+                totals[2]++;
+                // If itemization is required:
+                if (withItems) {
+                  // Get the XPath of the menu button.
+                  const mbXPath = await mbLoc.evaluate(element => window.getXPath(element));
+                  // Add an instance to the standard instances.
+                  standardInstances.push({
+                    ruleID: 'buttonMenu',
+                    what: `Menu responds nonstandardly to the ${key} key`,
+                    ordinalSeverity: 2,
+                    count: 1,
+                    catalogIndex: getXPathCatalogIndex(report, mbXPath as string)
+                  });
+                }
+                // Stop testing the menu button.
+                break;
+              }
+            }
+          }
+        }
+        // Otherwise, i.e. if the orientation and focus-management type were not obtained:
+        else {
+          // Report this.
+          console.log('ERROR: Menu orientation and focus-management type not obtained');
+        }
+      }
+      // Otherwise, i.e. if the data were not obtained:
+      else {
+        // Report this.
+        console.log('ERROR: Menu data not obtained');
+      }
+    }
+    // Otherwise, i.e. if it does not control exactly 1 menu:
+    else {
+      // Add to the totals.
+      totals[2]++;
+      // If itemization is required:
+      if (withItems) {
+        // Get the XPath of the menu button.
+        const mbXPath = await mbLoc.evaluate(element => window.getXPath(element));
+        // Add an instance to the standard instances.
+        standardInstances.push({
+          ruleID: 'buttonMenu',
+          what: 'Menu button does not control exactly 1 menu',
+          ordinalSeverity: 2,
+          count: 1,
+          catalogIndex: getXPathCatalogIndex(report, mbXPath as string)
+        });
+      }
+    }
+  }
+  // If itemization is not required and there are any instances:
+  if (! withItems && totals[2]) {
+    // Add a summary instance to the result.
+    standardInstances.push({
+      ruleID: 'buttonMenu',
+      what: 'Menu buttons and menus behave nonstandardly',
+      count: totals[2],
+      ordinalSeverity: 2
+    });
+  }
+  return {
+    data,
+    totals,
+    standardInstances
+  };
+};

--- a/testaro/tabNav.d.ts
+++ b/testaro/tabNav.d.ts
@@ -1,0 +1,33 @@
+import type { Page } from 'playwright';
+import type { Report, StandardInstance } from '../types';
+interface NavTally {
+    total: number;
+    correct: number;
+    incorrect: number;
+}
+interface TabItemData {
+    xPath?: string | null;
+    navigationErrors?: string[];
+    text?: string;
+}
+interface TabNavData {
+    totals: {
+        navigations: {
+            all: NavTally;
+            specific: Record<string, NavTally>;
+        };
+        tabElements: NavTally;
+        tabLists: NavTally;
+    };
+    tabElements?: {
+        incorrect: TabItemData[];
+        correct: TabItemData[];
+    };
+    prevented?: boolean;
+}
+export declare const reporter: (page: Page, report: Report, _: unknown, withItems: boolean) => Promise<{
+    data: TabNavData;
+    totals: number[];
+    standardInstances: StandardInstance[];
+}>;
+export {};

--- a/testaro/tabNav.js
+++ b/testaro/tabNav.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2021–2024 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -8,391 +9,320 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+// Shared configuration for timeout multiplier.
+const config_1 = require("../procs/config");
+const xPath_1 = require("../procs/xPath");
 /*
   tabNav
   This test reports nonstandard keyboard navigation among tab elements in visible tab lists. Standards are based on https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel.
+  Compiled to tabNav.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-// Shared configuration for timeout multiplier.
-const {applyMultiplier} = require('../procs/config');
-const {getXPathCatalogIndex} = require('../procs/xPath');
-
 // CONSTANTS
-
+// The cast types the object that reporter populates before the other functions read it.
 const data = {};
-
 // FUNCTIONS
-
 // Returns the index of the focused tab in an array of tabs.
 const focusedTab = async (tabs, page) => await page.evaluate(tabs => {
-  const focus = document.activeElement;
-  return tabs.indexOf(focus);
+    const focus = document.activeElement;
+    return tabs.indexOf(focus);
 }, tabs)
-.catch(error => {
-  console.log(`ERROR: could not find focused tab (${error.message})`);
-  return -1;
+    .catch(error => {
+    console.log(`ERROR: could not find focused tab (${error.message})`);
+    return -1;
 });
 // Tests a navigation on a focused tab element.
-const testKey = async (
-  tabs, tabElement, keyName, keyProp, goodIndex, elementIsCorrect, itemData, withItems, page
-) => {
-  let pressed = true;
-  // Click the tab element, to make the focus on it effective.
-  await tabElement.click({
-    timeout: applyMultiplier(500)
-  })
-  .catch(async error => {
-    console.log(
-      `ERROR clicking tab element ${itemData.text} (${error.message.replace(/\n.+/s, '')})`
-    );
+const testKey = async (tabs, tabElement, keyName, keyProp, goodIndex, elementIsCorrect, itemData, withItems, page) => {
+    let pressed = true;
+    // Click the tab element, to make the focus on it effective.
     await tabElement.click({
-      force: true
-    });
-  })
-  .catch(error => {
-    console.log(
-      `ERROR force-clicking tab element ${itemData.text} (${error.message.replace(/\n.+/s, '')})`
-    );
-    pressed = false;
-  });
-  // Increment the counts of navigations and key navigations.
-  data.totals.navigations.all.total++;
-  data.totals.navigations.specific[keyProp].total++;
-  const {navigationErrors} = itemData;
-  // If the click succeeded:
-  if (pressed) {
-    // Refocus the tab element and press the specified key (page.keyboard.press may fail).
-    await tabElement.press(keyName, {
-      timeout: applyMultiplier(1000)
+        timeout: (0, config_1.applyMultiplier)(500)
     })
-    .catch(error => {
-      console.log(`ERROR: could not press ${keyName} (${error.message})`);
-      pressed = false;
+        .catch(async (error) => {
+        console.log(`ERROR clicking tab element ${itemData.text} (${error.message.replace(/\n.+/s, '')})`);
+        await tabElement.click({
+            force: true
+        });
+    })
+        .catch(error => {
+        console.log(`ERROR force-clicking tab element ${itemData.text} (${error.message.replace(/\n.+/s, '')})`);
+        pressed = false;
     });
-    // If the refocus and keypress succeeded:
+    // Increment the counts of navigations and key navigations.
+    data.totals.navigations.all.total++;
+    data.totals.navigations.specific[keyProp].total++;
+    const { navigationErrors } = itemData;
+    // If the click succeeded:
     if (pressed) {
-      // Identify which tab element is now focused, if any.
-      const focusIndex = await focusedTab(tabs, page);
-      // If the focus is correct:
-      if (focusIndex === goodIndex) {
-        // Increment the counts of correct navigations and correct key navigations.
-        data.totals.navigations.all.correct++;
-        data.totals.navigations.specific[keyProp].correct++;
-      }
-      // Otherwise, i.e. if the focus is incorrect:
-      else {
+        // Refocus the tab element and press the specified key (page.keyboard.press may fail).
+        await tabElement.press(keyName, {
+            timeout: (0, config_1.applyMultiplier)(1000)
+        })
+            .catch(error => {
+            console.log(`ERROR: could not press ${keyName} (${error.message})`);
+            pressed = false;
+        });
+        // If the refocus and keypress succeeded:
+        if (pressed) {
+            // Identify which tab element is now focused, if any.
+            const focusIndex = await focusedTab(tabs, page);
+            // If the focus is correct:
+            if (focusIndex === goodIndex) {
+                // Increment the counts of correct navigations and correct key navigations.
+                data.totals.navigations.all.correct++;
+                data.totals.navigations.specific[keyProp].correct++;
+            }
+            // Otherwise, i.e. if the focus is incorrect:
+            else {
+                // Increment the counts of incorrect navigations and incorrect key navigations.
+                data.totals.navigations.all.incorrect++;
+                data.totals.navigations.specific[keyProp].incorrect++;
+                // Update the element status to incorrect.
+                elementIsCorrect = false;
+                // If itemization is required:
+                if (withItems) {
+                    // Update the element report.
+                    navigationErrors.push(keyName);
+                }
+            }
+            return elementIsCorrect;
+        }
+        // Otherwise, i.e. if the refocus or keypress failed:
+        else {
+            // Increment the counts of incorrect navigations and incorrect key navigations.
+            data.totals.navigations.all.incorrect++;
+            data.totals.navigations.specific[keyProp].incorrect++;
+            // If itemization is required and a focus failure has not yet been reported:
+            if (withItems && !navigationErrors.includes('focus')) {
+                // Update the element report.
+                navigationErrors.push('focus');
+            }
+            return false;
+        }
+    }
+    // Otherwise, i.e. if the click failed:
+    else {
         // Increment the counts of incorrect navigations and incorrect key navigations.
         data.totals.navigations.all.incorrect++;
         data.totals.navigations.specific[keyProp].incorrect++;
-        // Update the element status to incorrect.
-        elementIsCorrect = false;
-        // If itemization is required:
-        if (withItems) {
-          // Update the element report.
-          navigationErrors.push(keyName);
+        // If itemization is required and a click failure has not yet been reported:
+        if (withItems && !navigationErrors.includes('click')) {
+            // Update the element report.
+            navigationErrors.push('click');
         }
-      }
-      return elementIsCorrect;
+        return false;
     }
-    // Otherwise, i.e. if the refocus or keypress failed:
-    else {
-      // Increment the counts of incorrect navigations and incorrect key navigations.
-      data.totals.navigations.all.incorrect++;
-      data.totals.navigations.specific[keyProp].incorrect++;
-      // If itemization is required and a focus failure has not yet been reported:
-      if (withItems && ! navigationErrors.includes('focus')) {
-        // Update the element report.
-        navigationErrors.push('focus');
-      }
-      return false;
-    }
-  }
-  // Otherwise, i.e. if the click failed:
-  else {
-    // Increment the counts of incorrect navigations and incorrect key navigations.
-    data.totals.navigations.all.incorrect++;
-    data.totals.navigations.specific[keyProp].incorrect++;
-    // If itemization is required and a click failure has not yet been reported:
-    if (withItems && ! navigationErrors.includes('click')) {
-      // Update the element report.
-      navigationErrors.push('click');
-    }
-    return false;
-  }
 };
 // Returns the index to which an arrow key should move the focus.
 const arrowTarget = (startIndex, tabCount, orientation, direction) => {
-  if (orientation === 'horizontal') {
-    if (['up', 'down'].includes(direction)) {
-      return startIndex;
+    if (orientation === 'horizontal') {
+        if (['up', 'down'].includes(direction)) {
+            return startIndex;
+        }
+        else if (direction === 'left') {
+            return startIndex ? startIndex - 1 : tabCount - 1;
+        }
+        else if (direction === 'right') {
+            return startIndex === tabCount - 1 ? 0 : startIndex + 1;
+        }
     }
-    else if (direction === 'left') {
-      return startIndex ? startIndex - 1 : tabCount - 1;
+    else if (orientation === 'vertical') {
+        if (['left', 'right'].includes(direction)) {
+            return startIndex;
+        }
+        else if (direction === 'up') {
+            return startIndex ? startIndex - 1 : tabCount - 1;
+        }
+        else if (direction === 'down') {
+            return startIndex === tabCount - 1 ? 0 : startIndex + 1;
+        }
     }
-    else if (direction === 'right') {
-      return startIndex === tabCount - 1 ? 0 : startIndex + 1;
-    }
-  }
-  else if (orientation === 'vertical') {
-    if (['left', 'right'].includes(direction)) {
-      return startIndex;
-    }
-    else if (direction === 'up') {
-      return startIndex ? startIndex - 1 : tabCount - 1;
-    }
-    else if (direction === 'down') {
-      return startIndex === tabCount - 1 ? 0 : startIndex + 1;
-    }
-  }
 };
 /*
   Recursively tests tablist tab elements (per
   https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel)
 */
 const testTabs = async (tabs, index, listOrientation, listIsCorrect, withItems, page) => {
-  const tabCount = tabs.length;
-  // If any tab elements remain to be tested:
-  if (index < tabCount) {
-    // Increment the reported count of tab elements.
-    data.totals.tabElements.total++;
-    // Identify the tab element to be tested.
-    const currentTab = tabs[index];
-    // Initialize it as correct.
-    let isCorrect = true;
-    const itemData = {};
-    // If itemization is required:
-    if (withItems) {
-      // Initialize data on the element.
-      itemData.xPath = await page.evaluate(element => window.getXPath(element), currentTab);
-      itemData.navigationErrors = [];
+    const tabCount = tabs.length;
+    // If any tab elements remain to be tested:
+    if (index < tabCount) {
+        // Increment the reported count of tab elements.
+        data.totals.tabElements.total++;
+        // Identify the tab element to be tested.
+        const currentTab = tabs[index];
+        // Initialize it as correct.
+        let isCorrect = true;
+        const itemData = {};
+        // If itemization is required:
+        if (withItems) {
+            // Initialize data on the element.
+            itemData.xPath = await page.evaluate(element => window.getXPath(element), currentTab);
+            itemData.navigationErrors = [];
+        }
+        // Test the element with each navigation key.
+        isCorrect = await testKey(tabs, currentTab, 'Tab', 'tab', -1, isCorrect, itemData, withItems, page);
+        isCorrect = await testKey(tabs, currentTab, 'ArrowLeft', 'left', arrowTarget(index, tabCount, listOrientation, 'left'), isCorrect, itemData, withItems, page);
+        isCorrect = await testKey(tabs, currentTab, 'ArrowRight', 'right', arrowTarget(index, tabCount, listOrientation, 'right'), isCorrect, itemData, withItems, page);
+        isCorrect = await testKey(tabs, currentTab, 'ArrowUp', 'up', arrowTarget(index, tabCount, listOrientation, 'up'), isCorrect, itemData, withItems, page);
+        isCorrect = await testKey(tabs, currentTab, 'ArrowDown', 'down', arrowTarget(index, tabCount, listOrientation, 'down'), isCorrect, itemData, withItems, page);
+        isCorrect = await testKey(tabs, currentTab, 'Home', 'home', 0, isCorrect, itemData, withItems, page);
+        isCorrect = await testKey(tabs, currentTab, 'End', 'end', tabCount - 1, isCorrect, itemData, withItems, page);
+        // Update the tablist status (Node 14 does not support the ES 2021 &&= operator).
+        listIsCorrect = listIsCorrect && isCorrect;
+        // Increment the data.
+        data.totals.tabElements[isCorrect ? 'correct' : 'incorrect']++;
+        if (withItems) {
+            data.tabElements[isCorrect ? 'correct' : 'incorrect'].push(itemData);
+        }
+        // Process the next tab element.
+        return await testTabs(tabs, index + 1, listOrientation, listIsCorrect, withItems, page);
     }
-    // Test the element with each navigation key.
-    isCorrect = await testKey(
-      tabs,
-      currentTab,
-      'Tab',
-      'tab',
-      -1,
-      isCorrect,
-      itemData,
-      withItems,
-      page
-    );
-    isCorrect = await testKey(
-      tabs,
-      currentTab,
-      'ArrowLeft',
-      'left',
-      arrowTarget(index, tabCount, listOrientation, 'left'),
-      isCorrect,
-      itemData,
-      withItems,
-      page
-    );
-    isCorrect = await testKey(
-      tabs,
-      currentTab,
-      'ArrowRight',
-      'right',
-      arrowTarget(index, tabCount, listOrientation, 'right'),
-      isCorrect,
-      itemData,
-      withItems,
-      page
-    );
-    isCorrect = await testKey(
-      tabs,
-      currentTab,
-      'ArrowUp',
-      'up',
-      arrowTarget(index, tabCount, listOrientation, 'up'),
-      isCorrect,
-      itemData,
-      withItems,
-      page
-    );
-    isCorrect = await testKey(
-      tabs,
-      currentTab,
-      'ArrowDown',
-      'down',
-      arrowTarget(index, tabCount, listOrientation, 'down'),
-      isCorrect,
-      itemData,
-      withItems,
-      page
-    );
-    isCorrect = await testKey(
-      tabs,
-      currentTab,
-      'Home',
-      'home',
-      0,
-      isCorrect,
-      itemData,
-      withItems,
-      page
-    );
-    isCorrect = await testKey(
-      tabs, currentTab, 'End', 'end', tabCount - 1, isCorrect, itemData, withItems, page
-    );
-    // Update the tablist status (Node 14 does not support the ES 2021 &&= operator).
-    listIsCorrect = listIsCorrect && isCorrect;
-    // Increment the data.
-    data.totals.tabElements[isCorrect ? 'correct' : 'incorrect']++;
-    if (withItems) {
-      data.tabElements[isCorrect ? 'correct' : 'incorrect'].push(itemData);
+    // Otherwise, i.e. if all tab elements have been tested:
+    else {
+        // Return whether the tablist is correct.
+        return listIsCorrect;
     }
-    // Process the next tab element.
-    return await testTabs(tabs, index + 1, listOrientation, listIsCorrect, withItems, page);
-  }
-  // Otherwise, i.e. if all tab elements have been tested:
-  else {
-    // Return whether the tablist is correct.
-    return listIsCorrect;
-  }
 };
 // Recursively tests tablists.
 const testTabLists = async (tabLists, withItems, page) => {
-  // If any tablists remain to be tested:
-  if (tabLists.length) {
-    const firstTabList = tabLists[0];
-    let orientation = await firstTabList.getAttribute('aria-orientation')
-    .catch(error=> {
-      console.log(`ERROR: could not get tab-list orientation (${error.message})`);
-      return 'ERROR';
-    });
-    if (! orientation) {
-      orientation = 'horizontal';
+    // If any tablists remain to be tested:
+    if (tabLists.length) {
+        const firstTabList = tabLists[0];
+        let orientation = await firstTabList.getAttribute('aria-orientation')
+            .catch(error => {
+            console.log(`ERROR: could not get tab-list orientation (${error.message})`);
+            return 'ERROR';
+        });
+        if (!orientation) {
+            orientation = 'horizontal';
+        }
+        if (orientation === 'ERROR') {
+            data.prevented = true;
+        }
+        else {
+            const tabs = await firstTabList.$$('[role=tab]');
+            // If the tablist contains at least 2 tab elements:
+            if (tabs.length > 1) {
+                // Test them.
+                const isCorrect = await testTabs(tabs, 0, orientation, true, withItems, page);
+                // Increment the data.
+                data.totals.tabLists.total++;
+                data.totals.tabLists[isCorrect ? 'correct' : 'incorrect']++;
+                // Process the remaining tablists.
+                await testTabLists(tabLists.slice(1), withItems, page);
+            }
+        }
     }
-    if (orientation === 'ERROR') {
-      data.prevented = true;
-    }
-    else {
-      const tabs = await firstTabList.$$('[role=tab]');
-      // If the tablist contains at least 2 tab elements:
-      if (tabs.length > 1) {
-        // Test them.
-        const isCorrect = await testTabs(tabs, 0, orientation, true, withItems, page);
-        // Increment the data.
-        data.totals.tabLists.total++;
-        data.totals.tabLists[isCorrect ? 'correct' : 'incorrect']++;
-        // Process the remaining tablists.
-        await testTabLists(tabLists.slice(1), withItems, page);
-      }
-    }
-  }
 };
 // Runs the test and returns the result.
-exports.reporter = async (page, report, _, withItems) => {
-  // Initialize the results.
-  data.totals = {
-    navigations: {
-      all: {
-        total: 0,
-        correct: 0,
-        incorrect: 0
-      },
-      specific: {
-        tab: {
-          total: 0,
-          correct: 0,
-          incorrect: 0
+const reporter = async (page, report, _, withItems) => {
+    // Initialize the results.
+    data.totals = {
+        navigations: {
+            all: {
+                total: 0,
+                correct: 0,
+                incorrect: 0
+            },
+            specific: {
+                tab: {
+                    total: 0,
+                    correct: 0,
+                    incorrect: 0
+                },
+                left: {
+                    total: 0,
+                    correct: 0,
+                    incorrect: 0
+                },
+                right: {
+                    total: 0,
+                    correct: 0,
+                    incorrect: 0
+                },
+                up: {
+                    total: 0,
+                    correct: 0,
+                    incorrect: 0
+                },
+                down: {
+                    total: 0,
+                    correct: 0,
+                    incorrect: 0
+                },
+                home: {
+                    total: 0,
+                    correct: 0,
+                    incorrect: 0
+                },
+                end: {
+                    total: 0,
+                    correct: 0,
+                    incorrect: 0
+                }
+            }
         },
-        left: {
-          total: 0,
-          correct: 0,
-          incorrect: 0
+        tabElements: {
+            total: 0,
+            correct: 0,
+            incorrect: 0
         },
-        right: {
-          total: 0,
-          correct: 0,
-          incorrect: 0
-        },
-        up: {
-          total: 0,
-          correct: 0,
-          incorrect: 0
-        },
-        down: {
-          total: 0,
-          correct: 0,
-          incorrect: 0
-        },
-        home: {
-          total: 0,
-          correct: 0,
-          incorrect: 0
-        },
-        end: {
-          total: 0,
-          correct: 0,
-          incorrect: 0
+        tabLists: {
+            total: 0,
+            correct: 0,
+            incorrect: 0
         }
-      }
-    },
-    tabElements: {
-      total: 0,
-      correct: 0,
-      incorrect: 0
-    },
-    tabLists: {
-      total: 0,
-      correct: 0,
-      incorrect: 0
-    }
-  };
-  if (withItems) {
-    data.tabElements = {
-      incorrect: [],
-      correct: []
     };
-  }
-  // Get an array of element handles for the visible tablists.
-  const tabLists = await page.$$('[role=tablist]:visible');
-  if (tabLists.length) {
-    await testTabLists(tabLists, withItems, page);
-  }
-  // Get the totals of navigation errors, bad tabs, and bad tab lists.
-  const totals = data.totals ? [
-    data.totals.navigations.all.incorrect,
-    data.totals.tabElements.incorrect,
-    data.totals.tabLists.incorrect,
-    0
-  ] : [];
-  // Initialize the standard instances.
-  const standardInstances = [];
-  // If itemization is required:
-  if (withItems) {
-    // For each bad tab:
-    data.tabElements.incorrect.forEach(item => {
-      // Add an instance to the standard instances.
-      standardInstances.push({
-        ruleID: 'tabNav',
-        what: `Tab responds nonstandardly to ${item.navigationErrors.join(', ')}`,
-        ordinalSeverity: 1,
-        count: 1,
-        catalogIndex: getXPathCatalogIndex(report, item.xPath)
-      });
-    });
-  }
-  // Otherwise, if navigation is not required and any navigations were bad:
-  else if (data.totals.navigations.all.incorrect) {
-    // Add a summary instance to the standard instances.
-    standardInstances.push({
-      ruleID: 'tabNav',
-      what: 'Tab lists have nonstandard navigation',
-      ordinalSeverity: 1,
-      count: data.totals.navigations.all.incorrect
-    });
-  }
-  // Return the result.
-  return {
-    data,
-    totals,
-    standardInstances
-  };
+    if (withItems) {
+        data.tabElements = {
+            incorrect: [],
+            correct: []
+        };
+    }
+    // Get an array of element handles for the visible tablists.
+    const tabLists = await page.$$('[role=tablist]:visible');
+    if (tabLists.length) {
+        await testTabLists(tabLists, withItems, page);
+    }
+    // Get the totals of navigation errors, bad tabs, and bad tab lists.
+    const totals = data.totals ? [
+        data.totals.navigations.all.incorrect,
+        data.totals.tabElements.incorrect,
+        data.totals.tabLists.incorrect,
+        0
+    ] : [];
+    // Initialize the standard instances.
+    const standardInstances = [];
+    // If itemization is required:
+    if (withItems) {
+        // For each bad tab:
+        data.tabElements.incorrect.forEach(item => {
+            // Add an instance to the standard instances.
+            standardInstances.push({
+                ruleID: 'tabNav',
+                what: `Tab responds nonstandardly to ${item.navigationErrors.join(', ')}`,
+                ordinalSeverity: 1,
+                count: 1,
+                catalogIndex: (0, xPath_1.getXPathCatalogIndex)(report, item.xPath)
+            });
+        });
+    }
+    // Otherwise, if navigation is not required and any navigations were bad:
+    else if (data.totals.navigations.all.incorrect) {
+        // Add a summary instance to the standard instances.
+        standardInstances.push({
+            ruleID: 'tabNav',
+            what: 'Tab lists have nonstandard navigation',
+            ordinalSeverity: 1,
+            count: data.totals.navigations.all.incorrect
+        });
+    }
+    // Return the result.
+    return {
+        data,
+        totals,
+        standardInstances
+    };
 };
+exports.reporter = reporter;

--- a/testaro/tabNav.ts
+++ b/testaro/tabNav.ts
@@ -1,0 +1,454 @@
+/*
+  © 2021–2024 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {ElementHandle, Page} from 'playwright';
+// Shared configuration for timeout multiplier.
+import {applyMultiplier} from '../procs/config';
+import {getXPathCatalogIndex} from '../procs/xPath';
+import type {Report, StandardInstance} from '../types';
+
+// TYPES
+
+// A handle for a tab or tablist element.
+type Handle = ElementHandle<SVGElement | HTMLElement>;
+// Counts of navigations or elements, total and by correctness.
+interface NavTally {
+  total: number;
+  correct: number;
+  incorrect: number;
+}
+// Data on one tested tab element.
+interface TabItemData {
+  xPath?: string | null;
+  navigationErrors?: string[];
+  // Referenced in click-failure log messages but never assigned, so those logs print
+  // undefined; verbatim from the original.
+  text?: string;
+}
+// The module-level result data, populated once per reporter call.
+interface TabNavData {
+  totals: {
+    navigations: {
+      all: NavTally;
+      specific: Record<string, NavTally>;
+    };
+    tabElements: NavTally;
+    tabLists: NavTally;
+  };
+  tabElements?: {
+    incorrect: TabItemData[];
+    correct: TabItemData[];
+  };
+  prevented?: boolean;
+}
+
+/*
+  tabNav
+  This test reports nonstandard keyboard navigation among tab elements in visible tab lists. Standards are based on https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel.
+  Compiled to tabNav.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// CONSTANTS
+
+// The cast types the object that reporter populates before the other functions read it.
+const data = {} as TabNavData;
+
+// FUNCTIONS
+
+// Returns the index of the focused tab in an array of tabs.
+const focusedTab = async (tabs: Handle[], page: Page) => await page.evaluate(tabs => {
+  const focus = document.activeElement;
+  return tabs.indexOf(focus as SVGElement | HTMLElement);
+}, tabs)
+.catch(error => {
+  console.log(`ERROR: could not find focused tab (${error.message})`);
+  return -1;
+});
+// Tests a navigation on a focused tab element.
+const testKey = async (
+  tabs: Handle[],
+  tabElement: Handle,
+  keyName: string,
+  keyProp: string,
+  goodIndex: number | undefined,
+  elementIsCorrect: boolean,
+  itemData: TabItemData,
+  withItems: boolean,
+  page: Page
+) => {
+  let pressed = true;
+  // Click the tab element, to make the focus on it effective.
+  await tabElement.click({
+    timeout: applyMultiplier(500)
+  })
+  .catch(async error => {
+    console.log(
+      `ERROR clicking tab element ${itemData.text} (${error.message.replace(/\n.+/s, '')})`
+    );
+    await tabElement.click({
+      force: true
+    });
+  })
+  .catch(error => {
+    console.log(
+      `ERROR force-clicking tab element ${itemData.text} (${error.message.replace(/\n.+/s, '')})`
+    );
+    pressed = false;
+  });
+  // Increment the counts of navigations and key navigations.
+  data.totals.navigations.all.total++;
+  data.totals.navigations.specific[keyProp].total++;
+  const {navigationErrors} = itemData;
+  // If the click succeeded:
+  if (pressed) {
+    // Refocus the tab element and press the specified key (page.keyboard.press may fail).
+    await tabElement.press(keyName, {
+      timeout: applyMultiplier(1000)
+    })
+    .catch(error => {
+      console.log(`ERROR: could not press ${keyName} (${error.message})`);
+      pressed = false;
+    });
+    // If the refocus and keypress succeeded:
+    if (pressed) {
+      // Identify which tab element is now focused, if any.
+      const focusIndex = await focusedTab(tabs, page);
+      // If the focus is correct:
+      if (focusIndex === goodIndex) {
+        // Increment the counts of correct navigations and correct key navigations.
+        data.totals.navigations.all.correct++;
+        data.totals.navigations.specific[keyProp].correct++;
+      }
+      // Otherwise, i.e. if the focus is incorrect:
+      else {
+        // Increment the counts of incorrect navigations and incorrect key navigations.
+        data.totals.navigations.all.incorrect++;
+        data.totals.navigations.specific[keyProp].incorrect++;
+        // Update the element status to incorrect.
+        elementIsCorrect = false;
+        // If itemization is required:
+        if (withItems) {
+          // Update the element report.
+          navigationErrors!.push(keyName);
+        }
+      }
+      return elementIsCorrect;
+    }
+    // Otherwise, i.e. if the refocus or keypress failed:
+    else {
+      // Increment the counts of incorrect navigations and incorrect key navigations.
+      data.totals.navigations.all.incorrect++;
+      data.totals.navigations.specific[keyProp].incorrect++;
+      // If itemization is required and a focus failure has not yet been reported:
+      if (withItems && ! navigationErrors!.includes('focus')) {
+        // Update the element report.
+        navigationErrors!.push('focus');
+      }
+      return false;
+    }
+  }
+  // Otherwise, i.e. if the click failed:
+  else {
+    // Increment the counts of incorrect navigations and incorrect key navigations.
+    data.totals.navigations.all.incorrect++;
+    data.totals.navigations.specific[keyProp].incorrect++;
+    // If itemization is required and a click failure has not yet been reported:
+    if (withItems && ! navigationErrors!.includes('click')) {
+      // Update the element report.
+      navigationErrors!.push('click');
+    }
+    return false;
+  }
+};
+// Returns the index to which an arrow key should move the focus.
+const arrowTarget = (
+  startIndex: number, tabCount: number, orientation: string, direction: string
+) => {
+  if (orientation === 'horizontal') {
+    if (['up', 'down'].includes(direction)) {
+      return startIndex;
+    }
+    else if (direction === 'left') {
+      return startIndex ? startIndex - 1 : tabCount - 1;
+    }
+    else if (direction === 'right') {
+      return startIndex === tabCount - 1 ? 0 : startIndex + 1;
+    }
+  }
+  else if (orientation === 'vertical') {
+    if (['left', 'right'].includes(direction)) {
+      return startIndex;
+    }
+    else if (direction === 'up') {
+      return startIndex ? startIndex - 1 : tabCount - 1;
+    }
+    else if (direction === 'down') {
+      return startIndex === tabCount - 1 ? 0 : startIndex + 1;
+    }
+  }
+};
+/*
+  Recursively tests tablist tab elements (per
+  https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel)
+*/
+const testTabs = async (
+  tabs: Handle[],
+  index: number,
+  listOrientation: string,
+  listIsCorrect: boolean,
+  withItems: boolean,
+  page: Page
+): Promise<boolean> => {
+  const tabCount = tabs.length;
+  // If any tab elements remain to be tested:
+  if (index < tabCount) {
+    // Increment the reported count of tab elements.
+    data.totals.tabElements.total++;
+    // Identify the tab element to be tested.
+    const currentTab = tabs[index];
+    // Initialize it as correct.
+    let isCorrect = true;
+    const itemData: TabItemData = {};
+    // If itemization is required:
+    if (withItems) {
+      // Initialize data on the element.
+      itemData.xPath = await page.evaluate(element => window.getXPath(element), currentTab);
+      itemData.navigationErrors = [];
+    }
+    // Test the element with each navigation key.
+    isCorrect = await testKey(
+      tabs,
+      currentTab,
+      'Tab',
+      'tab',
+      -1,
+      isCorrect,
+      itemData,
+      withItems,
+      page
+    );
+    isCorrect = await testKey(
+      tabs,
+      currentTab,
+      'ArrowLeft',
+      'left',
+      arrowTarget(index, tabCount, listOrientation, 'left'),
+      isCorrect,
+      itemData,
+      withItems,
+      page
+    );
+    isCorrect = await testKey(
+      tabs,
+      currentTab,
+      'ArrowRight',
+      'right',
+      arrowTarget(index, tabCount, listOrientation, 'right'),
+      isCorrect,
+      itemData,
+      withItems,
+      page
+    );
+    isCorrect = await testKey(
+      tabs,
+      currentTab,
+      'ArrowUp',
+      'up',
+      arrowTarget(index, tabCount, listOrientation, 'up'),
+      isCorrect,
+      itemData,
+      withItems,
+      page
+    );
+    isCorrect = await testKey(
+      tabs,
+      currentTab,
+      'ArrowDown',
+      'down',
+      arrowTarget(index, tabCount, listOrientation, 'down'),
+      isCorrect,
+      itemData,
+      withItems,
+      page
+    );
+    isCorrect = await testKey(
+      tabs,
+      currentTab,
+      'Home',
+      'home',
+      0,
+      isCorrect,
+      itemData,
+      withItems,
+      page
+    );
+    isCorrect = await testKey(
+      tabs, currentTab, 'End', 'end', tabCount - 1, isCorrect, itemData, withItems, page
+    );
+    // Update the tablist status (Node 14 does not support the ES 2021 &&= operator).
+    listIsCorrect = listIsCorrect && isCorrect;
+    // Increment the data.
+    data.totals.tabElements[isCorrect ? 'correct' : 'incorrect']++;
+    if (withItems) {
+      data.tabElements![isCorrect ? 'correct' : 'incorrect'].push(itemData);
+    }
+    // Process the next tab element.
+    return await testTabs(tabs, index + 1, listOrientation, listIsCorrect, withItems, page);
+  }
+  // Otherwise, i.e. if all tab elements have been tested:
+  else {
+    // Return whether the tablist is correct.
+    return listIsCorrect;
+  }
+};
+// Recursively tests tablists.
+const testTabLists = async (tabLists: Handle[], withItems: boolean, page: Page): Promise<void> => {
+  // If any tablists remain to be tested:
+  if (tabLists.length) {
+    const firstTabList = tabLists[0];
+    let orientation = await firstTabList.getAttribute('aria-orientation')
+    .catch(error=> {
+      console.log(`ERROR: could not get tab-list orientation (${error.message})`);
+      return 'ERROR';
+    });
+    if (! orientation) {
+      orientation = 'horizontal';
+    }
+    if (orientation === 'ERROR') {
+      data.prevented = true;
+    }
+    else {
+      const tabs = await firstTabList.$$('[role=tab]');
+      // If the tablist contains at least 2 tab elements:
+      if (tabs.length > 1) {
+        // Test them.
+        const isCorrect = await testTabs(tabs, 0, orientation, true, withItems, page);
+        // Increment the data.
+        data.totals.tabLists.total++;
+        data.totals.tabLists[isCorrect ? 'correct' : 'incorrect']++;
+        // Process the remaining tablists.
+        await testTabLists(tabLists.slice(1), withItems, page);
+      }
+    }
+  }
+};
+// Runs the test and returns the result.
+export const reporter = async (page: Page, report: Report, _: unknown, withItems: boolean) => {
+  // Initialize the results.
+  data.totals = {
+    navigations: {
+      all: {
+        total: 0,
+        correct: 0,
+        incorrect: 0
+      },
+      specific: {
+        tab: {
+          total: 0,
+          correct: 0,
+          incorrect: 0
+        },
+        left: {
+          total: 0,
+          correct: 0,
+          incorrect: 0
+        },
+        right: {
+          total: 0,
+          correct: 0,
+          incorrect: 0
+        },
+        up: {
+          total: 0,
+          correct: 0,
+          incorrect: 0
+        },
+        down: {
+          total: 0,
+          correct: 0,
+          incorrect: 0
+        },
+        home: {
+          total: 0,
+          correct: 0,
+          incorrect: 0
+        },
+        end: {
+          total: 0,
+          correct: 0,
+          incorrect: 0
+        }
+      }
+    },
+    tabElements: {
+      total: 0,
+      correct: 0,
+      incorrect: 0
+    },
+    tabLists: {
+      total: 0,
+      correct: 0,
+      incorrect: 0
+    }
+  };
+  if (withItems) {
+    data.tabElements = {
+      incorrect: [],
+      correct: []
+    };
+  }
+  // Get an array of element handles for the visible tablists.
+  const tabLists = await page.$$('[role=tablist]:visible');
+  if (tabLists.length) {
+    await testTabLists(tabLists, withItems, page);
+  }
+  // Get the totals of navigation errors, bad tabs, and bad tab lists.
+  const totals = data.totals ? [
+    data.totals.navigations.all.incorrect,
+    data.totals.tabElements.incorrect,
+    data.totals.tabLists.incorrect,
+    0
+  ] : [];
+  // Initialize the standard instances.
+  const standardInstances: StandardInstance[] = [];
+  // If itemization is required:
+  if (withItems) {
+    // For each bad tab:
+    data.tabElements!.incorrect.forEach(item => {
+      // Add an instance to the standard instances.
+      standardInstances.push({
+        ruleID: 'tabNav',
+        what: `Tab responds nonstandardly to ${item.navigationErrors!.join(', ')}`,
+        ordinalSeverity: 1,
+        count: 1,
+        catalogIndex: getXPathCatalogIndex(report, item.xPath as string)
+      });
+    });
+  }
+  // Otherwise, if navigation is not required and any navigations were bad:
+  else if (data.totals.navigations.all.incorrect) {
+    // Add a summary instance to the standard instances.
+    standardInstances.push({
+      ruleID: 'tabNav',
+      what: 'Tab lists have nonstandard navigation',
+      ordinalSeverity: 1,
+      count: data.totals.navigations.all.incorrect
+    });
+  }
+  // Return the result.
+  return {
+    data,
+    totals,
+    standardInstances
+  };
+};


### PR DESCRIPTION
Phase 2, batch 7 of the migration on #73: `buttonMenu` and `tabNav`, the two largest bespoke reporters — **completing the conversion of all 52 rule modules**. Same contract as #103–#107/#109: strict TypeScript, committed in-place emit, no behavior change.

Pattern notes:

- `buttonMenu` gains `LocatorData`/`LocatorLocation` interfaces for its locator-data helper; the `spec` union (`string | Record<string, number>`) reflects the three shapes the runtime actually produces. The `aria-expanded` boolean `setAttribute` and the unguarded `activeElement` dereference are preserved verbatim with erased casts and comments.
- `tabNav`'s module-level mutable `data` object is typed with one erased cast (`{} as TabNavData`), so its many access sites typecheck without runtime change; `ElementHandle` arrays are typed with a `Handle` alias.

## Pre-existing quirks surfaced (preserved verbatim, commented in-code)

- `buttonMenu` line ~260: the `'+'` trial-key spec on a **horizontal** menu pushes the misspelled key `'ArrowtRight'`, which Playwright's `press` would reject. The validator's pinned trial keys only exercise vertical menus, so this has never fired there. Filing separately.
- `tabNav`'s click-failure log messages interpolate `itemData.text`, which nothing ever assigns — those logs print `undefined`.

## Verification

- `tsc` green; committed emit matches (CI drift gate); `node --check` sweep green.
- Emitted-vs-original token diffs reviewed for both.
- End-to-end validators for both rules (the `buttonMenu` validator pins its trial keys, so both are deterministic) on this branch vs current `main`: byte-identical output on both (timestamps and per-run timing strings normalized).

With this PR, Phase 2's rule-module conversion is complete: 52 of 52 rules are strict TypeScript. Next: the typed rule registry with the `tests/testaro.js` conversion (the Phase 2/3 boundary recorded on #73).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
