### PR TITLE
fix: deterministic list-link representative in styleDiff (#113)

### DIFF
--- a/testaro/styleDiff.js
+++ b/testaro/styleDiff.js
@@ -62,12 +62,13 @@ const linksByType = async (page) => await page.evaluateHandle(() => {
     lists.forEach(list => {
         // If it is a list of links:
         if (isLinkList(list)) {
-            // Choose one of the links randomly, assuming they have uniform styles.
+            // Choose the first link as the representative, assuming the links have uniform styles.
+            // A deterministic choice makes results reproducible on pages that violate the
+            // assumption, where a random choice made totals vary run to run (issue #113).
             const links = Array.from(list.querySelectorAll('a'));
-            const randomIndex = Math.floor(Math.random() * links.length);
-            const randomLink = links[randomIndex];
+            const firstLink = links[0];
             // Add it to the array.
-            listLinks.push(randomLink);
+            listLinks.push(firstLink);
         }
     });
     // Identify the inline links in the page.

--- a/testaro/styleDiff.ts
+++ b/testaro/styleDiff.ts
@@ -75,12 +75,13 @@ const linksByType = async (page: Page) => await page.evaluateHandle(() => {
   lists.forEach(list => {
     // If it is a list of links:
     if (isLinkList(list)) {
-      // Choose one of the links randomly, assuming they have uniform styles.
+      // Choose the first link as the representative, assuming the links have uniform styles.
+      // A deterministic choice makes results reproducible on pages that violate the
+      // assumption, where a random choice made totals vary run to run (issue #113).
       const links = Array.from(list.querySelectorAll('a'));
-      const randomIndex = Math.floor(Math.random() * links.length);
-      const randomLink = links[randomIndex];
+      const firstLink = links[0];
       // Add it to the array.
-      listLinks.push(randomLink);
+      listLinks.push(firstLink);
     }
   });
   // Identify the inline links in the page.


### PR DESCRIPTION
Fixes #113.

One-line behavior stabilization: `linksByType` now takes the **first** link of each link-list as its representative instead of a random one. Under the rule's stated assumption (uniform list-link styles) every choice is equivalent; on pages that violate the assumption, the random choice made totals vary run to run and made the validator flake ~50% of the time.

## Verification

- Eight consecutive runs of the emitted reporter against `validation/tests/targets/styleDiff/bad.html`: all produce `2+1` adjacent-link subtotals (pre-fix, the same harness produced both `2+1` and `1+1+1` across eight runs).
- Two full `npm test styleDiff` runs: byte-identical to each other (timestamps normalized) and identical to the outcome the existing expectations were written for — the validator's styleDiff-specific expectations now pass deterministically with **no expectation edits**. The 10 remaining failures are the pre-existing v60-style inline-field expectations shared across validators, unrelated to this change.

The separate design question — examining all list links to catch intra-list style diversity deterministically — is noted in #113 and intentionally not part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)