### PR TITLE
fix: engines floor Node >=20.19 (require(esm) dependencies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The main concepts of Testaro are:
 
 ### Operating system and Node.js version
 
-Testaro can be installed under a MacOS, Windows, Debian, or Ubuntu operating system with the latest long-term-support version of [Node.js](https://nodejs.org/en/).
+Testaro can be installed under a MacOS, Windows, Debian, or Ubuntu operating system with the latest long-term-support version of [Node.js](https://nodejs.org/en/). The minimum version is Node 20.19, because some dependencies (the Alfa packages and pixelmatch) are ES modules that Testaro loads with `require()`, which Node supports from 20.19 (and 22.12) onward.
 
 ### Browser security
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
   },
   "types": "./types.d.ts",
   "engines": {
-    "node": ">=20"
+    "node": ">=20.19"
   }
 }


### PR DESCRIPTION
Found during the Phase 3 boundary reassessment on #73: `@siteimprove/alfa-*` and `pixelmatch` are pure ES modules that the CommonJS code loads with `require()`. Node supports `require(esm)` unflagged only from **20.19** / 22.12, so on vanilla Node 20.0–20.18 the alfa adapter and the motion rule throw `ERR_REQUIRE_ESM` even though `engines: {node: ">=20"}` accepts those versions.

Bumps `engines` to `>=20.19` and adds the rationale to the README's version prose (which previously said only "latest LTS").

🤖 Generated with [Claude Code](https://claude.com/claude-code)