### PR TITLE
fix: engines floor Node >=22.12, dropping the EOL Node 20 line

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The main concepts of Testaro are:
 
 ### Operating system and Node.js version
 
-Testaro can be installed under a MacOS, Windows, Debian, or Ubuntu operating system with the latest long-term-support version of [Node.js](https://nodejs.org/en/). The minimum version is Node 20.19, because some dependencies (the Alfa packages and pixelmatch) are ES modules that Testaro loads with `require()`, which Node supports from 20.19 (and 22.12) onward.
+Testaro can be installed under a MacOS, Windows, Debian, or Ubuntu operating system with the latest long-term-support version of [Node.js](https://nodejs.org/en/). The minimum version is Node 22.12: Node 20 reached end of life in April 2026, and some dependencies (the Alfa packages and pixelmatch) are ES modules that Testaro loads with `require()`, which the Node 22 line supports from 22.12 onward. When Node 22 reaches end of life in April 2027, the minimum is expected to rise to Node 24.
 
 ### Browser security
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
   },
   "types": "./types.d.ts",
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   }
 }


### PR DESCRIPTION
Follow-up to #116, per the engines discussion: Node 20 reached end of life in April 2026, so a floor of 20.19 blessed an unmaintained runtime. This raises `engines` to `>=22.12` — the point on the maintained Node 22 LTS line where `require(esm)` is unflagged — and updates the README's rationale, including the expected rise to Node 24 when Node 22 reaches end of life in April 2027.

Deliberately **not** `>=24`: Node 22 is maintained LTS until April 2027 and nothing in the codebase needs anything newer than `require(esm)`, so requiring 24 would exclude supported-LTS consumers of the published package for no code benefit. Fleet deployments (already on Node 24) are unaffected either way.

Compatibility note for the next publish: an engines raise is a compatibility change and belongs in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)