### PR TITLE
TypeScript Phase 3 batch 2: package-consumer tool adapters (issue #73)

### DIFF
--- a/tests/alfa.d.ts
+++ b/tests/alfa.d.ts
@@ -1,0 +1,45 @@
+import type { Page } from 'playwright';
+import type { Report, StandardResult } from '../types';
+interface AlfaEvalItem {
+    diagnostic?: {
+        errors?: {
+            element?: unknown;
+            positionedDescendants?: unknown;
+        }[];
+    };
+    expectations?: {
+        error?: {
+            message?: string;
+        };
+    }[][];
+    outcome: string;
+    rule: {
+        requirements?: {
+            title?: string;
+        }[];
+        uri: string;
+    };
+    target?: {
+        children?: unknown;
+    };
+    code?: string;
+    path?: string;
+}
+interface AlfaNativeResult {
+    totals: {
+        failed: number;
+        cantTell: number;
+    };
+    items: AlfaEvalItem[];
+}
+export declare const reporter: (page: Page, report: Report, actIndex: number) => Promise<{
+    data: {
+        prevented?: boolean;
+        error?: string;
+    };
+    result: {
+        nativeResult: AlfaNativeResult;
+        standardResult: StandardResult;
+    };
+}>;
+export {};

--- a/tests/alfa.js
+++ b/tests/alfa.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2021–2024 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -8,159 +9,163 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const xPath_1 = require("../procs/xPath");
+const config_1 = require("../procs/config");
+/*
+  The alfa packages are pure ESM that Node loads via require(esm); their own
+  types do not resolve under this project's node10 module resolution, so the
+  imports stay requires and are untyped.
+*/
+let alfaRules = require('@siteimprove/alfa-rules').default;
+const { Audit } = require('@siteimprove/alfa-act');
+const { Playwright } = require('@siteimprove/alfa-playwright');
 /*
   alfa
   Implements the alfa ruleset for accessibility.
+  Compiled to alfa.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-let alfaRules = require('@siteimprove/alfa-rules').default;
-const {Audit} = require('@siteimprove/alfa-act');
-const {getNormalizedXPath, getXPathCatalogIndex} = require('../procs/xPath');
-const {Playwright} = require('@siteimprove/alfa-playwright');
-const {applyMultiplier} = require('../procs/config');
-
 // FUNCTIONS
-
 // Conducts and reports the alfa tests.
-exports.reporter = async (page, report, actIndex) => {
-  const act = report.acts[actIndex];
-  const {rules} = act;
-  // If only some rules are to be employed:
-  if (rules && rules.length) {
-    // Remove the other rules.
-    alfaRules = alfaRules.filter(rule => rules.includes(rule.uri.replace(/^.+-/, '')));
-  }
-  // Initialize the act report.
-  const data = {};
-  const result = {
-    nativeResult: {
-      totals: {
-        failed: 0,
-        cantTell: 0
-      },
-      items: []
-    },
-    standardResult: {}
-  };
-  const standard = report.standard !== 'no';
-  // If standard results are to be reported:
-  if (standard) {
-    // Initialize the standard result.
-    result.standardResult = {
-      prevented: false,
-      totals: [0, 0, 0, 0],
-      instances: []
+const reporter = async (page, report, actIndex) => {
+    const act = report.acts[actIndex];
+    const { rules } = act;
+    // If only some rules are to be employed:
+    if (rules && rules.length) {
+        // Remove the other rules.
+        alfaRules = alfaRules.filter((rule) => rules.includes(rule.uri.replace(/^.+-/, '')));
+    }
+    // Initialize the act report.
+    const data = {};
+    const result = {
+        nativeResult: {
+            totals: {
+                failed: 0,
+                cantTell: 0
+            },
+            items: []
+        },
+        standardResult: {}
     };
-  }
-  try {
+    const standard = report.standard !== 'no';
+    // If standard results are to be reported:
+    if (standard) {
+        // Initialize the standard result.
+        result.standardResult = {
+            prevented: false,
+            totals: [0, 0, 0, 0],
+            instances: []
+        };
+    }
     try {
-      // Wait for a stable page to make the page and its alfa version consistent.
-      await page.waitForLoadState('networkidle', {timeout: applyMultiplier(9000)});
-    }
-    // If that fails:
-    catch (error) {
-      // Wait for the page to be loaded.
-      await page.waitForLoadState('domcontentloaded', {timeout: applyMultiplier(6000)});
-    }
-    const doc = await page.evaluateHandle('document');
-    const alfaPage = await Playwright.toPage(doc);
-    // Test the page content with the specified rules.
-    const audit = Audit.of(alfaPage, alfaRules);
-    // Get the evaluations.
-    const evaluations = Array.from(await audit.evaluate());
-    const {nativeResult, standardResult} = result;
-    // For each of them:
-    for (const index in evaluations) {
-      const evaluation = evaluations[index];
-      const targetClass = evaluation.target;
-      // If it has a non-collection violator:
-      if (targetClass && ! targetClass._members) {
-        // Convert the evaluation to an element-specific item.
-        const item = evaluation.toJSON();
-        const {diagnostic, expectations, outcome, rule, target} = item;
-        // If the outcome of the item is a failure or warning:
-        if (['failed', 'cantTell'].includes(outcome)) {
-          // Delete typically massive properties unlikely to be useful.
-          delete target.children;
-          if (diagnostic?.errors) {
-            diagnostic.errors.forEach(error => {
-              delete error.element;
-              delete error.positionedDescendants;
-            });
-          }
-          // Increment the applicable total.
-          nativeResult.totals[outcome]++;
-          const codeLines = targetClass.toString().split('\n');
-          if (codeLines[0] === '#document') {
-            codeLines.splice(2, codeLines.length - 3, ' … ');
-          }
-          else if (codeLines[0].startsWith('<html')) {
-            codeLines.splice(1, codeLines.length - 2, ' … ');
-          }
-          let code = codeLines.join('/n');
-          if (code.length > 400) {
-            code = `${code.slice(0, 300)} … ${code.slice(-100)}`;
-          }
-          // Add properties of the evaluation to the item.
-          item.code = code;
-          item.path = targetClass.path();
-          // Add the item to the items of the native result.
-          nativeResult.items.push(item);
-          // If standard results are to be reported:
-          if (standard) {
-            const {requirements, uri} = rule;
-            // Get the rule ID of the item.
-            let ruleID = uri.replace(/^.+-/, '');
-            // Get the rule description of the item.
-            let what = (expectations?.[0]?.[1]?.error?.message || '').trim().replace(/\s+/g, ' ');
-            if (! what) {
-              if (requirements && requirements.length && requirements[0].title) {
-                what = requirements[0].title;
-              }
-            }
-            // Get the ordinal severity of the item.
-            let ordinalSeverity = 2;
-            // If the outcome is untestability:
-            if (outcome === 'cantTell') {
-              // Revise the rule-specific properties.
-              ruleID = ['r66', 'r69'].includes(ruleID) ? 'cantTell' : 'cantTellTextContrast';
-              what = `cannot test for rule ${ruleID}: ${what}`;
-              ordinalSeverity = 0;
-            }
-            // Increment the standard total.
-            standardResult.totals[ordinalSeverity]++;
-            const xPath = getNormalizedXPath(item.path?.replace(/\/text\(\).*$/, '') || '/html');
-            // Add an instance to the standard instances.
-            standardResult.instances.push({
-              ruleID,
-              what,
-              ordinalSeverity,
-              count: 1,
-              catalogIndex: getXPathCatalogIndex(report, xPath)
-            });
-          }
+        try {
+            // Wait for a stable page to make the page and its alfa version consistent.
+            await page.waitForLoadState('networkidle', { timeout: (0, config_1.applyMultiplier)(9000) });
         }
-      }
-    };
-  }
-  catch(error) {
-    data.prevented = true;
-    const {message} = error;
-    if (message) {
-      if (message.includes('Unsupported node of type: 4')) {
-        data.error = 'Alfa cannot test page because it contains CDATA';
-      }
-      else {
-        data.error = message;
-      }
+        // If that fails:
+        catch (error) {
+            // Wait for the page to be loaded.
+            await page.waitForLoadState('domcontentloaded', { timeout: (0, config_1.applyMultiplier)(6000) });
+        }
+        const doc = await page.evaluateHandle('document');
+        const alfaPage = await Playwright.toPage(doc);
+        // Test the page content with the specified rules.
+        const audit = Audit.of(alfaPage, alfaRules);
+        // Get the evaluations.
+        const evaluations = Array.from(await audit.evaluate());
+        const { nativeResult, standardResult } = result;
+        // For each of them:
+        for (const index in evaluations) {
+            const evaluation = evaluations[index];
+            const targetClass = evaluation.target;
+            // If it has a non-collection violator:
+            if (targetClass && !targetClass._members) {
+                // Convert the evaluation to an element-specific item.
+                const item = evaluation.toJSON();
+                const { diagnostic, expectations, outcome, rule, target } = item;
+                // If the outcome of the item is a failure or warning:
+                if (['failed', 'cantTell'].includes(outcome)) {
+                    // Delete typically massive properties unlikely to be useful.
+                    delete target.children;
+                    if (diagnostic?.errors) {
+                        diagnostic.errors.forEach(error => {
+                            delete error.element;
+                            delete error.positionedDescendants;
+                        });
+                    }
+                    // Increment the applicable total.
+                    nativeResult.totals[outcome]++;
+                    const codeLines = targetClass.toString().split('\n');
+                    if (codeLines[0] === '#document') {
+                        codeLines.splice(2, codeLines.length - 3, ' … ');
+                    }
+                    else if (codeLines[0].startsWith('<html')) {
+                        codeLines.splice(1, codeLines.length - 2, ' … ');
+                    }
+                    let code = codeLines.join('/n');
+                    if (code.length > 400) {
+                        code = `${code.slice(0, 300)} … ${code.slice(-100)}`;
+                    }
+                    // Add properties of the evaluation to the item.
+                    item.code = code;
+                    item.path = targetClass.path();
+                    // Add the item to the items of the native result.
+                    nativeResult.items.push(item);
+                    // If standard results are to be reported:
+                    if (standard) {
+                        const { requirements, uri } = rule;
+                        // Get the rule ID of the item.
+                        let ruleID = uri.replace(/^.+-/, '');
+                        // Get the rule description of the item.
+                        let what = (expectations?.[0]?.[1]?.error?.message || '').trim().replace(/\s+/g, ' ');
+                        if (!what) {
+                            if (requirements && requirements.length && requirements[0].title) {
+                                what = requirements[0].title;
+                            }
+                        }
+                        // Get the ordinal severity of the item.
+                        let ordinalSeverity = 2;
+                        // If the outcome is untestability:
+                        if (outcome === 'cantTell') {
+                            // Revise the rule-specific properties.
+                            ruleID = ['r66', 'r69'].includes(ruleID) ? 'cantTell' : 'cantTellTextContrast';
+                            what = `cannot test for rule ${ruleID}: ${what}`;
+                            ordinalSeverity = 0;
+                        }
+                        // Increment the standard total.
+                        standardResult.totals[ordinalSeverity]++;
+                        const xPath = (0, xPath_1.getNormalizedXPath)(item.path?.replace(/\/text\(\).*$/, '') || '/html');
+                        // Add an instance to the standard instances.
+                        standardResult.instances.push({
+                            ruleID,
+                            what,
+                            ordinalSeverity,
+                            count: 1,
+                            catalogIndex: (0, xPath_1.getXPathCatalogIndex)(report, xPath)
+                        });
+                    }
+                }
+            }
+        }
+        ;
     }
-    console.log(`ERROR: ${data.error}`);
-  }
-  return {
-    data,
-    result
-  };
+    catch (error) {
+        data.prevented = true;
+        const { message } = error;
+        if (message) {
+            if (message.includes('Unsupported node of type: 4')) {
+                data.error = 'Alfa cannot test page because it contains CDATA';
+            }
+            else {
+                data.error = message;
+            }
+        }
+        console.log(`ERROR: ${data.error}`);
+    }
+    return {
+        data,
+        result
+    };
 };
+exports.reporter = reporter;

--- a/tests/alfa.ts
+++ b/tests/alfa.ts
@@ -1,0 +1,222 @@
+/*
+  © 2021–2024 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {getNormalizedXPath, getXPathCatalogIndex} from '../procs/xPath';
+import {applyMultiplier} from '../procs/config';
+import type {Act, Report, StandardInstance, StandardResult} from '../types';
+/*
+  The alfa packages are pure ESM that Node loads via require(esm); their own
+  types do not resolve under this project's node10 module resolution, so the
+  imports stay requires and are untyped.
+*/
+let alfaRules = require('@siteimprove/alfa-rules').default;
+const {Audit} = require('@siteimprove/alfa-act');
+const {Playwright} = require('@siteimprove/alfa-playwright');
+
+// TYPES
+
+// The alfa-act properties this reporter consumes.
+interface AlfaAct extends Act {
+  rules?: string[];
+}
+// One evaluation of the audit, before JSON conversion.
+interface AlfaEvaluation {
+  target?: {
+    _members?: unknown;
+    toString: () => string;
+    path: () => string;
+  };
+  toJSON: () => AlfaEvalItem;
+}
+// One element-specific item converted from an evaluation.
+interface AlfaEvalItem {
+  diagnostic?: {
+    errors?: {
+      element?: unknown;
+      positionedDescendants?: unknown;
+    }[];
+  };
+  expectations?: {
+    error?: {
+      message?: string;
+    };
+  }[][];
+  outcome: string;
+  rule: {
+    requirements?: {title?: string}[];
+    uri: string;
+  };
+  target?: {children?: unknown};
+  code?: string;
+  path?: string;
+}
+// The native result: violation totals and element-specific items.
+interface AlfaNativeResult {
+  totals: {
+    failed: number;
+    cantTell: number;
+  };
+  items: AlfaEvalItem[];
+}
+
+/*
+  alfa
+  Implements the alfa ruleset for accessibility.
+  Compiled to alfa.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Conducts and reports the alfa tests.
+export const reporter = async (page: Page, report: Report, actIndex: number) => {
+  const act = report.acts[actIndex] as AlfaAct;
+  const {rules} = act;
+  // If only some rules are to be employed:
+  if (rules && rules.length) {
+    // Remove the other rules.
+    alfaRules = alfaRules.filter(
+      (rule: {uri: string}) => rules.includes(rule.uri.replace(/^.+-/, ''))
+    );
+  }
+  // Initialize the act report.
+  const data: {prevented?: boolean; error?: string} = {};
+  const result: {nativeResult: AlfaNativeResult; standardResult: StandardResult} = {
+    nativeResult: {
+      totals: {
+        failed: 0,
+        cantTell: 0
+      },
+      items: []
+    },
+    standardResult: {}
+  };
+  const standard = report.standard !== 'no';
+  // If standard results are to be reported:
+  if (standard) {
+    // Initialize the standard result.
+    result.standardResult = {
+      prevented: false,
+      totals: [0, 0, 0, 0],
+      instances: []
+    };
+  }
+  try {
+    try {
+      // Wait for a stable page to make the page and its alfa version consistent.
+      await page.waitForLoadState('networkidle', {timeout: applyMultiplier(9000)});
+    }
+    // If that fails:
+    catch (error) {
+      // Wait for the page to be loaded.
+      await page.waitForLoadState('domcontentloaded', {timeout: applyMultiplier(6000)});
+    }
+    const doc = await page.evaluateHandle('document');
+    const alfaPage = await Playwright.toPage(doc);
+    // Test the page content with the specified rules.
+    const audit = Audit.of(alfaPage, alfaRules);
+    // Get the evaluations.
+    const evaluations: AlfaEvaluation[] = Array.from(await audit.evaluate());
+    const {nativeResult, standardResult} = result;
+    // For each of them:
+    for (const index in evaluations) {
+      const evaluation = evaluations[index as unknown as number];
+      const targetClass = evaluation.target;
+      // If it has a non-collection violator:
+      if (targetClass && ! targetClass._members) {
+        // Convert the evaluation to an element-specific item.
+        const item = evaluation.toJSON();
+        const {diagnostic, expectations, outcome, rule, target} = item;
+        // If the outcome of the item is a failure or warning:
+        if (['failed', 'cantTell'].includes(outcome)) {
+          // Delete typically massive properties unlikely to be useful.
+          delete target!.children;
+          if (diagnostic?.errors) {
+            diagnostic.errors.forEach(error => {
+              delete error.element;
+              delete error.positionedDescendants;
+            });
+          }
+          // Increment the applicable total.
+          nativeResult.totals[outcome as 'failed' | 'cantTell']++;
+          const codeLines = targetClass.toString().split('\n');
+          if (codeLines[0] === '#document') {
+            codeLines.splice(2, codeLines.length - 3, ' … ');
+          }
+          else if (codeLines[0].startsWith('<html')) {
+            codeLines.splice(1, codeLines.length - 2, ' … ');
+          }
+          let code = codeLines.join('/n');
+          if (code.length > 400) {
+            code = `${code.slice(0, 300)} … ${code.slice(-100)}`;
+          }
+          // Add properties of the evaluation to the item.
+          item.code = code;
+          item.path = targetClass.path();
+          // Add the item to the items of the native result.
+          nativeResult.items.push(item);
+          // If standard results are to be reported:
+          if (standard) {
+            const {requirements, uri} = rule;
+            // Get the rule ID of the item.
+            let ruleID = uri.replace(/^.+-/, '');
+            // Get the rule description of the item.
+            let what = (expectations?.[0]?.[1]?.error?.message || '').trim().replace(/\s+/g, ' ');
+            if (! what) {
+              if (requirements && requirements.length && requirements[0].title) {
+                what = requirements[0].title;
+              }
+            }
+            // Get the ordinal severity of the item.
+            let ordinalSeverity: StandardInstance['ordinalSeverity'] = 2;
+            // If the outcome is untestability:
+            if (outcome === 'cantTell') {
+              // Revise the rule-specific properties.
+              ruleID = ['r66', 'r69'].includes(ruleID) ? 'cantTell' : 'cantTellTextContrast';
+              what = `cannot test for rule ${ruleID}: ${what}`;
+              ordinalSeverity = 0;
+            }
+            // Increment the standard total.
+            standardResult.totals![ordinalSeverity]++;
+            const xPath = getNormalizedXPath(item.path?.replace(/\/text\(\).*$/, '') || '/html');
+            // Add an instance to the standard instances.
+            standardResult.instances!.push({
+              ruleID,
+              what,
+              ordinalSeverity,
+              count: 1,
+              catalogIndex: getXPathCatalogIndex(report, xPath)
+            });
+          }
+        }
+      }
+    };
+  }
+  catch(error) {
+    data.prevented = true;
+    const {message} = error as Error;
+    if (message) {
+      if (message.includes('Unsupported node of type: 4')) {
+        data.error = 'Alfa cannot test page because it contains CDATA';
+      }
+      else {
+        data.error = message;
+      }
+    }
+    console.log(`ERROR: ${data.error}`);
+  }
+  return {
+    data,
+    result
+  };
+};

--- a/tests/aslint.d.ts
+++ b/tests/aslint.d.ts
@@ -1,0 +1,33 @@
+import type { Page } from 'playwright';
+import type { Report, StandardResult } from '../types';
+interface AslintResultItem {
+    message?: {
+        actual?: {
+            description?: string;
+        };
+    };
+    element?: {
+        xpath?: string;
+    };
+}
+interface AslintRuleData {
+    issueType: string;
+    status: {
+        type: string;
+    };
+    results: AslintResultItem[];
+}
+interface AslintNativeResult {
+    rules?: Record<string, AslintRuleData>;
+}
+export declare const reporter: (page: Page, report: Report, actIndex: number) => Promise<{
+    data: {
+        prevented?: boolean;
+        error?: string;
+    };
+    result: {
+        nativeResult: AslintNativeResult;
+        standardResult: StandardResult;
+    };
+}>;
+export {};

--- a/tests/aslint.js
+++ b/tests/aslint.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2023–2024 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -8,21 +9,47 @@
 
   SPDX-License-Identifier: MIT
 */
-
-/*
-  aslint
-  Implements the ASLint ruleset for accessibility.
-*/
-
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
 // IMPORTS
-
-const fs = require('fs/promises');
+const fs = __importStar(require("fs/promises"));
 // Shared configuration for timeout multiplier.
-const {applyMultiplier} = require('../procs/config');
-const {getNormalizedXPath, getXPathCatalogIndex} = require('../procs/xPath');
-
+const config_1 = require("../procs/config");
+const xPath_1 = require("../procs/xPath");
 // CONSTANTS
-
 /*
   Differentiates some rule IDs of aslint.
   If the purported rule ID is a key and the what property contains all of the strings except the
@@ -30,252 +57,253 @@ const {getNormalizedXPath, getXPathCatalogIndex} = require('../procs/xPath');
   array item.
 */
 const aslintData = {
-  'misused_required_attribute': [
-    ['not needed', 'misused_required_attributeR']
-  ],
-  'accessible_svg': [
-    ['associated', 'accessible_svgI'],
-    ['tabindex', 'accessible_svgT']
-  ],
-  'audio_alternative': [
-    ['track', 'audio_alternativeT'],
-    ['alternative', 'audio_alternativeA'],
-    ['bgsound', 'audio_alternativeB']
-  ],
-  'table_missing_description': [
-    ['describedby', 'associated', 'table_missing_descriptionDM'],
-    ['labeledby', 'associated', 'table_missing_descriptionLM'],
-    ['caption', 'not been defined', 'table_missing_descriptionC'],
-    ['summary', 'empty', 'table_missing_descriptionS'],
-    ['describedby', 'empty', 'table_missing_descriptionDE'],
-    ['labeledby', 'empty', 'table_missing_descriptionLE'],
-    ['caption', 'no content', 'table_missing_descriptionE']
-  ],
-  'label_implicitly_associated': [
-    ['only whice spaces', 'label_implicitly_associatedW'],
-    ['more than one', 'label_implicitly_associatedM']
-  ],
-  'label_inappropriate_association': [
-    ['Missing', 'label_inappropriate_associationM'],
-    ['non-form', 'label_inappropriate_associationN']
-  ],
-  'table_row_and_column_headers': [
-    ['headers', 'table_row_and_column_headersRC'],
-    ['Content', 'table_row_and_column_headersB'],
-    ['head of the columns', 'table_row_and_column_headersH']
-  ],
-  'color_contrast_state_pseudo_classes_abstract': [
-    ['position: fixed', 'color_contrast_state_pseudo_classes_abstractF'],
-    ['transparent', 'color_contrast_state_pseudo_classes_abstractB'],
-    ['least 3:1', 'color_contrast_state_pseudo_classes_abstract3'],
-    ['least 4.5:1', 'color_contrast_state_pseudo_classes_abstract4']
-  ],
-  'color_contrast_state_pseudo_classes_active': [
-    ['position: fixed', 'color_contrast_state_pseudo_classes_abstractF'],
-    ['transparent', 'color_contrast_state_pseudo_classes_abstractB'],
-    ['least 3:1', 'color_contrast_state_pseudo_classes_abstract3'],
-    ['least 4.5:1', 'color_contrast_state_pseudo_classes_abstract4']
-  ],
-  'color_contrast_state_pseudo_classes_focus': [
-    ['position: fixed', 'color_contrast_state_pseudo_classes_abstractF'],
-    ['transparent', 'color_contrast_state_pseudo_classes_abstractB'],
-    ['least 3:1', 'color_contrast_state_pseudo_classes_abstract3'],
-    ['least 4.5:1', 'color_contrast_state_pseudo_classes_abstract4']
-  ],
-  'color_contrast_state_pseudo_classes_hover': [
-    ['position: fixed', 'color_contrast_state_pseudo_classes_abstractF'],
-    ['transparent', 'color_contrast_state_pseudo_classes_abstractB'],
-    ['least 3:1', 'color_contrast_state_pseudo_classes_abstract3'],
-    ['least 4.5:1', 'color_contrast_state_pseudo_classes_abstract4']
-  ],
-  'color_contrast_aaa': [
-    ['transparent', 'color_contrast_aaaB'],
-    ['least 4.5:1', 'color_contrast_aaa4'],
-    ['least 7:1', 'color_contrast_aaa7']
-  ],
-  'animation': [
-    ['duration', 'animationD'],
-    ['iteration', 'animationI'],
-    ['mechanism', 'animationM']
-  ],
-  'page_title': [
-    ['empty', 'page_titleN'],
-    ['not identify', 'page_titleU']
-  ],
-  'aria_labelledby_association': [
-    ['exist', 'aria_labelledby_associationN'],
-    ['empty', 'aria_labelledby_associationE']
-  ],
-  'html_lang_attr': [
-    ['parameters', 'html_lang_attrP'],
-    ['nothing', 'html_lang_attrN'],
-    ['empty', 'html_lang_attrE']
-  ],
-  'missing_label': [
-    ['associated', 'missing_labelI'],
-    ['defined', 'missing_labelN'],
-    ['multiple labels', 'missing_labelM']
-  ],
-  'orientation': [
-    ['loaded', 'orientationT']
-  ]
+    'misused_required_attribute': [
+        ['not needed', 'misused_required_attributeR']
+    ],
+    'accessible_svg': [
+        ['associated', 'accessible_svgI'],
+        ['tabindex', 'accessible_svgT']
+    ],
+    'audio_alternative': [
+        ['track', 'audio_alternativeT'],
+        ['alternative', 'audio_alternativeA'],
+        ['bgsound', 'audio_alternativeB']
+    ],
+    'table_missing_description': [
+        ['describedby', 'associated', 'table_missing_descriptionDM'],
+        ['labeledby', 'associated', 'table_missing_descriptionLM'],
+        ['caption', 'not been defined', 'table_missing_descriptionC'],
+        ['summary', 'empty', 'table_missing_descriptionS'],
+        ['describedby', 'empty', 'table_missing_descriptionDE'],
+        ['labeledby', 'empty', 'table_missing_descriptionLE'],
+        ['caption', 'no content', 'table_missing_descriptionE']
+    ],
+    'label_implicitly_associated': [
+        ['only whice spaces', 'label_implicitly_associatedW'],
+        ['more than one', 'label_implicitly_associatedM']
+    ],
+    'label_inappropriate_association': [
+        ['Missing', 'label_inappropriate_associationM'],
+        ['non-form', 'label_inappropriate_associationN']
+    ],
+    'table_row_and_column_headers': [
+        ['headers', 'table_row_and_column_headersRC'],
+        ['Content', 'table_row_and_column_headersB'],
+        ['head of the columns', 'table_row_and_column_headersH']
+    ],
+    'color_contrast_state_pseudo_classes_abstract': [
+        ['position: fixed', 'color_contrast_state_pseudo_classes_abstractF'],
+        ['transparent', 'color_contrast_state_pseudo_classes_abstractB'],
+        ['least 3:1', 'color_contrast_state_pseudo_classes_abstract3'],
+        ['least 4.5:1', 'color_contrast_state_pseudo_classes_abstract4']
+    ],
+    'color_contrast_state_pseudo_classes_active': [
+        ['position: fixed', 'color_contrast_state_pseudo_classes_abstractF'],
+        ['transparent', 'color_contrast_state_pseudo_classes_abstractB'],
+        ['least 3:1', 'color_contrast_state_pseudo_classes_abstract3'],
+        ['least 4.5:1', 'color_contrast_state_pseudo_classes_abstract4']
+    ],
+    'color_contrast_state_pseudo_classes_focus': [
+        ['position: fixed', 'color_contrast_state_pseudo_classes_abstractF'],
+        ['transparent', 'color_contrast_state_pseudo_classes_abstractB'],
+        ['least 3:1', 'color_contrast_state_pseudo_classes_abstract3'],
+        ['least 4.5:1', 'color_contrast_state_pseudo_classes_abstract4']
+    ],
+    'color_contrast_state_pseudo_classes_hover': [
+        ['position: fixed', 'color_contrast_state_pseudo_classes_abstractF'],
+        ['transparent', 'color_contrast_state_pseudo_classes_abstractB'],
+        ['least 3:1', 'color_contrast_state_pseudo_classes_abstract3'],
+        ['least 4.5:1', 'color_contrast_state_pseudo_classes_abstract4']
+    ],
+    'color_contrast_aaa': [
+        ['transparent', 'color_contrast_aaaB'],
+        ['least 4.5:1', 'color_contrast_aaa4'],
+        ['least 7:1', 'color_contrast_aaa7']
+    ],
+    'animation': [
+        ['duration', 'animationD'],
+        ['iteration', 'animationI'],
+        ['mechanism', 'animationM']
+    ],
+    'page_title': [
+        ['empty', 'page_titleN'],
+        ['not identify', 'page_titleU']
+    ],
+    'aria_labelledby_association': [
+        ['exist', 'aria_labelledby_associationN'],
+        ['empty', 'aria_labelledby_associationE']
+    ],
+    'html_lang_attr': [
+        ['parameters', 'html_lang_attrP'],
+        ['nothing', 'html_lang_attrN'],
+        ['empty', 'html_lang_attrE']
+    ],
+    'missing_label': [
+        ['associated', 'missing_labelI'],
+        ['defined', 'missing_labelN'],
+        ['multiple labels', 'missing_labelM']
+    ],
+    'orientation': [
+        ['loaded', 'orientationT']
+    ]
 };
-
+/*
+  aslint
+  Implements the ASLint ruleset for accessibility.
+  Compiled to aslint.js by tsc (issue #73); edit this file, not the emitted one.
+*/
 // FUNCTIONS
-
 // Conducts and reports the ASLint tests.
-exports.reporter = async (page, report, actIndex) => {
-  // Initialize the act report.
-  let data = {};
-  const result = {
-    nativeResult: {},
-    standardResult: {}
-  };
-  const standard = report.standard !== 'no';
-  // If standard results are to be reported:
-  if (standard) {
-    // Initialize the standard result.
-    result.standardResult = {
-      prevented: false,
-      totals: [0, 0, 0, 0],
-      instances: []
+const reporter = async (page, report, actIndex) => {
+    // Initialize the act report.
+    let data = {};
+    const result = {
+        nativeResult: {},
+        standardResult: {}
     };
-  }
-  const {standardResult} = result;
-  // Get the ASLint runner and bundle scripts.
-  const aslintRunner = await fs.readFile(`${__dirname}/../procs/aslint.js`, 'utf8');
-  const aslintBundlePath = require.resolve('aslint-testaro/aslint.bundle.js');
-  const aslintBundle = await fs.readFile(aslintBundlePath, 'utf8');
-  // Get the nonce, if any.
-  const act = report.acts[actIndex];
-  const {jobData} = report;
-  const scriptNonce = jobData && jobData.lastScriptNonce;
-  // Inject the ASLint bundle and runner into the head of the page.
-  await page.evaluate(args => {
-    const {scriptNonce, aslintBundle, aslintRunner} = args;
-    // Bundle.
-    const bundleEl = document.createElement('script');
-    bundleEl.id = 'aslintBundle';
-    if (scriptNonce) {
-      bundleEl.nonce = scriptNonce;
-      console.log(`Added nonce ${scriptNonce} to bundle`);
-    }
-    bundleEl.textContent = aslintBundle;
-    document.head.insertAdjacentElement('beforeend', bundleEl);
-    // Runner.
-    const runnerEl = document.createElement('script');
-    if (scriptNonce) {
-      runnerEl.nonce = scriptNonce;
-      console.log(`Added nonce ${scriptNonce} to runner`);
-    }
-    runnerEl.textContent = aslintRunner;
-    document.body.insertAdjacentElement('beforeend', runnerEl);
-  }, {scriptNonce, aslintBundle, aslintRunner})
-  .catch(error => {
-    const message = `ERROR: ASLint injection failed (${error.message.slice(0, 400)})`;
-    console.log(message);
-    data.prevented = true;
-    data.error = message;
+    const standard = report.standard !== 'no';
+    // If standard results are to be reported:
     if (standard) {
-      standardResult.prevented = true;
+        // Initialize the standard result.
+        result.standardResult = {
+            prevented: false,
+            totals: [0, 0, 0, 0],
+            instances: []
+        };
     }
-  });
-  const reportLoc = page.locator('#aslintResult');
-  // If the injection succeeded:
-  if (! data.prevented) {
-    try {
-      // Wait for the test results to be attached to the page.
-      const waitOptions = {
-        state: 'attached',
-        timeout: applyMultiplier(20000)
-      };
-      await reportLoc.waitFor(waitOptions);
-    }
-    catch(error) {
-      const message = 'Attachment of test results to page failed';
-      console.log(message);
-      data.prevented = true;
-      data.error = `${message} (${error.message})`;
-    };
-  }
-  // If the injection and the result attachment both succeeded:
-  if (! data.prevented) {
-    // Get their text.
-    const actReport = await reportLoc.textContent();
-    try {
-      const nativeResult = result.nativeResult = JSON.parse(actReport);
-      // If any rules were reported violated:
-      if (nativeResult.rules) {
-        const {rules} = nativeResult;
-        // For each such rule:
-        for (const ruleID of Object.keys(rules)) {
-          const ruleData = rules[ruleID];
-          const {issueType, status} = ruleData;
-          const excluded = act.rules && ! act.rules.includes(ruleID);
-          const {type} = status;
-          // If rule is not an error or warning or is not to be tested:
-          if (
-            excluded
-            || ['passed', 'skipped'].includes(type)
-            || ! ['error', 'warning'].includes(issueType)
-          ) {
-            // Delete the rule report.
-            delete rules[ruleID];
-          }
+    const { standardResult } = result;
+    // Get the ASLint runner and bundle scripts.
+    const aslintRunner = await fs.readFile(`${__dirname}/../procs/aslint.js`, 'utf8');
+    const aslintBundlePath = require.resolve('aslint-testaro/aslint.bundle.js');
+    const aslintBundle = await fs.readFile(aslintBundlePath, 'utf8');
+    // Get the nonce, if any.
+    const act = report.acts[actIndex];
+    const { jobData } = report;
+    const scriptNonce = (jobData && jobData.lastScriptNonce);
+    // Inject the ASLint bundle and runner into the head of the page.
+    await page.evaluate(args => {
+        const { scriptNonce, aslintBundle, aslintRunner } = args;
+        // Bundle.
+        const bundleEl = document.createElement('script');
+        bundleEl.id = 'aslintBundle';
+        if (scriptNonce) {
+            bundleEl.nonce = scriptNonce;
+            console.log(`Added nonce ${scriptNonce} to bundle`);
         }
-        // If standard results are to be reported:
+        bundleEl.textContent = aslintBundle;
+        document.head.insertAdjacentElement('beforeend', bundleEl);
+        // Runner.
+        const runnerEl = document.createElement('script');
+        if (scriptNonce) {
+            runnerEl.nonce = scriptNonce;
+            console.log(`Added nonce ${scriptNonce} to runner`);
+        }
+        runnerEl.textContent = aslintRunner;
+        document.body.insertAdjacentElement('beforeend', runnerEl);
+    }, { scriptNonce, aslintBundle, aslintRunner })
+        .catch(error => {
+        const message = `ERROR: ASLint injection failed (${error.message.slice(0, 400)})`;
+        console.log(message);
+        data.prevented = true;
+        data.error = message;
         if (standard) {
-          const ruleIDs = Object.keys(rules);
-          // For each violated rule:
-          for (let ruleID of ruleIDs) {
-            const ruleData = rules[ruleID];
-            const {issueType, results} = ruleData;
-            // For each violation:
-            for (const result of results) {
-              const {message, element} = result;
-              // Get a description of the violated rule.
-              const what = message?.actual?.description ?? '';
-              const changer = aslintData[ruleID]?.find(
-                specs => specs.slice(0, -1).every(matcher => what.includes(matcher))
-              );
-              // If the rule ID is differentiatable:
-              if (changer) {
-                // Differentiate it.
-                ruleID = changer[changer.length - 1];
-              }
-              // Get the ordinal severity of the violation.
-              const ordinalSeverity = issueType === 'warning' ? 1 : 2;
-              // Get the pathID of the element.
-              const {xpath} = element;
-              const pathID = getNormalizedXPath(xpath);
-              // Use it to get the index of the element in the catalog.
-              const catalogIndex = getXPathCatalogIndex(report, pathID);
-              // Add an instance to the standard result.
-              standardResult.instances.push({
-                ruleID,
-                what,
-                ordinalSeverity,
-                count: 1,
-                catalogIndex
-              });
-              // Increment the standard total.
-              standardResult.totals[ordinalSeverity]++;
-            }
-          }
+            standardResult.prevented = true;
         }
-      }
+    });
+    const reportLoc = page.locator('#aslintResult');
+    // If the injection succeeded:
+    if (!data.prevented) {
+        try {
+            // Wait for the test results to be attached to the page.
+            const waitOptions = {
+                state: 'attached',
+                timeout: (0, config_1.applyMultiplier)(20000)
+            };
+            await reportLoc.waitFor(waitOptions);
+        }
+        catch (error) {
+            const message = 'Attachment of test results to page failed';
+            console.log(message);
+            data.prevented = true;
+            data.error = `${message} (${error.message})`;
+        }
+        ;
     }
-    // If the results are not JSON:
-    catch(error) {
-      const message = `Result processing failed (${error.message})`;
-      console.log(`ERROR: ${message}`);
-      // Report this.
-      data.prevented = true;
-      data.error = message;
+    // If the injection and the result attachment both succeeded:
+    if (!data.prevented) {
+        // Get their text.
+        const actReport = await reportLoc.textContent();
+        try {
+            const nativeResult = result.nativeResult = JSON.parse(actReport);
+            // If any rules were reported violated:
+            if (nativeResult.rules) {
+                const { rules } = nativeResult;
+                // For each such rule:
+                for (const ruleID of Object.keys(rules)) {
+                    const ruleData = rules[ruleID];
+                    const { issueType, status } = ruleData;
+                    const excluded = act.rules && !act.rules.includes(ruleID);
+                    const { type } = status;
+                    // If rule is not an error or warning or is not to be tested:
+                    if (excluded
+                        || ['passed', 'skipped'].includes(type)
+                        || !['error', 'warning'].includes(issueType)) {
+                        // Delete the rule report.
+                        delete rules[ruleID];
+                    }
+                }
+                // If standard results are to be reported:
+                if (standard) {
+                    const ruleIDs = Object.keys(rules);
+                    // For each violated rule:
+                    for (let ruleID of ruleIDs) {
+                        const ruleData = rules[ruleID];
+                        const { issueType, results } = ruleData;
+                        // For each violation:
+                        for (const result of results) {
+                            const { message, element } = result;
+                            // Get a description of the violated rule.
+                            const what = message?.actual?.description ?? '';
+                            const changer = aslintData[ruleID]?.find(specs => specs.slice(0, -1).every(matcher => what.includes(matcher)));
+                            // If the rule ID is differentiatable:
+                            if (changer) {
+                                // Differentiate it.
+                                ruleID = changer[changer.length - 1];
+                            }
+                            // Get the ordinal severity of the violation.
+                            const ordinalSeverity = issueType === 'warning' ? 1 : 2;
+                            // Get the pathID of the element.
+                            const { xpath } = element;
+                            const pathID = (0, xPath_1.getNormalizedXPath)(xpath);
+                            // Use it to get the index of the element in the catalog.
+                            const catalogIndex = (0, xPath_1.getXPathCatalogIndex)(report, pathID);
+                            // Add an instance to the standard result.
+                            standardResult.instances.push({
+                                ruleID,
+                                what,
+                                ordinalSeverity,
+                                count: 1,
+                                catalogIndex
+                            });
+                            // Increment the standard total.
+                            standardResult.totals[ordinalSeverity]++;
+                        }
+                    }
+                }
+            }
+        }
+        // If the results are not JSON:
+        catch (error) {
+            const message = `Result processing failed (${error.message})`;
+            console.log(`ERROR: ${message}`);
+            // Report this.
+            data.prevented = true;
+            data.error = message;
+        }
     }
-  }
-  return {
-    data,
-    result
-  };
+    return {
+        data,
+        result
+    };
 };
+exports.reporter = reporter;

--- a/tests/aslint.ts
+++ b/tests/aslint.ts
@@ -1,0 +1,306 @@
+/*
+  © 2023–2024 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import * as fs from 'fs/promises';
+import type {Page} from 'playwright';
+// Shared configuration for timeout multiplier.
+import {applyMultiplier} from '../procs/config';
+import {getNormalizedXPath, getXPathCatalogIndex} from '../procs/xPath';
+import type {Act, Report, StandardResult} from '../types';
+
+// TYPES
+
+// The aslint-act properties this reporter consumes.
+interface AslintAct extends Act {
+  rules?: string[];
+}
+// One violation of a rule in an ASLint result.
+interface AslintResultItem {
+  message?: {actual?: {description?: string}};
+  element?: {xpath?: string};
+}
+// The report of one rule in an ASLint result.
+interface AslintRuleData {
+  issueType: string;
+  status: {type: string};
+  results: AslintResultItem[];
+}
+// The native result: the parsed ASLint report.
+interface AslintNativeResult {
+  rules?: Record<string, AslintRuleData>;
+}
+
+// CONSTANTS
+
+/*
+  Differentiates some rule IDs of aslint.
+  If the purported rule ID is a key and the what property contains all of the strings except the
+  last of any array item of the value of that key, then the final rule ID is the last item of that
+  array item.
+*/
+const aslintData: Record<string, string[][]> = {
+  'misused_required_attribute': [
+    ['not needed', 'misused_required_attributeR']
+  ],
+  'accessible_svg': [
+    ['associated', 'accessible_svgI'],
+    ['tabindex', 'accessible_svgT']
+  ],
+  'audio_alternative': [
+    ['track', 'audio_alternativeT'],
+    ['alternative', 'audio_alternativeA'],
+    ['bgsound', 'audio_alternativeB']
+  ],
+  'table_missing_description': [
+    ['describedby', 'associated', 'table_missing_descriptionDM'],
+    ['labeledby', 'associated', 'table_missing_descriptionLM'],
+    ['caption', 'not been defined', 'table_missing_descriptionC'],
+    ['summary', 'empty', 'table_missing_descriptionS'],
+    ['describedby', 'empty', 'table_missing_descriptionDE'],
+    ['labeledby', 'empty', 'table_missing_descriptionLE'],
+    ['caption', 'no content', 'table_missing_descriptionE']
+  ],
+  'label_implicitly_associated': [
+    ['only whice spaces', 'label_implicitly_associatedW'],
+    ['more than one', 'label_implicitly_associatedM']
+  ],
+  'label_inappropriate_association': [
+    ['Missing', 'label_inappropriate_associationM'],
+    ['non-form', 'label_inappropriate_associationN']
+  ],
+  'table_row_and_column_headers': [
+    ['headers', 'table_row_and_column_headersRC'],
+    ['Content', 'table_row_and_column_headersB'],
+    ['head of the columns', 'table_row_and_column_headersH']
+  ],
+  'color_contrast_state_pseudo_classes_abstract': [
+    ['position: fixed', 'color_contrast_state_pseudo_classes_abstractF'],
+    ['transparent', 'color_contrast_state_pseudo_classes_abstractB'],
+    ['least 3:1', 'color_contrast_state_pseudo_classes_abstract3'],
+    ['least 4.5:1', 'color_contrast_state_pseudo_classes_abstract4']
+  ],
+  'color_contrast_state_pseudo_classes_active': [
+    ['position: fixed', 'color_contrast_state_pseudo_classes_abstractF'],
+    ['transparent', 'color_contrast_state_pseudo_classes_abstractB'],
+    ['least 3:1', 'color_contrast_state_pseudo_classes_abstract3'],
+    ['least 4.5:1', 'color_contrast_state_pseudo_classes_abstract4']
+  ],
+  'color_contrast_state_pseudo_classes_focus': [
+    ['position: fixed', 'color_contrast_state_pseudo_classes_abstractF'],
+    ['transparent', 'color_contrast_state_pseudo_classes_abstractB'],
+    ['least 3:1', 'color_contrast_state_pseudo_classes_abstract3'],
+    ['least 4.5:1', 'color_contrast_state_pseudo_classes_abstract4']
+  ],
+  'color_contrast_state_pseudo_classes_hover': [
+    ['position: fixed', 'color_contrast_state_pseudo_classes_abstractF'],
+    ['transparent', 'color_contrast_state_pseudo_classes_abstractB'],
+    ['least 3:1', 'color_contrast_state_pseudo_classes_abstract3'],
+    ['least 4.5:1', 'color_contrast_state_pseudo_classes_abstract4']
+  ],
+  'color_contrast_aaa': [
+    ['transparent', 'color_contrast_aaaB'],
+    ['least 4.5:1', 'color_contrast_aaa4'],
+    ['least 7:1', 'color_contrast_aaa7']
+  ],
+  'animation': [
+    ['duration', 'animationD'],
+    ['iteration', 'animationI'],
+    ['mechanism', 'animationM']
+  ],
+  'page_title': [
+    ['empty', 'page_titleN'],
+    ['not identify', 'page_titleU']
+  ],
+  'aria_labelledby_association': [
+    ['exist', 'aria_labelledby_associationN'],
+    ['empty', 'aria_labelledby_associationE']
+  ],
+  'html_lang_attr': [
+    ['parameters', 'html_lang_attrP'],
+    ['nothing', 'html_lang_attrN'],
+    ['empty', 'html_lang_attrE']
+  ],
+  'missing_label': [
+    ['associated', 'missing_labelI'],
+    ['defined', 'missing_labelN'],
+    ['multiple labels', 'missing_labelM']
+  ],
+  'orientation': [
+    ['loaded', 'orientationT']
+  ]
+};
+
+/*
+  aslint
+  Implements the ASLint ruleset for accessibility.
+  Compiled to aslint.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Conducts and reports the ASLint tests.
+export const reporter = async (page: Page, report: Report, actIndex: number) => {
+  // Initialize the act report.
+  let data: {prevented?: boolean; error?: string} = {};
+  const result: {nativeResult: AslintNativeResult; standardResult: StandardResult} = {
+    nativeResult: {},
+    standardResult: {}
+  };
+  const standard = report.standard !== 'no';
+  // If standard results are to be reported:
+  if (standard) {
+    // Initialize the standard result.
+    result.standardResult = {
+      prevented: false,
+      totals: [0, 0, 0, 0],
+      instances: []
+    };
+  }
+  const {standardResult} = result;
+  // Get the ASLint runner and bundle scripts.
+  const aslintRunner = await fs.readFile(`${__dirname}/../procs/aslint.js`, 'utf8');
+  const aslintBundlePath = require.resolve('aslint-testaro/aslint.bundle.js');
+  const aslintBundle = await fs.readFile(aslintBundlePath, 'utf8');
+  // Get the nonce, if any.
+  const act = report.acts[actIndex] as AslintAct;
+  const {jobData} = report;
+  const scriptNonce = (jobData && jobData.lastScriptNonce) as string | undefined;
+  // Inject the ASLint bundle and runner into the head of the page.
+  await page.evaluate(args => {
+    const {scriptNonce, aslintBundle, aslintRunner} = args;
+    // Bundle.
+    const bundleEl = document.createElement('script');
+    bundleEl.id = 'aslintBundle';
+    if (scriptNonce) {
+      bundleEl.nonce = scriptNonce;
+      console.log(`Added nonce ${scriptNonce} to bundle`);
+    }
+    bundleEl.textContent = aslintBundle;
+    document.head.insertAdjacentElement('beforeend', bundleEl);
+    // Runner.
+    const runnerEl = document.createElement('script');
+    if (scriptNonce) {
+      runnerEl.nonce = scriptNonce;
+      console.log(`Added nonce ${scriptNonce} to runner`);
+    }
+    runnerEl.textContent = aslintRunner;
+    document.body.insertAdjacentElement('beforeend', runnerEl);
+  }, {scriptNonce, aslintBundle, aslintRunner})
+  .catch(error => {
+    const message = `ERROR: ASLint injection failed (${error.message.slice(0, 400)})`;
+    console.log(message);
+    data.prevented = true;
+    data.error = message;
+    if (standard) {
+      standardResult.prevented = true;
+    }
+  });
+  const reportLoc = page.locator('#aslintResult');
+  // If the injection succeeded:
+  if (! data.prevented) {
+    try {
+      // Wait for the test results to be attached to the page.
+      const waitOptions = {
+        state: 'attached' as const,
+        timeout: applyMultiplier(20000)
+      };
+      await reportLoc.waitFor(waitOptions);
+    }
+    catch(error) {
+      const message = 'Attachment of test results to page failed';
+      console.log(message);
+      data.prevented = true;
+      data.error = `${message} (${(error as Error).message})`;
+    };
+  }
+  // If the injection and the result attachment both succeeded:
+  if (! data.prevented) {
+    // Get their text.
+    const actReport = await reportLoc.textContent();
+    try {
+      const nativeResult = result.nativeResult = JSON.parse(actReport as string);
+      // If any rules were reported violated:
+      if (nativeResult.rules) {
+        const {rules} = nativeResult as Required<AslintNativeResult>;
+        // For each such rule:
+        for (const ruleID of Object.keys(rules)) {
+          const ruleData = rules[ruleID];
+          const {issueType, status} = ruleData;
+          const excluded = act.rules && ! act.rules.includes(ruleID);
+          const {type} = status;
+          // If rule is not an error or warning or is not to be tested:
+          if (
+            excluded
+            || ['passed', 'skipped'].includes(type)
+            || ! ['error', 'warning'].includes(issueType)
+          ) {
+            // Delete the rule report.
+            delete rules[ruleID];
+          }
+        }
+        // If standard results are to be reported:
+        if (standard) {
+          const ruleIDs = Object.keys(rules);
+          // For each violated rule:
+          for (let ruleID of ruleIDs) {
+            const ruleData = rules[ruleID];
+            const {issueType, results} = ruleData;
+            // For each violation:
+            for (const result of results) {
+              const {message, element} = result;
+              // Get a description of the violated rule.
+              const what = message?.actual?.description ?? '';
+              const changer = aslintData[ruleID]?.find(
+                specs => specs.slice(0, -1).every(matcher => what.includes(matcher))
+              );
+              // If the rule ID is differentiatable:
+              if (changer) {
+                // Differentiate it.
+                ruleID = changer[changer.length - 1];
+              }
+              // Get the ordinal severity of the violation.
+              const ordinalSeverity = issueType === 'warning' ? 1 : 2;
+              // Get the pathID of the element.
+              const {xpath} = element!;
+              const pathID = getNormalizedXPath(xpath);
+              // Use it to get the index of the element in the catalog.
+              const catalogIndex = getXPathCatalogIndex(report, pathID);
+              // Add an instance to the standard result.
+              standardResult.instances!.push({
+                ruleID,
+                what,
+                ordinalSeverity,
+                count: 1,
+                catalogIndex
+              });
+              // Increment the standard total.
+              standardResult.totals![ordinalSeverity]++;
+            }
+          }
+        }
+      }
+    }
+    // If the results are not JSON:
+    catch(error) {
+      const message = `Result processing failed (${(error as Error).message})`;
+      console.log(`ERROR: ${message}`);
+      // Report this.
+      data.prevented = true;
+      data.error = message;
+    }
+  }
+  return {
+    data,
+    result
+  };
+};

--- a/tests/axe.d.ts
+++ b/tests/axe.d.ts
@@ -1,0 +1,27 @@
+import type { Page } from 'playwright';
+import type { AxeResults } from 'axe-core';
+import type { Report, StandardResult } from '../types';
+type AxeImpact = 'minor' | 'moderate' | 'serious' | 'critical';
+interface AxeNativeResult {
+    totals?: {
+        rulesNA: number;
+        rulesPassed: number;
+        rulesWarned: number;
+        rulesViolated: number;
+        warnings: Record<AxeImpact, number>;
+        violations: Record<AxeImpact, number>;
+    };
+    details?: AxeResults;
+}
+interface AxeData {
+    prevented?: boolean;
+    error?: string;
+}
+export declare const reporter: (page: Page, report: Report, actIndex: number) => Promise<{
+    data: AxeData;
+    result: {
+        nativeResult: AxeNativeResult;
+        standardResult: StandardResult;
+    };
+}>;
+export {};

--- a/tests/axe.js
+++ b/tests/axe.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2021–2024 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -8,7 +9,18 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const xPath_1 = require("../procs/xPath");
+const axePlaywright = require('axe-playwright');
+// CONSTANTS
+const { injectAxe } = axePlaywright;
+const severityWeights = {
+    minor: 0,
+    moderate: 0,
+    serious: 1,
+    critical: 1
+};
 /*
   axe
   Implements the axe-core ruleset for accessibility.
@@ -28,215 +40,200 @@
   incomplete categories, node totals by severity. It does not show rule or node totals by test
   category (“tag”), such as 'wcag21aaa'. Scoring can consider test categories by getting the value
   of the 'tags' property of each rule.
+  Compiled to axe.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const axePlaywright = require('axe-playwright');
-const {getAttributeXPath, getXPathCatalogIndex} = require('../procs/xPath');
-
-// CONSTANTS
-
-const {injectAxe} = axePlaywright;
-const severityWeights = {
-  minor: 0,
-  moderate: 0,
-  serious: 1,
-  critical: 1
-};
-
 // FUNCTIONS
-
 // Conducts and reports the Axe tests.
-exports.reporter = async (page, report, actIndex) => {
-  const act = report.acts[actIndex];
-  const {detailLevel, rules} = act;
-  // Initialize the act report.
-  let data = {};
-  const result = {
-    nativeResult: {},
-    standardResult: {}
-  };
-  const standard = report.standard !== 'no';
-  // If standard results are to be reported:
-  if (standard) {
-    // Initialize the standard result.
-    result.standardResult = {
-      prevented: false,
-      totals: [0, 0, 0, 0],
-      instances: []
+const reporter = async (page, report, actIndex) => {
+    const act = report.acts[actIndex];
+    const { detailLevel, rules } = act;
+    // Initialize the act report.
+    let data = {};
+    const result = {
+        nativeResult: {},
+        standardResult: {}
     };
-  }
-  const {nativeResult, standardResult} = result;
-  // Inject axe-core into the page.
-  await injectAxe(page)
-  .catch(error => {
-    console.log(`ERROR: Axe injection failed (${error.message})`);
-    data.prevented = true;
-    data.error = 'ERROR: axe injection failed';
-  });
-  // If the injection succeeded:
-  if (! data.prevented) {
-    // Get the data on the elements violating the specified axe-core rules.
-    const axeOptions = {
-      resultTypes: ['violations', 'incomplete']
-    };
-    if (rules && rules.length) {
-      axeOptions.runOnly = rules;
+    const standard = report.standard !== 'no';
+    // If standard results are to be reported:
+    if (standard) {
+        // Initialize the standard result.
+        result.standardResult = {
+            prevented: false,
+            totals: [0, 0, 0, 0],
+            instances: []
+        };
     }
-    else {
-      axeOptions.runOnly = ['experimental', 'best-practice', 'wcag2a', 'wcag2aa', 'wcag2aaa', 'wcag21a', 'wcag21aa', 'wcag21aaa'];
-    }
-    const axeReport = await axePlaywright.getAxeResults(page, null, axeOptions);
-    const {inapplicable, passes, incomplete, violations} = axeReport;
-    // If the test succeeded:
-    if (violations) {
-      // Initialize the native result.
-      nativeResult.totals = {
-        rulesNA: 0,
-        rulesPassed: 0,
-        rulesWarned: 0,
-        rulesViolated: 0,
-        warnings: {
-          minor: 0,
-          moderate: 0,
-          serious: 0,
-          critical: 0
-        },
-        violations: {
-          minor: 0,
-          moderate: 0,
-          serious: 0,
-          critical: 0
+    const { nativeResult, standardResult } = result;
+    // Inject axe-core into the page.
+    await injectAxe(page)
+        .catch(error => {
+        console.log(`ERROR: Axe injection failed (${error.message})`);
+        data.prevented = true;
+        data.error = 'ERROR: axe injection failed';
+    });
+    // If the injection succeeded:
+    if (!data.prevented) {
+        // Get the data on the elements violating the specified axe-core rules.
+        const axeOptions = {
+            resultTypes: ['violations', 'incomplete']
+        };
+        if (rules && rules.length) {
+            axeOptions.runOnly = rules;
         }
-      };
-      nativeResult.details = axeReport;
-      // Populate the native-result totals.
-      const {totals} = nativeResult;
-      totals.rulesNA = inapplicable.length;
-      totals.rulesPassed = passes.length;
-      incomplete.forEach(rule => {
-        totals.rulesWarned++;
-        rule.nodes.forEach(node => {
-          totals.warnings[node.impact]++;
-        });
-      });
-      violations.forEach(rule => {
-        totals.rulesViolated++;
-        rule.nodes.forEach(node => {
-          totals.violations[node.impact]++;
-        });
-      });
-      // Delete irrelevant properties from the report details.
-      const irrelevants = ['inapplicable', 'passes', 'incomplete', 'violations']
-      .slice(0, 4 - detailLevel);
-      irrelevants.forEach(irrelevant => {
-        delete axeReport[irrelevant];
-      });
-      // If standard results are to be reported and there are any suspicions:
-      if (standard && (totals.rulesViolated || totals.rulesWarned)) {
-        // Resolve each suspected element's FULL data-xpath from the live DOM,
-        // keyed by its axe target. axe-core truncates node.html (~300 chars,
-        // appends '...'), so parsing data-xpath out of node.html yields a
-        // truncated XPath for elements with long attribute lists. node.target
-        // is a reliable CSS selector; read the injected data-xpath directly off
-        // the element instead. Falls back to the node.html parse on any failure.
-        const fullXPathByTargetKey = {};
-        try {
-          const suspectNodes = ['incomplete', 'violations']
-          .filter(certainty => nativeResult?.details?.[certainty])
-          .flatMap(certainty => nativeResult.details[certainty].flatMap(rule => rule.nodes));
-          const targets = suspectNodes.map(node => node.target);
-          const resolvedXPaths = await page.evaluate(targetList => targetList.map(target => {
-            try {
-              // axe target is an array of selectors (nested arrays for frames/
-              // shadow roots). Use the deepest plain-string selector for the
-              // common, non-framed case; skip otherwise.
-              const selector = Array.isArray(target)
-                ? (typeof target[target.length - 1] === 'string' ? target[target.length - 1] : null)
-                : (typeof target === 'string' ? target : null);
-              if (! selector) {
-                return null;
-              }
-              const element = document.querySelector(selector);
-              return element ? element.getAttribute('data-xpath') : null;
-            }
-            catch(error) {
-              return null;
-            }
-          }), targets);
-          suspectNodes.forEach((node, index) => {
-            if (resolvedXPaths[index]) {
-              fullXPathByTargetKey[JSON.stringify(node.target)] = resolvedXPaths[index];
-            }
-          });
+        else {
+            axeOptions.runOnly = ['experimental', 'best-practice', 'wcag2a', 'wcag2aa', 'wcag2aaa', 'wcag21a', 'wcag21aa', 'wcag21aaa'];
         }
-        catch(error) {
-          // Leave the map empty; every instance falls back to node.html below.
-        }
-        // For each certainty type:
-        ['incomplete', 'violations'].forEach(certainty => {
-          // If there are any suspicions of this type:
-          if (nativeResult?.details?.[certainty]) {
-            // For each rule with any suspicions:
-            nativeResult.details[certainty].forEach(rule => {
-              // For each element suspected of violating the rule:
-              rule.nodes.forEach(node => {
-                // Get descriptions of the rule.
-                const whatSet = new Set([
-                  rule.help,
-                  ... node.any.map(anyItem => anyItem.message),
-                  ... node.all.map(allItem => allItem.message)
-                ]);
-                // Get the ordinal severity of the suspicion.
-                const ordinalSeverity = severityWeights[node.impact]
-                + (certainty === 'violations' ? 2 : 0);
-                // Increment the standard total.
-                standardResult.totals[ordinalSeverity]++;
-                // Get the XPath of the suspected element from its data-xpath
-                // attribute. Prefer the full value resolved from the live DOM
-                // (above); fall back to parsing it out of axe's node.html,
-                // which axe truncates and can corrupt the XPath.
-                const xPath = fullXPathByTargetKey[JSON.stringify(node.target)]
-                || getAttributeXPath(node.html);
-                const instance = {
-                  ruleID: rule.id,
-                  what: Array.from(whatSet.values()).join('; '),
-                  ordinalSeverity,
-                  count: 1,
-                  catalogIndex: getXPathCatalogIndex(report, xPath)
-                };
-                standardResult.instances.push(instance);
-              });
+        const axeReport = await axePlaywright.getAxeResults(page, null, axeOptions);
+        const { inapplicable, passes, incomplete, violations } = axeReport;
+        // If the test succeeded:
+        if (violations) {
+            // Initialize the native result.
+            nativeResult.totals = {
+                rulesNA: 0,
+                rulesPassed: 0,
+                rulesWarned: 0,
+                rulesViolated: 0,
+                warnings: {
+                    minor: 0,
+                    moderate: 0,
+                    serious: 0,
+                    critical: 0
+                },
+                violations: {
+                    minor: 0,
+                    moderate: 0,
+                    serious: 0,
+                    critical: 0
+                }
+            };
+            nativeResult.details = axeReport;
+            // Populate the native-result totals.
+            const { totals } = nativeResult;
+            totals.rulesNA = inapplicable.length;
+            totals.rulesPassed = passes.length;
+            incomplete.forEach(rule => {
+                totals.rulesWarned++;
+                rule.nodes.forEach(node => {
+                    totals.warnings[node.impact]++;
+                });
             });
-          }
-        });
-      }
+            violations.forEach(rule => {
+                totals.rulesViolated++;
+                rule.nodes.forEach(node => {
+                    totals.violations[node.impact]++;
+                });
+            });
+            // Delete irrelevant properties from the report details.
+            const irrelevants = ['inapplicable', 'passes', 'incomplete', 'violations']
+                .slice(0, 4 - detailLevel);
+            irrelevants.forEach(irrelevant => {
+                delete axeReport[irrelevant];
+            });
+            // If standard results are to be reported and there are any suspicions:
+            if (standard && (totals.rulesViolated || totals.rulesWarned)) {
+                // Resolve each suspected element's FULL data-xpath from the live DOM,
+                // keyed by its axe target. axe-core truncates node.html (~300 chars,
+                // appends '...'), so parsing data-xpath out of node.html yields a
+                // truncated XPath for elements with long attribute lists. node.target
+                // is a reliable CSS selector; read the injected data-xpath directly off
+                // the element instead. Falls back to the node.html parse on any failure.
+                const fullXPathByTargetKey = {};
+                try {
+                    const suspectNodes = ['incomplete', 'violations']
+                        .filter(certainty => nativeResult?.details?.[certainty])
+                        .flatMap(certainty => nativeResult.details[certainty].flatMap(rule => rule.nodes));
+                    const targets = suspectNodes.map(node => node.target);
+                    const resolvedXPaths = await page.evaluate(targetList => targetList.map(target => {
+                        try {
+                            // axe target is an array of selectors (nested arrays for frames/
+                            // shadow roots). Use the deepest plain-string selector for the
+                            // common, non-framed case; skip otherwise.
+                            const selector = Array.isArray(target)
+                                ? (typeof target[target.length - 1] === 'string' ? target[target.length - 1] : null)
+                                : (typeof target === 'string' ? target : null);
+                            if (!selector) {
+                                return null;
+                            }
+                            const element = document.querySelector(selector);
+                            return element ? element.getAttribute('data-xpath') : null;
+                        }
+                        catch (error) {
+                            return null;
+                        }
+                    }), targets);
+                    suspectNodes.forEach((node, index) => {
+                        if (resolvedXPaths[index]) {
+                            fullXPathByTargetKey[JSON.stringify(node.target)] = resolvedXPaths[index];
+                        }
+                    });
+                }
+                catch (error) {
+                    // Leave the map empty; every instance falls back to node.html below.
+                }
+                // For each certainty type:
+                ['incomplete', 'violations'].forEach(certainty => {
+                    // If there are any suspicions of this type:
+                    if (nativeResult?.details?.[certainty]) {
+                        // For each rule with any suspicions:
+                        nativeResult.details[certainty].forEach(rule => {
+                            // For each element suspected of violating the rule:
+                            rule.nodes.forEach((node) => {
+                                // Get descriptions of the rule.
+                                const whatSet = new Set([
+                                    rule.help,
+                                    ...node.any.map(anyItem => anyItem.message),
+                                    ...node.all.map(allItem => allItem.message)
+                                ]);
+                                // Get the ordinal severity of the suspicion.
+                                const ordinalSeverity = severityWeights[node.impact]
+                                    + (certainty === 'violations' ? 2 : 0);
+                                // Increment the standard total.
+                                standardResult.totals[ordinalSeverity]++;
+                                // Get the XPath of the suspected element from its data-xpath
+                                // attribute. Prefer the full value resolved from the live DOM
+                                // (above); fall back to parsing it out of axe's node.html,
+                                // which axe truncates and can corrupt the XPath.
+                                const xPath = fullXPathByTargetKey[JSON.stringify(node.target)]
+                                    || (0, xPath_1.getAttributeXPath)(node.html);
+                                const instance = {
+                                    ruleID: rule.id,
+                                    what: Array.from(whatSet.values()).join('; '),
+                                    ordinalSeverity: ordinalSeverity,
+                                    count: 1,
+                                    catalogIndex: (0, xPath_1.getXPathCatalogIndex)(report, xPath)
+                                };
+                                standardResult.instances.push(instance);
+                            });
+                        });
+                    }
+                });
+            }
+        }
+        // Otherwise, i.e. if the test failed:
+        else {
+            // Report this.
+            data.prevented = true;
+            data.error = 'ERROR: Act failed';
+            if (standard) {
+                standardResult.prevented = true;
+            }
+        }
     }
-    // Otherwise, i.e. if the test failed:
-    else {
-      // Report this.
-      data.prevented = true;
-      data.error = 'ERROR: Act failed';
-      if (standard) {
-        standardResult.prevented = true;
-      }
+    // Return the result.
+    try {
+        JSON.stringify(data);
     }
-  }
-  // Return the result.
-  try {
-    JSON.stringify(data);
-  }
-  catch(error) {
-    const message = `ERROR: Axe result cannot be made JSON (${error.message})`;
-    console.log(message);
-    data = {
-      prevented: true,
-      error: message
+    catch (error) {
+        const message = `ERROR: Axe result cannot be made JSON (${error.message})`;
+        console.log(message);
+        data = {
+            prevented: true,
+            error: message
+        };
+    }
+    return {
+        data,
+        result
     };
-  }
-  return {
-    data,
-    result
-  };
 };
+exports.reporter = reporter;

--- a/tests/axe.ts
+++ b/tests/axe.ts
@@ -1,0 +1,275 @@
+/*
+  © 2021–2024 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import type {AxeResults, NodeResult, RunOptions} from 'axe-core';
+import {getAttributeXPath, getXPathCatalogIndex} from '../procs/xPath';
+import type {Act, Report, StandardInstance, StandardResult} from '../types';
+const axePlaywright = require('axe-playwright') as typeof import('axe-playwright');
+
+// TYPES
+
+// The axe-act properties this reporter consumes.
+interface AxeAct extends Act {
+  detailLevel?: number;
+  rules?: string[];
+}
+// The impact-classified severity of an axe node.
+type AxeImpact = 'minor' | 'moderate' | 'serious' | 'critical';
+// The native result: rule and node totals and the axe report details.
+interface AxeNativeResult {
+  totals?: {
+    rulesNA: number;
+    rulesPassed: number;
+    rulesWarned: number;
+    rulesViolated: number;
+    warnings: Record<AxeImpact, number>;
+    violations: Record<AxeImpact, number>;
+  };
+  details?: AxeResults;
+}
+// The data of the act report.
+interface AxeData {
+  prevented?: boolean;
+  error?: string;
+}
+
+// CONSTANTS
+
+const {injectAxe} = axePlaywright;
+const severityWeights: Record<AxeImpact, number> = {
+  minor: 0,
+  moderate: 0,
+  serious: 1,
+  critical: 1
+};
+
+/*
+  axe
+  Implements the axe-core ruleset for accessibility.
+
+  The rules argument defaults to all rules; otherwise, specify an array of rule names.
+
+  The detailLevel argument specifies how many result categories are to be included in the
+  details. 0 = none; 1 = violations; 2 = violations and incomplete; 3 = violations, incomplete,
+  and passes; 4 = violations, incomplete, passes, and inapplicable. Regardless of the value of this
+  argument, Axe-core is instructed to report all nodes with violation or incomplete results, but
+  only 1 node per rule found to be passed or inapplicable. Therefore, from the results of this test
+  it is possible to count the rules passed and the inapplicable rules, but not the nodes for which
+  each rule is passed or inapplicable. To count those nodes, one would need to revise the
+  'resultTypes' property of the 'axeOptions' object.
+
+  The report of this test shows rule totals by result category and, within the violation and
+  incomplete categories, node totals by severity. It does not show rule or node totals by test
+  category (“tag”), such as 'wcag21aaa'. Scoring can consider test categories by getting the value
+  of the 'tags' property of each rule.
+  Compiled to axe.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Conducts and reports the Axe tests.
+export const reporter = async (page: Page, report: Report, actIndex: number) => {
+  const act = report.acts[actIndex] as AxeAct;
+  const {detailLevel, rules} = act;
+  // Initialize the act report.
+  let data: AxeData = {};
+  const result: {nativeResult: AxeNativeResult; standardResult: StandardResult} = {
+    nativeResult: {},
+    standardResult: {}
+  };
+  const standard = report.standard !== 'no';
+  // If standard results are to be reported:
+  if (standard) {
+    // Initialize the standard result.
+    result.standardResult = {
+      prevented: false,
+      totals: [0, 0, 0, 0],
+      instances: []
+    };
+  }
+  const {nativeResult, standardResult} = result;
+  // Inject axe-core into the page.
+  await injectAxe(page as Parameters<typeof injectAxe>[0])
+  .catch(error => {
+    console.log(`ERROR: Axe injection failed (${error.message})`);
+    data.prevented = true;
+    data.error = 'ERROR: axe injection failed';
+  });
+  // If the injection succeeded:
+  if (! data.prevented) {
+    // Get the data on the elements violating the specified axe-core rules.
+    const axeOptions: RunOptions = {
+      resultTypes: ['violations', 'incomplete']
+    };
+    if (rules && rules.length) {
+      axeOptions.runOnly = rules;
+    }
+    else {
+      axeOptions.runOnly = ['experimental', 'best-practice', 'wcag2a', 'wcag2aa', 'wcag2aaa', 'wcag21a', 'wcag21aa', 'wcag21aaa'];
+    }
+    const axeReport = await axePlaywright.getAxeResults(
+      page as Parameters<typeof injectAxe>[0], null as unknown as undefined, axeOptions
+    );
+    const {inapplicable, passes, incomplete, violations} = axeReport;
+    // If the test succeeded:
+    if (violations) {
+      // Initialize the native result.
+      nativeResult.totals = {
+        rulesNA: 0,
+        rulesPassed: 0,
+        rulesWarned: 0,
+        rulesViolated: 0,
+        warnings: {
+          minor: 0,
+          moderate: 0,
+          serious: 0,
+          critical: 0
+        },
+        violations: {
+          minor: 0,
+          moderate: 0,
+          serious: 0,
+          critical: 0
+        }
+      };
+      nativeResult.details = axeReport;
+      // Populate the native-result totals.
+      const {totals} = nativeResult;
+      totals.rulesNA = inapplicable.length;
+      totals.rulesPassed = passes.length;
+      incomplete.forEach(rule => {
+        totals.rulesWarned++;
+        rule.nodes.forEach(node => {
+          totals.warnings[node.impact as AxeImpact]++;
+        });
+      });
+      violations.forEach(rule => {
+        totals.rulesViolated++;
+        rule.nodes.forEach(node => {
+          totals.violations[node.impact as AxeImpact]++;
+        });
+      });
+      // Delete irrelevant properties from the report details.
+      const irrelevants = ['inapplicable', 'passes', 'incomplete', 'violations']
+      .slice(0, 4 - (detailLevel as number));
+      irrelevants.forEach(irrelevant => {
+        delete (axeReport as unknown as Record<string, unknown>)[irrelevant];
+      });
+      // If standard results are to be reported and there are any suspicions:
+      if (standard && (totals.rulesViolated || totals.rulesWarned)) {
+        // Resolve each suspected element's FULL data-xpath from the live DOM,
+        // keyed by its axe target. axe-core truncates node.html (~300 chars,
+        // appends '...'), so parsing data-xpath out of node.html yields a
+        // truncated XPath for elements with long attribute lists. node.target
+        // is a reliable CSS selector; read the injected data-xpath directly off
+        // the element instead. Falls back to the node.html parse on any failure.
+        const fullXPathByTargetKey: Record<string, string> = {};
+        try {
+          const suspectNodes = (['incomplete', 'violations'] as const)
+          .filter(certainty => nativeResult?.details?.[certainty])
+          .flatMap(certainty => nativeResult.details![certainty].flatMap(rule => rule.nodes));
+          const targets = suspectNodes.map(node => node.target as unknown as string | string[]);
+          const resolvedXPaths = await page.evaluate(targetList => targetList.map(target => {
+            try {
+              // axe target is an array of selectors (nested arrays for frames/
+              // shadow roots). Use the deepest plain-string selector for the
+              // common, non-framed case; skip otherwise.
+              const selector = Array.isArray(target)
+                ? (typeof target[target.length - 1] === 'string' ? target[target.length - 1] : null)
+                : (typeof target === 'string' ? target : null);
+              if (! selector) {
+                return null;
+              }
+              const element = document.querySelector(selector);
+              return element ? element.getAttribute('data-xpath') : null;
+            }
+            catch(error) {
+              return null;
+            }
+          }), targets);
+          suspectNodes.forEach((node, index) => {
+            if (resolvedXPaths[index]) {
+              fullXPathByTargetKey[JSON.stringify(node.target)] = resolvedXPaths[index];
+            }
+          });
+        }
+        catch(error) {
+          // Leave the map empty; every instance falls back to node.html below.
+        }
+        // For each certainty type:
+        (['incomplete', 'violations'] as const).forEach(certainty => {
+          // If there are any suspicions of this type:
+          if (nativeResult?.details?.[certainty]) {
+            // For each rule with any suspicions:
+            nativeResult.details[certainty].forEach(rule => {
+              // For each element suspected of violating the rule:
+              rule.nodes.forEach((node: NodeResult) => {
+                // Get descriptions of the rule.
+                const whatSet = new Set([
+                  rule.help,
+                  ... node.any.map(anyItem => anyItem.message),
+                  ... node.all.map(allItem => allItem.message)
+                ]);
+                // Get the ordinal severity of the suspicion.
+                const ordinalSeverity = severityWeights[node.impact as AxeImpact]
+                + (certainty === 'violations' ? 2 : 0);
+                // Increment the standard total.
+                standardResult.totals![ordinalSeverity]++;
+                // Get the XPath of the suspected element from its data-xpath
+                // attribute. Prefer the full value resolved from the live DOM
+                // (above); fall back to parsing it out of axe's node.html,
+                // which axe truncates and can corrupt the XPath.
+                const xPath = fullXPathByTargetKey[JSON.stringify(node.target)]
+                || getAttributeXPath(node.html);
+                const instance: StandardInstance = {
+                  ruleID: rule.id,
+                  what: Array.from(whatSet.values()).join('; '),
+                  ordinalSeverity: ordinalSeverity as StandardInstance['ordinalSeverity'],
+                  count: 1,
+                  catalogIndex: getXPathCatalogIndex(report, xPath)
+                };
+                standardResult.instances!.push(instance);
+              });
+            });
+          }
+        });
+      }
+    }
+    // Otherwise, i.e. if the test failed:
+    else {
+      // Report this.
+      data.prevented = true;
+      data.error = 'ERROR: Act failed';
+      if (standard) {
+        standardResult.prevented = true;
+      }
+    }
+  }
+  // Return the result.
+  try {
+    JSON.stringify(data);
+  }
+  catch(error) {
+    const message = `ERROR: Axe result cannot be made JSON (${(error as Error).message})`;
+    console.log(message);
+    data = {
+      prevented: true,
+      error: message
+    };
+  }
+  return {
+    data,
+    result
+  };
+};

--- a/tests/ibm.d.ts
+++ b/tests/ibm.d.ts
@@ -1,0 +1,52 @@
+import type { Page } from 'playwright';
+import type { Report, StandardResult } from '../types';
+interface IbmItem {
+    ruleId: string;
+    level: string;
+    message: string;
+    snippet: string;
+    apiArgs?: unknown;
+    category?: unknown;
+    ignored?: unknown;
+    messageArgs?: unknown;
+    reasonId?: unknown;
+    ruleTime?: unknown;
+    value?: unknown;
+}
+interface IbmCounts {
+    violation: number;
+    recommendation: number;
+    [key: string]: number;
+}
+interface IbmActReport {
+    summary?: {
+        counts?: IbmCounts;
+    };
+    results: IbmItem[];
+    items?: IbmItem[];
+}
+type IbmTrimmedReport = {
+    totals: IbmCounts;
+    items: IbmItem[] | undefined;
+    error?: undefined;
+} | {
+    totals: null;
+    items: IbmItem[];
+    error: string;
+};
+export declare const reporter: (page: Page, report: Report, actIndex: number) => Promise<{
+    data: {};
+    result: {
+        nativeResult: IbmTrimmedReport | Record<string, never>;
+        standardResult: StandardResult;
+    };
+} | {
+    data: {
+        report: IbmActReport;
+    } | {
+        prevented: boolean;
+        error: string;
+    };
+    result: {};
+}>;
+export {};

--- a/tests/ibm.js
+++ b/tests/ibm.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2021–2024 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -8,7 +9,11 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const xPath_1 = require("../procs/xPath");
+const accessibilityChecker = require('accessibility-checker');
+const { getCompliance } = accessibilityChecker;
 /*
   ibm
   Implements the IBM Equal Access ruleset for accessibility.
@@ -17,192 +22,187 @@
 
   This rule engine is compatible with Windows only if the accessibility-checker package
   is revised. See README.md for details.
+  Compiled to ibm.js by tsc (issue #73); edit this file, not the emitted one.
 */
-
-// IMPORTS
-
-const {getAttributeXPath, getXPathCatalogIndex} = require('../procs/xPath');
-const accessibilityChecker = require('accessibility-checker');
-const {getCompliance} = accessibilityChecker;
-
 // FUNCTIONS
-
 // Runs the IBM test and returns the result.
-const run = async content => {
-  const nowLabel = (new Date()).toISOString().slice(0, 19);
-  try {
-    const ibmReport = await getCompliance(content, nowLabel);
-    if (typeof ibmReport === 'object' && ibmReport.report) {
-      return ibmReport;
+const run = async (content) => {
+    const nowLabel = (new Date()).toISOString().slice(0, 19);
+    try {
+        const ibmReport = await getCompliance(content, nowLabel);
+        if (typeof ibmReport === 'object' && ibmReport.report) {
+            return ibmReport;
+        }
+        else {
+            return {
+                prevented: true,
+                error: 'ibm getCompliance produced no report'
+            };
+        }
     }
-    else {
-      return {
-        prevented: true,
-        error: 'ibm getCompliance produced no report'
-      };
+    catch (error) {
+        console.log('ibm getCompliance failed');
+        return {
+            prevented: true,
+            error: error.message.slice(0, 200)
+        };
     }
-  }
-  catch(error) {
-    console.log('ibm getCompliance failed');
-    return {
-      prevented: true,
-      error: error.message.slice(0, 200)
-    };
-  }
 };
 // Revises act-report totals for any rule limitation.
 const limitRuleTotals = (actReport, rules) => {
-  if (rules && Array.isArray(rules) && rules.length) {
-    const totals = actReport.summary.counts;
-    const items = actReport.results;
-    totals.violation = totals.recommendation = 0;
-    items.forEach(item => {
-      if (rules.includes(item.ruleId)) {
-        totals[item.level]++;
-      }
-    });
-  }
+    if (rules && Array.isArray(rules) && rules.length) {
+        const totals = actReport.summary.counts;
+        const items = actReport.results;
+        totals.violation = totals.recommendation = 0;
+        items.forEach(item => {
+            if (rules.includes(item.ruleId)) {
+                totals[item.level]++;
+            }
+        });
+    }
 };
 // Trims an IBM report.
 const trimActReport = (actReport, withItems, rules) => {
-  // If the act report includes a summary:
-  if (actReport && actReport.summary) {
-    // Remove excluded rules from the act report.
-    limitRuleTotals(actReport, rules);
-    const totals = actReport.summary.counts;
-    // If the act report includes totals:
-    if (totals) {
-      // If itemization is required:
-      if (withItems) {
-        // Trim the items.
-        if (rules && Array.isArray(rules) && rules.length) {
-          actReport.items = actReport.results.filter(item => rules.includes(item.ruleId));
+    // If the act report includes a summary:
+    if (actReport && actReport.summary) {
+        // Remove excluded rules from the act report.
+        limitRuleTotals(actReport, rules);
+        const totals = actReport.summary.counts;
+        // If the act report includes totals:
+        if (totals) {
+            // If itemization is required:
+            if (withItems) {
+                // Trim the items.
+                if (rules && Array.isArray(rules) && rules.length) {
+                    actReport.items = actReport.results.filter(item => rules.includes(item.ruleId));
+                }
+                else {
+                    actReport.items = actReport.results;
+                }
+                actReport.items.forEach(item => {
+                    delete item.apiArgs;
+                    delete item.category;
+                    delete item.ignored;
+                    delete item.messageArgs;
+                    delete item.reasonId;
+                    delete item.ruleTime;
+                    delete item.value;
+                });
+            }
+            // Return the act report, trimmed.
+            return {
+                totals,
+                items: actReport.items
+            };
         }
+        // Otherwise, i.e. if it excludes totals:
         else {
-          actReport.items = actReport.results;
+            // Return an act report with this error.
+            return {
+                totals: null,
+                items: [],
+                error: 'No totals reported'
+            };
         }
-        actReport.items.forEach(item => {
-          delete item.apiArgs;
-          delete item.category;
-          delete item.ignored;
-          delete item.messageArgs;
-          delete item.reasonId;
-          delete item.ruleTime;
-          delete item.value;
-        });
-      }
-      // Return the act report, trimmed.
-      return {
-        totals,
-        items: actReport.items
-      };
     }
-    // Otherwise, i.e. if it excludes totals:
+    // Otherwise, i.e. if it excludes a summary:
     else {
-      // Return an act report with this error.
-      return {
-        totals: null,
-        items: [],
-        error: 'No totals reported'
-      };
-    }
-  }
-  // Otherwise, i.e. if it excludes a summary:
-  else {
-    // Return an act report with this error.
-    return {
-      totals: null,
-      items: [],
-      error: 'No summary reported'
-    };
-  }
-};
-// Conducts and reports the IBM Equal Access tests.
-exports.reporter = async (page, report, actIndex) => {
-  const act = report.acts[actIndex];
-  const {withItems, rules} = act;
-  // Initialize the act report.
-  const result = {
-    nativeResult: {},
-    standardResult: {}
-  };
-  const standard = report.standard !== 'no';
-  // If standard results are to be reported:
-  if (standard) {
-    // Initialize the standard result.
-    result.standardResult = {
-      prevented: false,
-      totals: [0, 0, 0, 0],
-      instances: []
-    };
-  }
-  try {
-    // Conduct the tests.
-    const runReport = await run(page);
-    const actReport = runReport.report;
-    // If there were results:
-    if (actReport) {
-      // Trim them.
-      result.nativeResult = trimActReport(actReport, withItems, rules);
-      const {nativeResult, standardResult} = result;
-      const {error, totals} = nativeResult;
-      // If they were not trimmable:
-      if (error) {
         // Return an act report with this error.
         return {
-          data: {
-            prevented: true,
-            error
-          },
-          result: {}
-        }
-      }
-      // Otherwise, i.e. if they were trimmable, and if standard results are to be reported:
-      if (standard) {
-        // Populate the totals of the standard result.
-        standardResult.totals = [totals.recommendation, 0, totals.violation, 0];
-        // For each item of the native result:
-        nativeResult.items.forEach(item => {
-          // Populate a standard instance.
-          const standardItem = {
-            ruleID: item.ruleId,
-            what: item.message,
-            ordinalSeverity: item.level === 'recommendation' ? 0 : 2,
-            count: 1
-          };
-          // Get the XPath from the added attribute, because path.dom is wrong.
-          const xPath = getAttributeXPath(item.snippet);
-          // If the XPath was obtained:
-          if (xPath) {
-            // Add the catalog index to the standard instance.
-            standardItem.catalogIndex = getXPathCatalogIndex(report, xPath);
-          }
-          // Add the standard instance to the standard result.
-          standardResult.instances.push(standardItem);
-        });
-      }
-      return {
-        data: {},
-        result
-      };
+            totals: null,
+            items: [],
+            error: 'No summary reported'
+        };
     }
-    // Otherwise, i.e. if there was only an error, return it in an act report.
-    return {
-      data: runReport,
-      result: {}
-    }
-  }
-  // If an error occurred:
-  catch(error) {
-    const message = `Act failed (${error.message.slice(0, 200)})`;
-    console.log(message);
-    // Return it in an act report.
-    return {
-      data: {
-        prevented: true,
-        error: message
-      },
-      result: {}
-    };
-  }
 };
+// Conducts and reports the IBM Equal Access tests.
+const reporter = async (page, report, actIndex) => {
+    const act = report.acts[actIndex];
+    const { withItems, rules } = act;
+    // Initialize the act report.
+    const result = {
+        nativeResult: {},
+        standardResult: {}
+    };
+    const standard = report.standard !== 'no';
+    // If standard results are to be reported:
+    if (standard) {
+        // Initialize the standard result.
+        result.standardResult = {
+            prevented: false,
+            totals: [0, 0, 0, 0],
+            instances: []
+        };
+    }
+    try {
+        // Conduct the tests.
+        const runReport = await run(page);
+        const actReport = runReport.report;
+        // If there were results:
+        if (actReport) {
+            // Trim them.
+            result.nativeResult = trimActReport(actReport, withItems, rules);
+            const { nativeResult, standardResult } = result;
+            const { error, totals } = nativeResult;
+            // If they were not trimmable:
+            if (error) {
+                // Return an act report with this error.
+                return {
+                    data: {
+                        prevented: true,
+                        error
+                    },
+                    result: {}
+                };
+            }
+            // Otherwise, i.e. if they were trimmable, and if standard results are to be reported:
+            if (standard) {
+                // Populate the totals of the standard result.
+                standardResult.totals = [totals.recommendation, 0, totals.violation, 0];
+                // For each item of the native result (without itemization, items is
+                // undefined and this throws, caught below; verbatim from the original):
+                nativeResult.items.forEach(item => {
+                    // Populate a standard instance.
+                    const standardItem = {
+                        ruleID: item.ruleId,
+                        what: item.message,
+                        ordinalSeverity: item.level === 'recommendation' ? 0 : 2,
+                        count: 1
+                    };
+                    // Get the XPath from the added attribute, because path.dom is wrong.
+                    const xPath = (0, xPath_1.getAttributeXPath)(item.snippet);
+                    // If the XPath was obtained:
+                    if (xPath) {
+                        // Add the catalog index to the standard instance.
+                        standardItem.catalogIndex = (0, xPath_1.getXPathCatalogIndex)(report, xPath);
+                    }
+                    // Add the standard instance to the standard result.
+                    standardResult.instances.push(standardItem);
+                });
+            }
+            return {
+                data: {},
+                result
+            };
+        }
+        // Otherwise, i.e. if there was only an error, return it in an act report.
+        return {
+            data: runReport,
+            result: {}
+        };
+    }
+    // If an error occurred:
+    catch (error) {
+        const message = `Act failed (${error.message.slice(0, 200)})`;
+        console.log(message);
+        // Return it in an act report.
+        return {
+            data: {
+                prevented: true,
+                error: message
+            },
+            result: {}
+        };
+    }
+};
+exports.reporter = reporter;

--- a/tests/ibm.ts
+++ b/tests/ibm.ts
@@ -1,0 +1,253 @@
+/*
+  © 2021–2024 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {getAttributeXPath, getXPathCatalogIndex} from '../procs/xPath';
+import type {Act, Report, StandardInstance, StandardResult} from '../types';
+const accessibilityChecker = require('accessibility-checker') as typeof import('accessibility-checker');
+const {getCompliance} = accessibilityChecker;
+
+// TYPES
+
+// The ibm-act properties this reporter consumes.
+interface IbmAct extends Act {
+  withItems?: boolean;
+  rules?: string[];
+}
+// One item (rule violation) of an IBM act report.
+interface IbmItem {
+  ruleId: string;
+  level: string;
+  message: string;
+  snippet: string;
+  apiArgs?: unknown;
+  category?: unknown;
+  ignored?: unknown;
+  messageArgs?: unknown;
+  reasonId?: unknown;
+  ruleTime?: unknown;
+  value?: unknown;
+}
+// The violation totals of an IBM act report.
+interface IbmCounts {
+  violation: number;
+  recommendation: number;
+  [key: string]: number;
+}
+// An IBM act report before trimming.
+interface IbmActReport {
+  summary?: {counts?: IbmCounts};
+  results: IbmItem[];
+  items?: IbmItem[];
+}
+// An IBM act report after trimming: results, or an error.
+type IbmTrimmedReport =
+  | {totals: IbmCounts; items: IbmItem[] | undefined; error?: undefined}
+  | {totals: null; items: IbmItem[]; error: string};
+
+/*
+  ibm
+  Implements the IBM Equal Access ruleset for accessibility.
+
+  This rule engine depends on aceconfig.js.
+
+  This rule engine is compatible with Windows only if the accessibility-checker package
+  is revised. See README.md for details.
+  Compiled to ibm.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Runs the IBM test and returns the result.
+const run = async (content: Page) => {
+  const nowLabel = (new Date()).toISOString().slice(0, 19);
+  try {
+    const ibmReport = await getCompliance(content, nowLabel);
+    if (typeof ibmReport === 'object' && ibmReport.report) {
+      return ibmReport as unknown as {report: IbmActReport};
+    }
+    else {
+      return {
+        prevented: true,
+        error: 'ibm getCompliance produced no report'
+      };
+    }
+  }
+  catch(error) {
+    console.log('ibm getCompliance failed');
+    return {
+      prevented: true,
+      error: (error as Error).message.slice(0, 200)
+    };
+  }
+};
+// Revises act-report totals for any rule limitation.
+const limitRuleTotals = (actReport: IbmActReport, rules: string[] | undefined) => {
+  if (rules && Array.isArray(rules) && rules.length) {
+    const totals = actReport.summary!.counts!;
+    const items = actReport.results;
+    totals.violation = totals.recommendation = 0;
+    items.forEach(item => {
+      if (rules.includes(item.ruleId)) {
+        totals[item.level]++;
+      }
+    });
+  }
+};
+// Trims an IBM report.
+const trimActReport = (
+  actReport: IbmActReport | undefined, withItems: boolean | undefined, rules: string[] | undefined
+): IbmTrimmedReport => {
+  // If the act report includes a summary:
+  if (actReport && actReport.summary) {
+    // Remove excluded rules from the act report.
+    limitRuleTotals(actReport, rules);
+    const totals = actReport.summary.counts;
+    // If the act report includes totals:
+    if (totals) {
+      // If itemization is required:
+      if (withItems) {
+        // Trim the items.
+        if (rules && Array.isArray(rules) && rules.length) {
+          actReport.items = actReport.results.filter(item => rules.includes(item.ruleId));
+        }
+        else {
+          actReport.items = actReport.results;
+        }
+        actReport.items.forEach(item => {
+          delete item.apiArgs;
+          delete item.category;
+          delete item.ignored;
+          delete item.messageArgs;
+          delete item.reasonId;
+          delete item.ruleTime;
+          delete item.value;
+        });
+      }
+      // Return the act report, trimmed.
+      return {
+        totals,
+        items: actReport.items
+      };
+    }
+    // Otherwise, i.e. if it excludes totals:
+    else {
+      // Return an act report with this error.
+      return {
+        totals: null,
+        items: [],
+        error: 'No totals reported'
+      };
+    }
+  }
+  // Otherwise, i.e. if it excludes a summary:
+  else {
+    // Return an act report with this error.
+    return {
+      totals: null,
+      items: [],
+      error: 'No summary reported'
+    };
+  }
+};
+// Conducts and reports the IBM Equal Access tests.
+export const reporter = async (page: Page, report: Report, actIndex: number) => {
+  const act = report.acts[actIndex] as IbmAct;
+  const {withItems, rules} = act;
+  // Initialize the act report.
+  const result: {nativeResult: IbmTrimmedReport | Record<string, never>; standardResult: StandardResult} = {
+    nativeResult: {},
+    standardResult: {}
+  };
+  const standard = report.standard !== 'no';
+  // If standard results are to be reported:
+  if (standard) {
+    // Initialize the standard result.
+    result.standardResult = {
+      prevented: false,
+      totals: [0, 0, 0, 0],
+      instances: []
+    };
+  }
+  try {
+    // Conduct the tests.
+    const runReport = await run(page);
+    const actReport = (runReport as {report?: IbmActReport}).report;
+    // If there were results:
+    if (actReport) {
+      // Trim them.
+      result.nativeResult = trimActReport(actReport, withItems, rules);
+      const {nativeResult, standardResult} = result as
+        {nativeResult: IbmTrimmedReport; standardResult: StandardResult};
+      const {error, totals} = nativeResult;
+      // If they were not trimmable:
+      if (error) {
+        // Return an act report with this error.
+        return {
+          data: {
+            prevented: true,
+            error
+          },
+          result: {}
+        }
+      }
+      // Otherwise, i.e. if they were trimmable, and if standard results are to be reported:
+      if (standard) {
+        // Populate the totals of the standard result.
+        standardResult.totals = [totals!.recommendation, 0, totals!.violation, 0];
+        // For each item of the native result (without itemization, items is
+        // undefined and this throws, caught below; verbatim from the original):
+        nativeResult.items!.forEach(item => {
+          // Populate a standard instance.
+          const standardItem: StandardInstance = {
+            ruleID: item.ruleId,
+            what: item.message,
+            ordinalSeverity: item.level === 'recommendation' ? 0 : 2,
+            count: 1
+          };
+          // Get the XPath from the added attribute, because path.dom is wrong.
+          const xPath = getAttributeXPath(item.snippet);
+          // If the XPath was obtained:
+          if (xPath) {
+            // Add the catalog index to the standard instance.
+            standardItem.catalogIndex = getXPathCatalogIndex(report, xPath);
+          }
+          // Add the standard instance to the standard result.
+          standardResult.instances!.push(standardItem);
+        });
+      }
+      return {
+        data: {},
+        result
+      };
+    }
+    // Otherwise, i.e. if there was only an error, return it in an act report.
+    return {
+      data: runReport,
+      result: {}
+    }
+  }
+  // If an error occurred:
+  catch(error) {
+    const message = `Act failed (${(error as Error).message.slice(0, 200)})`;
+    console.log(message);
+    // Return it in an act report.
+    return {
+      data: {
+        prevented: true,
+        error: message
+      },
+      result: {}
+    };
+  }
+};

--- a/tests/qualWeb.d.ts
+++ b/tests/qualWeb.d.ts
@@ -1,0 +1,39 @@
+import type { Page } from 'playwright';
+import type { Report, StandardResult } from '../types';
+interface QwElement {
+    htmlCode?: string;
+}
+interface QwRaResult {
+    verdict: string;
+    description?: string;
+    elements?: QwElement[];
+}
+interface QwRuleAssertions {
+    metadata?: {
+        warning?: number;
+        failed?: number;
+    };
+    results: QwRaResult[];
+}
+interface QwModuleReport {
+    assertions?: Record<string, QwRuleAssertions>;
+}
+interface QwNativeResult {
+    system?: {
+        page?: {
+            dom?: unknown;
+        };
+    };
+    modules?: Record<string, QwModuleReport>;
+}
+export declare const reporter: (page: Page, report: Report, actIndex: number, timeLimit: number) => Promise<{
+    data: {
+        prevented?: boolean;
+        error?: string;
+    };
+    result: {
+        nativeResult: QwNativeResult;
+        standardResult: StandardResult;
+    };
+}>;
+export {};

--- a/tests/qualWeb.js
+++ b/tests/qualWeb.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
   © 2023–2024 CVS Health and/or one of its affiliates. All rights reserved.
   © 2026 Jeff Witt.
@@ -8,297 +9,299 @@
 
   SPDX-License-Identifier: MIT
 */
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reporter = void 0;
+const xPath_1 = require("../procs/xPath");
 /*
-  qualWeb
-  Implements the QualWeb ruleset for accessibility.
+  The @qualweb packages declare their types only in package-exports maps, which
+  this project's node10 module resolution cannot read, so the imports stay
+  requires and are untyped.
 */
-
-// IMPORTS
-
-const {QualWeb} = require('@qualweb/core');
-const {ACTRules} = require('@qualweb/act-rules');
-const {WCAGTechniques} = require('@qualweb/wcag-techniques');
-const {BestPractices} = require('@qualweb/best-practices');
-const {PlaywrightDriver} = require('@qualweb/playwright-driver');
-const {getAttributeXPath, getXPathCatalogIndex} = require('../procs/xPath');
-
+const { QualWeb } = require('@qualweb/core');
+const { ACTRules } = require('@qualweb/act-rules');
+const { WCAGTechniques } = require('@qualweb/wcag-techniques');
+const { BestPractices } = require('@qualweb/best-practices');
+const { PlaywrightDriver } = require('@qualweb/playwright-driver');
 // CONSTANTS
-
 // QualWeb core engine with Playwright as driver.
 const qualWeb = new QualWeb(undefined, new PlaywrightDriver({
-  adBlock: true,
-  stealth: true
+    adBlock: true,
+    stealth: true
 }));
 const actRulesModule = new ACTRules({});
 const wcagModule = new WCAGTechniques({});
 const bpModule = new BestPractices({});
 // Mapping of QualWeb module violation types to ordinal severities.
 const ordinalSeverities = {
-  'act-rules': {
-    'warning': 1,
-    'failed': 3
-  },
-  'wcag-techniques': {
-    'warning': 0,
-    'failed': 2
-  },
-  'best-practices': {
-    'warning': 0,
-    'failed': 1
-  }
-}
-
+    'act-rules': {
+        'warning': 1,
+        'failed': 3
+    },
+    'wcag-techniques': {
+        'warning': 0,
+        'failed': 2
+    },
+    'best-practices': {
+        'warning': 0,
+        'failed': 1
+    }
+};
+/*
+  qualWeb
+  Implements the QualWeb ruleset for accessibility.
+  Compiled to qualWeb.js by tsc (issue #73); edit this file, not the emitted one.
+*/
 // FUNCTIONS
-
 // Conducts and reports the QualWeb tests.
-exports.reporter = async (page, report, actIndex, timeLimit) => {
-  const act = report.acts[actIndex];
-  const {rules} = act;
-  const clusterOptions = {
-    maxConcurrency: 1,
-    timeout: timeLimit * 1000,
-    monitor: false
-  };
-  // Initialize the act report.
-  const data = {};
-  const result = {
-    nativeResult: {},
-    standardResult: {}
-  };
-  const standard = report.standard !== 'no';
-  // If standard results are to be reported:
-  if (standard) {
-    // Initialize the standard result.
-    result.standardResult = {
-      prevented: false,
-      totals: [0, 0, 0, 0],
-      instances: []
+const reporter = async (page, report, actIndex, timeLimit) => {
+    const act = report.acts[actIndex];
+    const { rules } = act;
+    const clusterOptions = {
+        maxConcurrency: 1,
+        timeout: timeLimit * 1000,
+        monitor: false
     };
-  }
-  try {
-    // Start the QualWeb core engine, which launches a Playwright browser.
-    await qualWeb.start(clusterOptions);
-  }
-  // If the start fails:
-  catch(error) {
-    return {
-      data: {
-        prevented: true,
-        error: `Core engine start failed (${error.message})`
-      },
-      result
+    // Initialize the act report.
+    const data = {};
+    const result = {
+        nativeResult: {},
+        standardResult: {}
     };
-  }
-  // Otherwise, i.e. if the start succeeds, specify the invariant test options.
-  const qualWebOptions = {
-    log: {
-      console: false,
-      file: false
-    },
-    crawlOptions: {
-      maxDepth: 0,
-      maxUrls: 1,
-      timeout: timeLimit * 1000,
-      maxParallelCrawls: 1,
-      logging: true
-    },
-    execute: {
-      counter: true
-    },
-    modules: []
-  };
-  try {
-    // Provide the page content, including the data-xpath attributes.
-    qualWebOptions.html = await page.content();
-    // Specify which rules to test for, adding a custom execute property for report processing.
-    const actSpec = rules ? rules.find(typeRules => typeRules.startsWith('act:')) : null;
-    const wcagSpec = rules ? rules.find(typeRules => typeRules.startsWith('wcag:')) : null;
-    const bestSpec = rules ? rules.find(typeRules => typeRules.startsWith('best:')) : null;
-    if (actSpec) {
-      if (actSpec === 'act:') {
-        qualWebOptions.execute.act = false;
-      }
-      else {
-        const actRules = actSpec.slice(4).split(',').map(num => `QW-ACT-R${num}`);
-        qualWebOptions['act-rules'] = {rules: actRules};
-        qualWebOptions.modules.push(actRulesModule);
-        qualWebOptions.execute.act = true;
-      }
+    const standard = report.standard !== 'no';
+    // If standard results are to be reported:
+    if (standard) {
+        // Initialize the standard result.
+        result.standardResult = {
+            prevented: false,
+            totals: [0, 0, 0, 0],
+            instances: []
+        };
     }
-    else {
-      qualWebOptions['act-rules'] = {
-        levels: ['A', 'AA', 'AAA'],
-        principles: ['Perceivable', 'Operable', 'Understandable', 'Robust']
-      };
-      qualWebOptions.modules.push(actRulesModule);
-      qualWebOptions.execute.act = true;
-    }
-    if (wcagSpec) {
-      if (wcagSpec === 'wcag:') {
-        qualWebOptions.execute.wcag = false;
-      }
-      else {
-        const wcagTechniques = wcagSpec.slice(5).split(',').map(num => `QW-WCAG-T${num}`);
-        qualWebOptions['wcag-techniques'] = {techniques: wcagTechniques};
-        qualWebOptions.modules.push(wcagModule);
-        qualWebOptions.execute.wcag = true;
-      }
-    }
-    else {
-      qualWebOptions['wcag-techniques'] = {
-        levels: ['A', 'AA', 'AAA'],
-        principles: ['Perceivable', 'Operable', 'Understandable', 'Robust']
-      };
-      qualWebOptions.modules.push(wcagModule);
-      qualWebOptions.execute.wcag = true;
-    }
-    if (bestSpec) {
-      if (bestSpec === 'best:') {
-        qualWebOptions.execute.bp = false;
-      }
-      else {
-        const bestPractices = bestSpec.slice(5).split(',').map(num => `QW-BP${num}`);
-        qualWebOptions['best-practices'] = {bestPractices};
-        qualWebOptions.modules.push(bpModule);
-        qualWebOptions.execute.bp = true;
-      }
-    }
-    else {
-      qualWebOptions['best-practices'] = {};
-      qualWebOptions.modules.push(bpModule);
-      qualWebOptions.execute.bp = true;
-    }
-    let qwReport;
     try {
-      // Get the report.
-      qwReport = await qualWeb.evaluate(qualWebOptions);
+        // Start the QualWeb core engine, which launches a Playwright browser.
+        await qualWeb.start(clusterOptions);
     }
-    catch(error) {
-      return {
-        data: {
-          prevented: true,
-          error: `qualWeb evaluation failed (${error.message})`
+    // If the start fails:
+    catch (error) {
+        return {
+            data: {
+                prevented: true,
+                error: `Core engine start failed (${error.message})`
+            },
+            result
+        };
+    }
+    // Otherwise, i.e. if the start succeeds, specify the invariant test options.
+    const qualWebOptions = {
+        log: {
+            console: false,
+            file: false
         },
-        result
-      };
-    }
-    // Add the report to the result.
-    result.nativeResult = qwReport.customHtml;
-    const {nativeResult, standardResult} = result;
-    // If the report contains, as it should, a copy of the DOM:
-    if (nativeResult?.system?.page?.dom) {
-      // Delete the copy for parsimony.
-      delete nativeResult.system.page.dom;
-      const {modules} = nativeResult;
-      // If the report contains, as it should, a modules property:
-      if (modules) {
-        // For each test section in it:
-        for (const section of ['act-rules', 'wcag-techniques', 'best-practices']) {
-          // If testing in the section was specified:
-          if (qualWebOptions[section]) {
-            // If the section exists:
-            if (modules[section]) {
-              const {assertions} = modules[section];
-              // If it contains assertions (test results):
-              if (assertions) {
-                const ruleIDs = Object.keys(assertions);
-                // For each rule:
-                for (const ruleID of ruleIDs) {
-                  const ruleAssertions = assertions[ruleID];
-                  const {metadata} = ruleAssertions;
-                  // If there were any warnings or failures:
-                  if (metadata?.warning || metadata?.failed) {
-                    // Delete nonviolations from the results.
-                    ruleAssertions.results = ruleAssertions.results.filter(
-                      raResult => raResult.verdict !== 'passed'
-                    );
-                    // For each test result:
-                    for (const raResult of ruleAssertions.results) {
-                      const {elements, verdict} = raResult;
-                      // If any violations are reported:
-                      if (elements?.length) {
-                        // For each violating element:
-                        for (const element of elements) {
-                          // Limit the size of its reported excerpt.
-                          if (element.htmlCode?.length > 2000) {
-                            element.htmlCode = `${element.htmlCode.slice(0, 2000)} …`;
-                          }
-                          // If standard results are to be reported:
-                          if (standard) {
-                            const ordinalSeverity = ordinalSeverities[section][verdict];
-                            // Increment the applicable total.
-                            standardResult.totals[ordinalSeverity]++;
-                            // Initialize a standard instance.
-                            const what = `[${verdict}] ${raResult.description}`;
-                            const xPath = getAttributeXPath(element.htmlCode);
-                            const instance = {
-                              ruleID,
-                              what,
-                              ordinalSeverity: ordinalSeverities[section][verdict],
-                              count: 1,
-                              catalogIndex: getXPathCatalogIndex(report, xPath)
-                            };
-                            // Add the instance to the standard result.
-                            standardResult.instances.push(instance);
-                          }
-                        };
-                      }
-                    };
-                  }
-                  // Otherwise, i.e. if there were no warnings or failures:
-                  else {
-                    // Delete the rule.
-                    delete assertions[ruleID];
-                  }
-                };
-              }
-              // Otherwise, i.e. if it contains no assertions:
-              else {
+        crawlOptions: {
+            maxDepth: 0,
+            maxUrls: 1,
+            timeout: timeLimit * 1000,
+            maxParallelCrawls: 1,
+            logging: true
+        },
+        execute: {
+            counter: true
+        },
+        modules: []
+    };
+    try {
+        // Provide the page content, including the data-xpath attributes.
+        qualWebOptions.html = await page.content();
+        // Specify which rules to test for, adding a custom execute property for report processing.
+        const actSpec = rules ? rules.find(typeRules => typeRules.startsWith('act:')) : null;
+        const wcagSpec = rules ? rules.find(typeRules => typeRules.startsWith('wcag:')) : null;
+        const bestSpec = rules ? rules.find(typeRules => typeRules.startsWith('best:')) : null;
+        if (actSpec) {
+            if (actSpec === 'act:') {
+                qualWebOptions.execute.act = false;
+            }
+            else {
+                const actRules = actSpec.slice(4).split(',').map(num => `QW-ACT-R${num}`);
+                qualWebOptions['act-rules'] = { rules: actRules };
+                qualWebOptions.modules.push(actRulesModule);
+                qualWebOptions.execute.act = true;
+            }
+        }
+        else {
+            qualWebOptions['act-rules'] = {
+                levels: ['A', 'AA', 'AAA'],
+                principles: ['Perceivable', 'Operable', 'Understandable', 'Robust']
+            };
+            qualWebOptions.modules.push(actRulesModule);
+            qualWebOptions.execute.act = true;
+        }
+        if (wcagSpec) {
+            if (wcagSpec === 'wcag:') {
+                qualWebOptions.execute.wcag = false;
+            }
+            else {
+                const wcagTechniques = wcagSpec.slice(5).split(',').map(num => `QW-WCAG-T${num}`);
+                qualWebOptions['wcag-techniques'] = { techniques: wcagTechniques };
+                qualWebOptions.modules.push(wcagModule);
+                qualWebOptions.execute.wcag = true;
+            }
+        }
+        else {
+            qualWebOptions['wcag-techniques'] = {
+                levels: ['A', 'AA', 'AAA'],
+                principles: ['Perceivable', 'Operable', 'Understandable', 'Robust']
+            };
+            qualWebOptions.modules.push(wcagModule);
+            qualWebOptions.execute.wcag = true;
+        }
+        if (bestSpec) {
+            if (bestSpec === 'best:') {
+                qualWebOptions.execute.bp = false;
+            }
+            else {
+                const bestPractices = bestSpec.slice(5).split(',').map(num => `QW-BP${num}`);
+                qualWebOptions['best-practices'] = { bestPractices };
+                qualWebOptions.modules.push(bpModule);
+                qualWebOptions.execute.bp = true;
+            }
+        }
+        else {
+            qualWebOptions['best-practices'] = {};
+            qualWebOptions.modules.push(bpModule);
+            qualWebOptions.execute.bp = true;
+        }
+        let qwReport;
+        try {
+            // Get the report.
+            qwReport = await qualWeb.evaluate(qualWebOptions);
+        }
+        catch (error) {
+            return {
+                data: {
+                    prevented: true,
+                    error: `qualWeb evaluation failed (${error.message})`
+                },
+                result
+            };
+        }
+        // Add the report to the result.
+        result.nativeResult = qwReport.customHtml;
+        const { nativeResult, standardResult } = result;
+        // If the report contains, as it should, a copy of the DOM:
+        if (nativeResult?.system?.page?.dom) {
+            // Delete the copy for parsimony.
+            delete nativeResult.system.page.dom;
+            const { modules } = nativeResult;
+            // If the report contains, as it should, a modules property:
+            if (modules) {
+                // For each test section in it:
+                for (const section of ['act-rules', 'wcag-techniques', 'best-practices']) {
+                    // If testing in the section was specified:
+                    if (qualWebOptions[section]) {
+                        // If the section exists:
+                        if (modules[section]) {
+                            const { assertions } = modules[section];
+                            // If it contains assertions (test results):
+                            if (assertions) {
+                                const ruleIDs = Object.keys(assertions);
+                                // For each rule:
+                                for (const ruleID of ruleIDs) {
+                                    const ruleAssertions = assertions[ruleID];
+                                    const { metadata } = ruleAssertions;
+                                    // If there were any warnings or failures:
+                                    if (metadata?.warning || metadata?.failed) {
+                                        // Delete nonviolations from the results.
+                                        ruleAssertions.results = ruleAssertions.results.filter(raResult => raResult.verdict !== 'passed');
+                                        // For each test result:
+                                        for (const raResult of ruleAssertions.results) {
+                                            const { elements, verdict } = raResult;
+                                            // If any violations are reported:
+                                            if (elements?.length) {
+                                                // For each violating element:
+                                                for (const element of elements) {
+                                                    // Limit the size of its reported excerpt.
+                                                    if (element.htmlCode?.length > 2000) {
+                                                        element.htmlCode = `${element.htmlCode.slice(0, 2000)} …`;
+                                                    }
+                                                    // If standard results are to be reported:
+                                                    if (standard) {
+                                                        const ordinalSeverity = ordinalSeverities[section][verdict];
+                                                        // Increment the applicable total.
+                                                        standardResult.totals[ordinalSeverity]++;
+                                                        // Initialize a standard instance.
+                                                        const what = `[${verdict}] ${raResult.description}`;
+                                                        const xPath = (0, xPath_1.getAttributeXPath)(element.htmlCode);
+                                                        const instance = {
+                                                            ruleID,
+                                                            what,
+                                                            ordinalSeverity: ordinalSeverities[section][verdict],
+                                                            count: 1,
+                                                            catalogIndex: (0, xPath_1.getXPathCatalogIndex)(report, xPath)
+                                                        };
+                                                        // Add the instance to the standard result.
+                                                        standardResult.instances.push(instance);
+                                                    }
+                                                }
+                                                ;
+                                            }
+                                        }
+                                        ;
+                                    }
+                                    // Otherwise, i.e. if there were no warnings or failures:
+                                    else {
+                                        // Delete the rule.
+                                        delete assertions[ruleID];
+                                    }
+                                }
+                                ;
+                            }
+                            // Otherwise, i.e. if it contains no assertions:
+                            else {
+                                // Report this.
+                                data.prevented = true;
+                                data.error = 'No assertions';
+                            }
+                        }
+                        // Otherwise, i.e. if the section is missing:
+                        else {
+                            // Report this.
+                            data.prevented = true;
+                            data.error = `No ${section} section`;
+                        }
+                    }
+                }
+            }
+            // Otherwise, i.e. if the report does not contain a modules property:
+            else {
                 // Report this.
                 data.prevented = true;
-                data.error = 'No assertions';
-              }
+                data.error = 'No modules';
             }
-            // Otherwise, i.e. if the section is missing:
-            else {
-              // Report this.
-              data.prevented = true;
-              data.error = `No ${section} section`;
-            }
-          }
         }
-      }
-      // Otherwise, i.e. if the report does not contain a modules property:
-      else {
-        // Report this.
+        // Otherwise, i.e. if the report does not contain a copy of the DOM:
+        else {
+            // Report this.
+            data.prevented = true;
+            data.error = 'No DOM';
+        }
+        // Stop the QualWeb core engine.
+        await qualWeb.stop();
+        // Test whether the result is an object.
+        try {
+            JSON.stringify(result);
+        }
+        catch (error) {
+            data.prevented = true;
+            data.error = `QualWeb result cannot be made JSON (${error.message})`;
+        }
+    }
+    catch (error) {
         data.prevented = true;
-        data.error = 'No modules';
-      }
+        data.error = `QualWeb failed (${error.message})`;
     }
-    // Otherwise, i.e. if the report does not contain a copy of the DOM:
-    else {
-      // Report this.
-      data.prevented = true;
-      data.error = 'No DOM';
-    }
-    // Stop the QualWeb core engine.
-    await qualWeb.stop();
-    // Test whether the result is an object.
-    try {
-      JSON.stringify(result);
-    }
-    catch(error) {
-      data.prevented = true;
-      data.error = `QualWeb result cannot be made JSON (${error.message})`;
-    }
-  }
-  catch(error) {
-    data.prevented = true;
-    data.error = `QualWeb failed (${error.message})`;
-  }
-  return {
-    data,
-    result
-  };
+    return {
+        data,
+        result
+    };
 };
+exports.reporter = reporter;

--- a/tests/qualWeb.ts
+++ b/tests/qualWeb.ts
@@ -1,0 +1,369 @@
+/*
+  © 2023–2024 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2026 Jeff Witt.
+  © 2025–2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+// IMPORTS
+
+import type {Page} from 'playwright';
+import {getAttributeXPath, getXPathCatalogIndex} from '../procs/xPath';
+import type {Act, Report, StandardInstance, StandardResult} from '../types';
+/*
+  The @qualweb packages declare their types only in package-exports maps, which
+  this project's node10 module resolution cannot read, so the imports stay
+  requires and are untyped.
+*/
+const {QualWeb} = require('@qualweb/core');
+const {ACTRules} = require('@qualweb/act-rules');
+const {WCAGTechniques} = require('@qualweb/wcag-techniques');
+const {BestPractices} = require('@qualweb/best-practices');
+const {PlaywrightDriver} = require('@qualweb/playwright-driver');
+
+// TYPES
+
+// The qualWeb-act properties this reporter consumes.
+interface QualWebAct extends Act {
+  rules?: string[];
+}
+// The section names of a QualWeb report.
+type QwSection = 'act-rules' | 'wcag-techniques' | 'best-practices';
+// One element reported by a QualWeb assertion result.
+interface QwElement {
+  htmlCode?: string;
+}
+// One result of a QualWeb rule assertion.
+interface QwRaResult {
+  verdict: string;
+  description?: string;
+  elements?: QwElement[];
+}
+// The assertions for one QualWeb rule.
+interface QwRuleAssertions {
+  metadata?: {
+    warning?: number;
+    failed?: number;
+  };
+  results: QwRaResult[];
+}
+// One module section of a QualWeb report.
+interface QwModuleReport {
+  assertions?: Record<string, QwRuleAssertions>;
+}
+// The native result: the customHtml QualWeb report.
+interface QwNativeResult {
+  system?: {
+    page?: {
+      dom?: unknown;
+    };
+  };
+  modules?: Record<string, QwModuleReport>;
+}
+// The options of a QualWeb evaluation.
+interface QualWebOptions {
+  log: {console: boolean; file: boolean};
+  crawlOptions: {
+    maxDepth: number;
+    maxUrls: number;
+    timeout: number;
+    maxParallelCrawls: number;
+    logging: boolean;
+  };
+  execute: {counter: boolean; act?: boolean; wcag?: boolean; bp?: boolean};
+  modules: unknown[];
+  html?: string;
+  'act-rules'?: {rules?: string[]; levels?: string[]; principles?: string[]};
+  'wcag-techniques'?: {techniques?: string[]; levels?: string[]; principles?: string[]};
+  'best-practices'?: {bestPractices?: string[]};
+}
+
+// CONSTANTS
+
+// QualWeb core engine with Playwright as driver.
+const qualWeb = new QualWeb(undefined, new PlaywrightDriver({
+  adBlock: true,
+  stealth: true
+}));
+const actRulesModule = new ACTRules({});
+const wcagModule = new WCAGTechniques({});
+const bpModule = new BestPractices({});
+// Mapping of QualWeb module violation types to ordinal severities.
+const ordinalSeverities: Record<QwSection, Record<string, StandardInstance['ordinalSeverity']>> = {
+  'act-rules': {
+    'warning': 1,
+    'failed': 3
+  },
+  'wcag-techniques': {
+    'warning': 0,
+    'failed': 2
+  },
+  'best-practices': {
+    'warning': 0,
+    'failed': 1
+  }
+}
+
+/*
+  qualWeb
+  Implements the QualWeb ruleset for accessibility.
+  Compiled to qualWeb.js by tsc (issue #73); edit this file, not the emitted one.
+*/
+
+// FUNCTIONS
+
+// Conducts and reports the QualWeb tests.
+export const reporter = async (page: Page, report: Report, actIndex: number, timeLimit: number) => {
+  const act = report.acts[actIndex] as QualWebAct;
+  const {rules} = act;
+  const clusterOptions = {
+    maxConcurrency: 1,
+    timeout: timeLimit * 1000,
+    monitor: false
+  };
+  // Initialize the act report.
+  const data: {prevented?: boolean; error?: string} = {};
+  const result: {nativeResult: QwNativeResult; standardResult: StandardResult} = {
+    nativeResult: {},
+    standardResult: {}
+  };
+  const standard = report.standard !== 'no';
+  // If standard results are to be reported:
+  if (standard) {
+    // Initialize the standard result.
+    result.standardResult = {
+      prevented: false,
+      totals: [0, 0, 0, 0],
+      instances: []
+    };
+  }
+  try {
+    // Start the QualWeb core engine, which launches a Playwright browser.
+    await qualWeb.start(clusterOptions);
+  }
+  // If the start fails:
+  catch(error) {
+    return {
+      data: {
+        prevented: true,
+        error: `Core engine start failed (${(error as Error).message})`
+      },
+      result
+    };
+  }
+  // Otherwise, i.e. if the start succeeds, specify the invariant test options.
+  const qualWebOptions: QualWebOptions = {
+    log: {
+      console: false,
+      file: false
+    },
+    crawlOptions: {
+      maxDepth: 0,
+      maxUrls: 1,
+      timeout: timeLimit * 1000,
+      maxParallelCrawls: 1,
+      logging: true
+    },
+    execute: {
+      counter: true
+    },
+    modules: []
+  };
+  try {
+    // Provide the page content, including the data-xpath attributes.
+    qualWebOptions.html = await page.content();
+    // Specify which rules to test for, adding a custom execute property for report processing.
+    const actSpec = rules ? rules.find(typeRules => typeRules.startsWith('act:')) : null;
+    const wcagSpec = rules ? rules.find(typeRules => typeRules.startsWith('wcag:')) : null;
+    const bestSpec = rules ? rules.find(typeRules => typeRules.startsWith('best:')) : null;
+    if (actSpec) {
+      if (actSpec === 'act:') {
+        qualWebOptions.execute.act = false;
+      }
+      else {
+        const actRules = actSpec.slice(4).split(',').map(num => `QW-ACT-R${num}`);
+        qualWebOptions['act-rules'] = {rules: actRules};
+        qualWebOptions.modules.push(actRulesModule);
+        qualWebOptions.execute.act = true;
+      }
+    }
+    else {
+      qualWebOptions['act-rules'] = {
+        levels: ['A', 'AA', 'AAA'],
+        principles: ['Perceivable', 'Operable', 'Understandable', 'Robust']
+      };
+      qualWebOptions.modules.push(actRulesModule);
+      qualWebOptions.execute.act = true;
+    }
+    if (wcagSpec) {
+      if (wcagSpec === 'wcag:') {
+        qualWebOptions.execute.wcag = false;
+      }
+      else {
+        const wcagTechniques = wcagSpec.slice(5).split(',').map(num => `QW-WCAG-T${num}`);
+        qualWebOptions['wcag-techniques'] = {techniques: wcagTechniques};
+        qualWebOptions.modules.push(wcagModule);
+        qualWebOptions.execute.wcag = true;
+      }
+    }
+    else {
+      qualWebOptions['wcag-techniques'] = {
+        levels: ['A', 'AA', 'AAA'],
+        principles: ['Perceivable', 'Operable', 'Understandable', 'Robust']
+      };
+      qualWebOptions.modules.push(wcagModule);
+      qualWebOptions.execute.wcag = true;
+    }
+    if (bestSpec) {
+      if (bestSpec === 'best:') {
+        qualWebOptions.execute.bp = false;
+      }
+      else {
+        const bestPractices = bestSpec.slice(5).split(',').map(num => `QW-BP${num}`);
+        qualWebOptions['best-practices'] = {bestPractices};
+        qualWebOptions.modules.push(bpModule);
+        qualWebOptions.execute.bp = true;
+      }
+    }
+    else {
+      qualWebOptions['best-practices'] = {};
+      qualWebOptions.modules.push(bpModule);
+      qualWebOptions.execute.bp = true;
+    }
+    let qwReport;
+    try {
+      // Get the report.
+      qwReport = await qualWeb.evaluate(qualWebOptions);
+    }
+    catch(error) {
+      return {
+        data: {
+          prevented: true,
+          error: `qualWeb evaluation failed (${(error as Error).message})`
+        },
+        result
+      };
+    }
+    // Add the report to the result.
+    result.nativeResult = qwReport.customHtml;
+    const {nativeResult, standardResult} = result;
+    // If the report contains, as it should, a copy of the DOM:
+    if (nativeResult?.system?.page?.dom) {
+      // Delete the copy for parsimony.
+      delete nativeResult.system.page.dom;
+      const {modules} = nativeResult;
+      // If the report contains, as it should, a modules property:
+      if (modules) {
+        // For each test section in it:
+        for (const section of ['act-rules', 'wcag-techniques', 'best-practices'] as QwSection[]) {
+          // If testing in the section was specified:
+          if (qualWebOptions[section]) {
+            // If the section exists:
+            if (modules[section]) {
+              const {assertions} = modules[section];
+              // If it contains assertions (test results):
+              if (assertions) {
+                const ruleIDs = Object.keys(assertions);
+                // For each rule:
+                for (const ruleID of ruleIDs) {
+                  const ruleAssertions = assertions[ruleID];
+                  const {metadata} = ruleAssertions;
+                  // If there were any warnings or failures:
+                  if (metadata?.warning || metadata?.failed) {
+                    // Delete nonviolations from the results.
+                    ruleAssertions.results = ruleAssertions.results.filter(
+                      raResult => raResult.verdict !== 'passed'
+                    );
+                    // For each test result:
+                    for (const raResult of ruleAssertions.results) {
+                      const {elements, verdict} = raResult;
+                      // If any violations are reported:
+                      if (elements?.length) {
+                        // For each violating element:
+                        for (const element of elements) {
+                          // Limit the size of its reported excerpt.
+                          if ((element.htmlCode?.length as number) > 2000) {
+                            element.htmlCode = `${element.htmlCode!.slice(0, 2000)} …`;
+                          }
+                          // If standard results are to be reported:
+                          if (standard) {
+                            const ordinalSeverity = ordinalSeverities[section][verdict];
+                            // Increment the applicable total.
+                            standardResult.totals![ordinalSeverity]++;
+                            // Initialize a standard instance.
+                            const what = `[${verdict}] ${raResult.description}`;
+                            const xPath = getAttributeXPath(element.htmlCode);
+                            const instance: StandardInstance = {
+                              ruleID,
+                              what,
+                              ordinalSeverity: ordinalSeverities[section][verdict],
+                              count: 1,
+                              catalogIndex: getXPathCatalogIndex(report, xPath)
+                            };
+                            // Add the instance to the standard result.
+                            standardResult.instances!.push(instance);
+                          }
+                        };
+                      }
+                    };
+                  }
+                  // Otherwise, i.e. if there were no warnings or failures:
+                  else {
+                    // Delete the rule.
+                    delete assertions[ruleID];
+                  }
+                };
+              }
+              // Otherwise, i.e. if it contains no assertions:
+              else {
+                // Report this.
+                data.prevented = true;
+                data.error = 'No assertions';
+              }
+            }
+            // Otherwise, i.e. if the section is missing:
+            else {
+              // Report this.
+              data.prevented = true;
+              data.error = `No ${section} section`;
+            }
+          }
+        }
+      }
+      // Otherwise, i.e. if the report does not contain a modules property:
+      else {
+        // Report this.
+        data.prevented = true;
+        data.error = 'No modules';
+      }
+    }
+    // Otherwise, i.e. if the report does not contain a copy of the DOM:
+    else {
+      // Report this.
+      data.prevented = true;
+      data.error = 'No DOM';
+    }
+    // Stop the QualWeb core engine.
+    await qualWeb.stop();
+    // Test whether the result is an object.
+    try {
+      JSON.stringify(result);
+    }
+    catch(error) {
+      data.prevented = true;
+      data.error = `QualWeb result cannot be made JSON (${(error as Error).message})`;
+    }
+  }
+  catch(error) {
+    data.prevented = true;
+    data.error = `QualWeb failed (${(error as Error).message})`;
+  }
+  return {
+    data,
+    result
+  };
+};


### PR DESCRIPTION
Completes Phase 3 of the strict-TypeScript migration (#73): the five adapters that consume rule-engine npm packages — **alfa, axe, ibm, aslint, qualWeb**. With #118, all 11 tool adapters in `tests/` are now strict TypeScript. Same contract as before: strict from day one, committed tsc emit, no behavior change.

## Typing strategy per dependency

Typing follows what each package can support under this project's node10 module resolution:

- **axe-playwright** and **accessibility-checker** resolve their own types, so they are consumed through typed requires (`require(...) as typeof import(...)`), with `axe-core`'s `AxeResults`/`NodeResult`/`RunOptions` used type-only in the axe adapter.
- **@siteimprove/alfa-\*** are pure ESM loaded via `require(esm)`; their types don't resolve under node10, so the requires stay untyped (commented), and local structural interfaces type the evaluation/item shapes the adapter actually touches.
- **@qualweb/\*** declare types only in package-exports maps, invisible to node10 — same untyped-require-plus-local-interfaces treatment, including a typed `QualWebOptions` local interface for the dynamically built options object.

## Pre-existing quirk preserved verbatim (commented in-code)

- ibm: the standard-result pass iterates `nativeResult.items`, which is undefined unless `withItems` is set — so ibm with standard results and `withItems: false` throws into its catch and reports the act failed.

## Verification

- `tsc` strict green (the ibm trim result is a discriminated union, so the error/success branches type-check without widening).
- **Token-level emit diff** (acorn tokenizer) of each emitted `.js` vs the original: only module lowering plus parens from erased casts and one shorthand-to-longhand property (`ordinalSeverity: ordinalSeverity`) from a cast.
- **End-to-end, branch vs main**: a job against a violation-rich local page ran all five tools on both sides with real coverage — alfa 10, axe 19, ibm 11, aslint 44, qualWeb 26 standard instances, every one carrying a catalog index — byte-identical reports after normalizing timestamps (including axe's `timestamp`, qualWeb's `createdAt`, and ibm's `date`/`hash` report metadata) and repo paths.

With this PR, Phase 3 is complete. Next per the roadmap: Phase 4, the engine procs (`doActs.js`, `launch.js`, and friends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)