### PR TITLE
ci: run the type check on Node 24, above the engines floor

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - name: Install dependencies
         run: npm ci --ignore-scripts --no-audit --no-fund


### PR DESCRIPTION
The TypeScript workflow pinned `node-version: 20`. Node 20 reached end of life in April 2026 and is below the `>=22.12` engines floor set in #117, so `npm ci` has been running against an unsupported engine on every pull request. This raises the pin to 24, the version the fleet runs.

Verified: this is the only `node-version` pin in `.github/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)