### PR TITLE
fix(htmlcs): do not populate standard totals when standard results are off

### DIFF
--- a/tests/htmlcs.js
+++ b/tests/htmlcs.js
@@ -184,8 +184,12 @@ const reporter = async (page, report, actIndex) => {
                 standardResult.instances.push(instance);
             }
         }
-        standardResult.totals[0] = nativeResult.totals.cantTell;
-        standardResult.totals[2] = nativeResult.totals.failed;
+        // If standard results are to be reported:
+        if (standard) {
+            // Populate the standard-result totals.
+            standardResult.totals[0] = nativeResult.totals.cantTell;
+            standardResult.totals[2] = nativeResult.totals.failed;
+        }
     }
     return {
         data,

--- a/tests/htmlcs.ts
+++ b/tests/htmlcs.ts
@@ -171,8 +171,12 @@ export const reporter = async (page: Page, report: Report, actIndex: number) => 
         standardResult.instances!.push(instance);
       }
     }
-    standardResult.totals![0] = nativeResult.totals.cantTell;
-    standardResult.totals![2] = nativeResult.totals.failed;
+    // If standard results are to be reported:
+    if (standard) {
+      // Populate the standard-result totals.
+      standardResult.totals![0] = nativeResult.totals.cantTell;
+      standardResult.totals![2] = nativeResult.totals.failed;
+    }
   }
   return {
     data,


### PR DESCRIPTION
Closes #123.

The two totals assignments at the end of htmlcs message processing ran outside the `standard` guard:

```js
standardResult.totals[0] = nativeResult.totals.cantTell;
standardResult.totals[2] = nativeResult.totals.failed;
```

With `standard: 'no'`, `standardResult` is `{}`, so `standardResult.totals` is `undefined` and the element assignment throws. The throw escaped the reporter, so `doTestAct` discarded the entire act — precisely on runs where the tool itself had succeeded.

## Verification

Against a violation-rich local page, running htmlcs through `doJob`:

| | before | after |
|---|---|---|
| `standard: 'no'` | act lost: no `data`, no `result` | act completes: native result intact (10 failed messages), empty standard result |
| `standard: 'also'` | 10 instances, totals `[0, 0, 10, 0]` | unchanged |

`tsc` green; the emitted `htmlcs.js` diff is the same guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)