### PR TITLE
fix(ed11y): report a prevented tool run instead of crashing on it

### DIFF
--- a/tests/ed11y.d.ts
+++ b/tests/ed11y.d.ts
@@ -16,7 +16,10 @@ interface Ed11yNativeResult {
     error?: string;
 }
 export declare const reporter: (page: Page, report: Report, actIndex: number) => Promise<{
-    data: {};
+    data: {
+        prevented?: boolean;
+        error?: string;
+    };
     result: {
         nativeResult: Ed11yNativeResult;
         standardResult: StandardResult;

--- a/tests/ed11y.js
+++ b/tests/ed11y.js
@@ -128,14 +128,22 @@ const reporter = async (page, report, actIndex) => {
         script,
         rulesToTest: act.rules
     });
-    // If a standard result is to be reported:
-    if (standard) {
+    // If the tool script failed to run:
+    if (result.nativeResult.prevented) {
+        // Report the prevention.
+        data.prevented = true;
+        data.error = result.nativeResult.error;
+        if (standard) {
+            result.standardResult.prevented = true;
+        }
+    }
+    // Otherwise, i.e. if it ran, and if a standard result is to be reported:
+    else if (standard) {
         const { standardResult } = result;
         const { warningCount, errorCount, results } = result.nativeResult;
         // Populate the standard-result totals.
         standardResult.totals = [warningCount, 0, errorCount, 0];
-        // For each native-result instance (if the tool was prevented, results is
-        // undefined and this throws; verbatim from the original):
+        // For each native-result instance:
         results.forEach(nativeInstance => {
             // Create a standard-result instance.
             const { test, content, dismissalKey, xPath } = nativeInstance;

--- a/tests/ed11y.ts
+++ b/tests/ed11y.ts
@@ -75,7 +75,7 @@ export const reporter = async (page: Page, report: Report, actIndex: number) => 
   const {jobData} = report;
   const scriptNonce = (jobData && jobData.lastScriptNonce) as string | undefined;
   // Initialize the act report.
-  let data = {};
+  let data: {prevented?: boolean; error?: string} = {};
   const result: {nativeResult: Ed11yNativeResult; standardResult: StandardResult} = {
     nativeResult: {},
     standardResult: {}
@@ -144,15 +144,23 @@ export const reporter = async (page: Page, report: Report, actIndex: number) => 
     script,
     rulesToTest: act.rules
   });
-  // If a standard result is to be reported:
-  if (standard) {
+  // If the tool script failed to run:
+  if (result.nativeResult.prevented) {
+    // Report the prevention.
+    data.prevented = true;
+    data.error = result.nativeResult.error as string;
+    if (standard) {
+      result.standardResult.prevented = true;
+    }
+  }
+  // Otherwise, i.e. if it ran, and if a standard result is to be reported:
+  else if (standard) {
     const {standardResult} = result;
-    const {warningCount, errorCount, results} = result.nativeResult;
+    const {warningCount, errorCount, results} = result.nativeResult as Required<Ed11yNativeResult>;
     // Populate the standard-result totals.
     standardResult.totals = [warningCount, 0, errorCount, 0] as SeverityTotals;
-    // For each native-result instance (if the tool was prevented, results is
-    // undefined and this throws; verbatim from the original):
-    results!.forEach(nativeInstance => {
+    // For each native-result instance:
+    results.forEach(nativeInstance => {
       // Create a standard-result instance.
       const {test, content, dismissalKey, xPath} = nativeInstance;
       const instance = {} as StandardInstance;


### PR DESCRIPTION
Closes #122.

When the in-page `Ed11y` constructor throws — for example, when the page's content security policy blocks the injected tool script — the callback resolves the native result as `{prevented: true, error}`. But the standard-result pass ran unconditionally: it wrote `[undefined, 0, undefined, 0]` into the totals and then threw on `results.forEach`. Because the throw escaped the reporter, `doTestAct` discarded the entire act and the prevention never reached `jobData.preventions`.

The reporter now branches on the prevention: copy the error into the act data, mark any standard result prevented, skip the totals and instances.

## Verification

Against a page whose CSP forbids all scripts (`script-src 'none'`):

| | before | after |
|---|---|---|
| act data | act lost — no `data`, no `result` | `{prevented: true, error: "Ed11y is not defined"}` |
| standard result | — | `{prevented: true, totals: [0,0,0,0], instances: []}` |
| `jobData.preventions` | `{}` | `{ed11y: "Ed11y is not defined"}` |

On a page that permits the tool, output is unchanged: 6 instances with totals `[3, 0, 3, 0]` under `standard: 'also'`, and an empty standard result under `standard: 'no'`.

`tsc` green; the emitted `ed11y.js` carries the same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)