### PR TITLE
fix(validation): build each validation catalog on the page being validated

### DIFF
--- a/validation/tests/jobProperties/motion.json
+++ b/validation/tests/jobProperties/motion.json
@@ -1,55 +1,14 @@
 {
   "rule": "motion",
   "timeLimit": 20,
+  "imageColor": 2,
   "acts": [
     {
       "type": "launch",
       "target": {
-        "url": "file://validation/tests/targets/motion/good.html",
-        "what": "page without motion"
+        "url": "file://validation/tests/targets/motion/bad.html",
+        "what": "page with motion"
       }
-    },
-    {
-      "type": "test",
-      "which": "testaro",
-      "stopOnFail": true,
-      "expect": [
-        [
-          "standardResult.totals.0",
-          "=",
-          0
-        ],
-        [
-          "standardResult.totals.1",
-          "=",
-          0
-        ],
-        [
-          "standardResult.totals.2",
-          "=",
-          0
-        ],
-        [
-          "standardResult.totals.3",
-          "=",
-          0
-        ],
-        [
-          "standardResult.instances.length",
-          "=",
-          0
-        ]
-      ],
-      "withItems": true,
-      "rules": [
-        "y",
-        "motion"
-      ]
-    },
-    {
-      "type": "url",
-      "which": "file://validation/tests/targets/motion/bad.html",
-      "what": "page with motion"
     },
     {
       "type": "test",
@@ -69,17 +28,12 @@
         [
           "standardResult.instances.0.what",
           "i",
-          "moves or changes"
+          "changes spontaneously"
         ],
         [
           "standardResult.instances.0.ordinalSeverity",
           ">",
           -1
-        ],
-        [
-          "standardResult.instances.0.tagName",
-          "=",
-          "HTML"
         ]
       ],
       "withItems": true,

--- a/validation/validateTest.js
+++ b/validation/validateTest.js
@@ -60,8 +60,25 @@ exports.validateTest = async testID => {
   if (jobProperties.standard) {
     job.standard = jobProperties.standard;
   }
+  // Rules that compare a page with its catalog image (motion) need one to be made.
+  if (jobProperties.imageColor !== undefined) {
+    job.imageColor = jobProperties.imageColor;
+  }
   job.what = `validate Testaro test ${jobProperties.rule}`;
   job.acts = jobProperties.acts;
+  /*
+    Make the job target the page that the job launches. The catalog, and the page
+    image that the motion rule compares its own screenshot with, are made on the
+    job target before the first act, so leaving the target at its default made
+    every validation catalog a catalog of an unrelated page.
+  */
+  const launchAct = jobProperties.acts.find(act => act.type === 'launch');
+  if (launchAct && launchAct.target && launchAct.target.url) {
+    job.target = {
+      what: launchAct.target.what || 'page for test validation',
+      url: launchAct.target.url
+    };
+  }
   // Perform it.
   report = await doJob(job);
   // Report whether the end time was reported.


### PR DESCRIPTION
The validator harness never updated the job target, so `run.js` built the catalog — and the page image the `motion` rule compares its screenshot with — on `validation/tests/targets/adbID/index.html` for **every** rule. The harness now takes the target from the job's own launch act, and passes an `imageColor` property through, without which no page image is made at all.

## Why the motion validator needed both

Before this PR, the motion validator failed all 5 of its expectations on every branch, because with no `imageColor` the rule was simply prevented (`Initial image missing`) — so it silently validated nothing. Adding the image alone was not enough: with the target still pointing at the adbID page, the rule compared each motion target with an image of an unrelated page and reported a violation on `good.html`, **the target that has no motion** (reproducibly, 3 runs of 3).

With both fixes, `good.html` is correctly clean.

## Why the job now launches the page with motion

`getCatalog` runs once per job, before the first act, so the baseline image belongs to the job target alone; a page reached later by a `url` act is compared with the launch page's image. That means one job can validate motion on one page. This job now launches `bad.html`, so the baseline is an image of the same page and the detection is genuine. #131 covers restoring a no-motion check (and documents two further consequences of the job-scoped baseline, including a chromium false negative).

The stale expectations are replaced: the rule's description has been `Content changes spontaneously` for some time, not `moves or changes`, and it identifies its element with `catalogIndex`, not the v60 `tagName` field.

## Verification

- The motion validator passes 3 runs of 3 (`######## Success: No failures`), where before it failed 5 expectations on every run.
- `adbID`, `autocomplete`, and `hover` report **exactly** the same expectation failures with this change as they do on `main` — 9 and 1, 6, and 10 respectively — all pre-existing v60-style expectations, unaffected by the corrected catalog.

Noted while here, not changed: every job-properties file declares a `timeLimit`, but neither the harness nor the engine reads it — per-tool limits come from the `timeLimits` table in `procs/doActs.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)