### PR TITLE
chore: name the repository at its current location

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This application implements option B.
 
 ## Installation as an independent application
 
-To install Testaro as an independent application, rather than a dependency, clone the [Testaro repository](https://github.com/jrpool/testaro). To ensure that the binary browsers of its Playwright dependency get installed, execute `(p)npx playwright install` after executing `(p)npm install`.
+To install Testaro as an independent application, rather than a dependency, clone the [Testaro repository](https://github.com/YRA-Tech/testaro). To ensure that the binary browsers of its Playwright dependency get installed, execute `(p)npx playwright install` after executing `(p)npm install`.
 
 To update Testaro when it is an independent application, execute:
 
@@ -560,7 +560,7 @@ If you want the stand-alone API to perform the tests, you need to have that API 
 
 You can define additional Testaro rules and functionality. Contributions are welcome.
 
-Please report any issues, including feature requests, at the [repository](https://github.com/jrpool/testaro/issues).
+Please report any issues, including feature requests, at the [repository](https://github.com/YRA-Tech/testaro/issues).
 
 ## Accessibility principles
 
@@ -656,7 +656,7 @@ From 12 February 2024 through 30 September 2025, contributors of code to Testaro
 
 ## Future work
 
-Future work contemplated for this project is described in its [issues](https://github.com/jrpool/testaro/issues) and also discussed in the [UPGRADES.md](UPGRADES.md) file.
+Future work contemplated for this project is described in its [issues](https://github.com/YRA-Tech/testaro/issues) and also discussed in the [UPGRADES.md](UPGRADES.md) file.
 
 ## Etymology
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jrpool/testaro.git"
+    "url": "git+https://github.com/YRA-Tech/testaro.git"
   },
   "keywords": [
     "accessibility",
@@ -30,9 +30,9 @@
   "author": "Jonathan Pool <jonathan.pool@jpdev.pro>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/jrpool/testaro/issues"
+    "url": "https://github.com/YRA-Tech/testaro/issues"
   },
-  "homepage": "https://github.com/jrpool/testaro#readme",
+  "homepage": "https://github.com/YRA-Tech/testaro#readme",
   "dependencies": {
     "@qualweb/core": "^0.9.5",
     "@qualweb/act-rules": "^0.8.5",


### PR DESCRIPTION
`package.json` (`repository`, `bugs`, `homepage`) and three README links still named `jrpool/testaro`. GitHub redirects that path to `YRA-Tech/testaro`, so nothing was broken — but the npm package page and the README pointed readers at a name the project no longer uses, and bug reports reached the tracker through a redirect.

The `author` field is deliberately unchanged: authorship is a matter of record, not of repository location.

**Related, not addressed here:** the `testaro` package on npm still lists `jrpool` as its only maintainer, and the registry's latest version is 78.0.8 while this repo is at 78.1.0. Publishing rights need sorting out before the next release, independently of these URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)