### PR TITLE
fix: Correct testaro motion test to make an image comparable to the catalog image

### DIFF
--- a/testaro/motion.js
+++ b/testaro/motion.js
@@ -15,7 +15,7 @@ const { PNG } = require('pngjs');
   motion
   This test reports motion in a page by making a page image and comparing it with the initial one, i.e. the one made by the catalog proc.
 
-  For minimal accessibility, standards require motion to be brief, or else stoppable by the user. But stopping motion can be difficult or impossible, and, by the time a user manages to stop motion, the motion may have caused annoyance or harm. For superior accessibility, a page contains no motion until and unless the user authorizes it. The test reports a rule violation if any pixels differ between the screenshots. The larger the change fraction, the greater the ordinal severity.
+  For minimal accessibility, standards require motion to be brief, or else stoppable by the user. But stopping motion can be difficult or impossible, and, by the time a user manages to stop motion, the motion may have caused annoyance or harm. For superior accessibility, a page contains no motion until and unless the user authorizes it. The test reports a rule violation if any pixels differ between the screenshots. The larger the change, the greater the ordinal severity.
 
   WARNING: The shoot test uses the procs/screenShot module. See the warning in that module about browser types.
 

--- a/testaro/motion.js
+++ b/testaro/motion.js
@@ -70,7 +70,7 @@ const reporter = async (page, report) => {
                         // Describe the violation.
                         violationWhat = `Content changes spontaneously (${pixelChanges} pixels changed)`;
                         // Get the ordinal severity from the fractional pixel change.
-                        ordinalSeverity = Math.min(3, Math.floor(Math.log10(pixelChanges) - 2));
+                        ordinalSeverity = Math.max(0, Math.min(3, Math.floor(Math.log10(pixelChanges) - 2)));
                     }
                 }
                 catch (err) {

--- a/testaro/motion.js
+++ b/testaro/motion.js
@@ -32,6 +32,7 @@ const reporter = async (page, report) => {
     if (report.images?.length) {
         let violationWhat = '';
         let ordinalSeverity = 0;
+        let detailsExpanded = true;
         // Expand all closed details elements, for comparability.
         await page.evaluate(() => {
             document.querySelectorAll('details:not([open])').forEach(details => {
@@ -39,65 +40,71 @@ const reporter = async (page, report) => {
             });
         }).catch(error => {
             console.log(`ERROR: Expanding details elements failed (${error.message})`);
-        });
-        // Make an image with the same color type as the initial one and get its base64 encoding.
-        const png = await (0, shoot_1.shoot)(page, report, {
-            exclusionSelector: null,
-            colorType: report.imageColor,
-            action: 'return'
+            detailsExpanded = false;
+            data.prevented = true;
+            data.error = `Expansion of details elements failed (${error.message})`;
         });
         // If this succeeded:
-        if (png) {
-            // Parse both base64 encodings into PNG objects.
-            const initialPNG = PNG.sync.read(Buffer.from(report.images[0], 'base64'));
-            const finalPNG = PNG.sync.read(Buffer.from(png, 'base64'));
-            // If their dimensions differ:
-            if (finalPNG.width !== initialPNG.width || finalPNG.height !== initialPNG.height) {
-                const fromSize = `${initialPNG.width}×${initialPNG.height}`;
-                const toSize = `${finalPNG.width}×${finalPNG.height}`;
-                // Describe the violation.
-                violationWhat = `Page size changes spontaneously (from ${fromSize} to ${toSize})`;
-            }
-            // Otherwise, i.e. if their dimensions are identical:
-            else {
-                // Get the count of differing pixels between the images, using the default sensitivity.
-                try {
-                    const pixelChanges = pixelmatch(initialPNG.data, finalPNG.data, null, initialPNG.width, initialPNG.height, {
-                        threshold: 0.1
-                    });
-                    // If any pixels were changed:
-                    if (pixelChanges) {
-                        // Describe the violation.
-                        violationWhat = `Content changes spontaneously (${pixelChanges} pixels changed)`;
-                        // Get the ordinal severity from the fractional pixel change.
-                        ordinalSeverity = Math.max(0, Math.min(3, Math.floor(Math.log10(pixelChanges) - 2)));
+        if (detailsExpanded) {
+            // Make an image with the same color type as the initial one and get its base64 encoding.
+            const png = await (0, shoot_1.shoot)(page, report, {
+                exclusionSelector: null,
+                colorType: report.imageColor,
+                action: 'return'
+            });
+            // If this succeeded:
+            if (png) {
+                // Parse both base64 encodings into PNG objects.
+                const initialPNG = PNG.sync.read(Buffer.from(report.images[0], 'base64'));
+                const finalPNG = PNG.sync.read(Buffer.from(png, 'base64'));
+                // If their dimensions differ:
+                if (finalPNG.width !== initialPNG.width || finalPNG.height !== initialPNG.height) {
+                    const fromSize = `${initialPNG.width}×${initialPNG.height}`;
+                    const toSize = `${finalPNG.width}×${finalPNG.height}`;
+                    // Describe the violation.
+                    violationWhat = `Page size changes spontaneously (from ${fromSize} to ${toSize})`;
+                }
+                // Otherwise, i.e. if their dimensions are identical:
+                else {
+                    // Get the count of differing pixels between the images, using the default sensitivity.
+                    try {
+                        const pixelChanges = pixelmatch(initialPNG.data, finalPNG.data, null, initialPNG.width, initialPNG.height, {
+                            threshold: 0.1
+                        });
+                        // If any pixels were changed:
+                        if (pixelChanges) {
+                            // Describe the violation.
+                            violationWhat = `Content changes spontaneously (${pixelChanges} pixels changed)`;
+                            // Get the ordinal severity from the count of changed pixels.
+                            ordinalSeverity = Math.max(0, Math.min(3, Math.floor(Math.log10(pixelChanges) - 2)));
+                        }
+                    }
+                    catch (err) {
+                        console.log(`pixelmatch error: ${err.message}, ${err.stack}`);
+                        data.prevented = true;
+                        data.error = `Pixel comparison failed: ${err.message}`;
                     }
                 }
-                catch (err) {
-                    console.log(`pixelmatch error: ${err.message}, ${err.stack}`);
-                    data.prevented = true;
-                    data.error = `Pixel comparison failed: ${err.message}`;
+                // If there was a violation:
+                if (violationWhat) {
+                    // Add to the totals.
+                    totals[ordinalSeverity] = 1;
+                    // Get a summary standard instance.
+                    standardInstances.push({
+                        ruleID: 'motion',
+                        what: violationWhat,
+                        ordinalSeverity: ordinalSeverity,
+                        count: 1,
+                        catalogIndex: (0, xPath_1.getXPathCatalogIndex)(report, '/html/body')
+                    });
                 }
             }
-            // If there was a violation:
-            if (violationWhat) {
-                // Add to the totals.
-                totals[ordinalSeverity] = 1;
-                // Get a summary standard instance.
-                standardInstances.push({
-                    ruleID: 'motion',
-                    what: violationWhat,
-                    ordinalSeverity: ordinalSeverity,
-                    count: 1,
-                    catalogIndex: (0, xPath_1.getXPathCatalogIndex)(report, '/html/body')
-                });
+            // Otherwise, i.e. if it failed:
+            else {
+                // Report this.
+                data.prevented = true;
+                data.error = 'Image creation failed';
             }
-        }
-        // Otherwise, i.e. if it failed:
-        else {
-            // Report this.
-            data.prevented = true;
-            data.error = 'Image creation failed';
         }
     }
     // Otherwise, i.e. if the initial image does not exist:

--- a/testaro/motion.js
+++ b/testaro/motion.js
@@ -32,6 +32,14 @@ const reporter = async (page, report) => {
     if (report.images?.length) {
         let violationWhat = '';
         let ordinalSeverity = 0;
+        // Expand all closed details elements, for comparability.
+        await page.evaluate(() => {
+            document.querySelectorAll('details:not([open])').forEach(details => {
+                details.setAttribute('open', '');
+            });
+        }).catch(error => {
+            console.log(`ERROR: Expanding details elements failed (${error.message})`);
+        });
         // Make an image with the same color type as the initial one and get its base64 encoding.
         const png = await (0, shoot_1.shoot)(page, report, {
             exclusionSelector: null,
@@ -57,14 +65,12 @@ const reporter = async (page, report) => {
                     const pixelChanges = pixelmatch(initialPNG.data, finalPNG.data, null, initialPNG.width, initialPNG.height, {
                         threshold: 0.1
                     });
-                    // Get the ratio of differing to all pixels as a percentage.
-                    const changePercent = Math.round(100 * pixelChanges / (initialPNG.width * initialPNG.height));
                     // If any pixels were changed:
                     if (pixelChanges) {
                         // Describe the violation.
-                        violationWhat = `Content changes spontaneously (${changePercent}% of pixels changed)`;
+                        violationWhat = `Content changes spontaneously (${pixelChanges} pixels changed)`;
                         // Get the ordinal severity from the fractional pixel change.
-                        ordinalSeverity = Math.floor(Math.min(3, 0.4 * Math.sqrt(changePercent)));
+                        ordinalSeverity = Math.min(3, Math.floor(Math.log10(pixelChanges) - 2));
                     }
                 }
                 catch (err) {

--- a/testaro/motion.ts
+++ b/testaro/motion.ts
@@ -37,6 +37,14 @@ export const reporter = async (page: Page, report: Report) => {
   if (report.images?.length) {
     let violationWhat = '';
     let ordinalSeverity = 0;
+    // Expand all closed details elements, for comparability.
+    await page.evaluate(() => {
+      document.querySelectorAll('details:not([open])').forEach(details => {
+        details.setAttribute('open', '');
+      });
+    }).catch(error => {
+      console.log(`ERROR: Expanding details elements failed (${error.message})`);
+    });
     // Make an image with the same color type as the initial one and get its base64 encoding.
     const png = await shoot(page, report, {
       exclusionSelector: null,
@@ -69,16 +77,12 @@ export const reporter = async (page: Page, report: Report) => {
               threshold: 0.1
             }
           );
-          // Get the ratio of differing to all pixels as a percentage.
-          const changePercent = Math.round(
-            100 * pixelChanges / (initialPNG.width * initialPNG.height)
-          );
           // If any pixels were changed:
           if (pixelChanges) {
             // Describe the violation.
-            violationWhat = `Content changes spontaneously (${changePercent}% of pixels changed)`;
+            violationWhat = `Content changes spontaneously (${pixelChanges} pixels changed)`;
             // Get the ordinal severity from the fractional pixel change.
-            ordinalSeverity = Math.floor(Math.min(3, 0.4 * Math.sqrt(changePercent)));
+            ordinalSeverity = Math.min(3, Math.floor(Math.log10(pixelChanges) - 2));
           }
         } catch (err) {
           console.log(`pixelmatch error: ${(err as Error).message}, ${(err as Error).stack}`);

--- a/testaro/motion.ts
+++ b/testaro/motion.ts
@@ -18,7 +18,7 @@ const {PNG} = require('pngjs');
   motion
   This test reports motion in a page by making a page image and comparing it with the initial one, i.e. the one made by the catalog proc.
 
-  For minimal accessibility, standards require motion to be brief, or else stoppable by the user. But stopping motion can be difficult or impossible, and, by the time a user manages to stop motion, the motion may have caused annoyance or harm. For superior accessibility, a page contains no motion until and unless the user authorizes it. The test reports a rule violation if any pixels differ between the screenshots. The larger the change fraction, the greater the ordinal severity.
+  For minimal accessibility, standards require motion to be brief, or else stoppable by the user. But stopping motion can be difficult or impossible, and, by the time a user manages to stop motion, the motion may have caused annoyance or harm. For superior accessibility, a page contains no motion until and unless the user authorizes it. The test reports a rule violation if any pixels differ between the screenshots. The larger the change, the greater the ordinal severity.
 
   WARNING: The shoot test uses the procs/screenShot module. See the warning in that module about browser types.
 

--- a/testaro/motion.ts
+++ b/testaro/motion.ts
@@ -37,6 +37,7 @@ export const reporter = async (page: Page, report: Report) => {
   if (report.images?.length) {
     let violationWhat = '';
     let ordinalSeverity = 0;
+    let detailsExpanded = true;
     // Expand all closed details elements, for comparability.
     await page.evaluate(() => {
       document.querySelectorAll('details:not([open])').forEach(details => {
@@ -44,71 +45,77 @@ export const reporter = async (page: Page, report: Report) => {
       });
     }).catch(error => {
       console.log(`ERROR: Expanding details elements failed (${error.message})`);
-    });
-    // Make an image with the same color type as the initial one and get its base64 encoding.
-    const png = await shoot(page, report, {
-      exclusionSelector: null,
-      colorType: report.imageColor,
-      action: 'return'
+      detailsExpanded = false;
+      data.prevented = true;
+      data.error = `Expansion of details elements failed (${error.message})`;
     });
     // If this succeeded:
-    if (png) {
-      // Parse both base64 encodings into PNG objects.
-      const initialPNG = PNG.sync.read(Buffer.from(report.images[0], 'base64'));
-      const finalPNG = PNG.sync.read(Buffer.from(png, 'base64'));
-      // If their dimensions differ:
-      if (finalPNG.width !== initialPNG.width || finalPNG.height !== initialPNG.height) {
-        const fromSize = `${initialPNG.width}×${initialPNG.height}`;
-        const toSize = `${finalPNG.width}×${finalPNG.height}`;
-        // Describe the violation.
-        violationWhat = `Page size changes spontaneously (from ${fromSize} to ${toSize})`;
-      }
-      // Otherwise, i.e. if their dimensions are identical:
-      else {
-        // Get the count of differing pixels between the images, using the default sensitivity.
-        try {
-          const pixelChanges = pixelmatch(
-            initialPNG.data,
-            finalPNG.data,
-            null,
-            initialPNG.width,
-            initialPNG.height,
-            {
-              threshold: 0.1
+    if (detailsExpanded) {
+      // Make an image with the same color type as the initial one and get its base64 encoding.
+      const png = await shoot(page, report, {
+        exclusionSelector: null,
+        colorType: report.imageColor,
+        action: 'return'
+      });
+      // If this succeeded:
+      if (png) {
+        // Parse both base64 encodings into PNG objects.
+        const initialPNG = PNG.sync.read(Buffer.from(report.images[0], 'base64'));
+        const finalPNG = PNG.sync.read(Buffer.from(png, 'base64'));
+        // If their dimensions differ:
+        if (finalPNG.width !== initialPNG.width || finalPNG.height !== initialPNG.height) {
+          const fromSize = `${initialPNG.width}×${initialPNG.height}`;
+          const toSize = `${finalPNG.width}×${finalPNG.height}`;
+          // Describe the violation.
+          violationWhat = `Page size changes spontaneously (from ${fromSize} to ${toSize})`;
+        }
+        // Otherwise, i.e. if their dimensions are identical:
+        else {
+          // Get the count of differing pixels between the images, using the default sensitivity.
+          try {
+            const pixelChanges = pixelmatch(
+              initialPNG.data,
+              finalPNG.data,
+              null,
+              initialPNG.width,
+              initialPNG.height,
+              {
+                threshold: 0.1
+              }
+            );
+            // If any pixels were changed:
+            if (pixelChanges) {
+              // Describe the violation.
+              violationWhat = `Content changes spontaneously (${pixelChanges} pixels changed)`;
+              // Get the ordinal severity from the count of changed pixels.
+              ordinalSeverity = Math.max(0, Math.min(3, Math.floor(Math.log10(pixelChanges) - 2)));
             }
-          );
-          // If any pixels were changed:
-          if (pixelChanges) {
-            // Describe the violation.
-            violationWhat = `Content changes spontaneously (${pixelChanges} pixels changed)`;
-            // Get the ordinal severity from the fractional pixel change.
-            ordinalSeverity = Math.max(0, Math.min(3, Math.floor(Math.log10(pixelChanges) - 2)));
+          } catch (err) {
+            console.log(`pixelmatch error: ${(err as Error).message}, ${(err as Error).stack}`);
+            data.prevented = true;
+            data.error = `Pixel comparison failed: ${(err as Error).message}`;
           }
-        } catch (err) {
-          console.log(`pixelmatch error: ${(err as Error).message}, ${(err as Error).stack}`);
-          data.prevented = true;
-          data.error = `Pixel comparison failed: ${(err as Error).message}`;
+        }
+        // If there was a violation:
+        if (violationWhat) {
+          // Add to the totals.
+          totals[ordinalSeverity] = 1;
+          // Get a summary standard instance.
+          standardInstances.push({
+            ruleID: 'motion',
+            what: violationWhat,
+            ordinalSeverity: ordinalSeverity as StandardInstance['ordinalSeverity'],
+            count: 1,
+            catalogIndex: getXPathCatalogIndex(report, '/html/body')
+          });
         }
       }
-      // If there was a violation:
-      if (violationWhat) {
-        // Add to the totals.
-        totals[ordinalSeverity] = 1;
-        // Get a summary standard instance.
-        standardInstances.push({
-          ruleID: 'motion',
-          what: violationWhat,
-          ordinalSeverity: ordinalSeverity as StandardInstance['ordinalSeverity'],
-          count: 1,
-          catalogIndex: getXPathCatalogIndex(report, '/html/body')
-        });
+      // Otherwise, i.e. if it failed:
+      else {
+        // Report this.
+        data.prevented = true;
+        data.error = 'Image creation failed';
       }
-    }
-    // Otherwise, i.e. if it failed:
-    else {
-      // Report this.
-      data.prevented = true;
-      data.error = 'Image creation failed';
     }
   }
   // Otherwise, i.e. if the initial image does not exist:

--- a/testaro/motion.ts
+++ b/testaro/motion.ts
@@ -82,7 +82,7 @@ export const reporter = async (page: Page, report: Report) => {
             // Describe the violation.
             violationWhat = `Content changes spontaneously (${pixelChanges} pixels changed)`;
             // Get the ordinal severity from the fractional pixel change.
-            ordinalSeverity = Math.min(3, Math.floor(Math.log10(pixelChanges) - 2));
+            ordinalSeverity = Math.max(0, Math.min(3, Math.floor(Math.log10(pixelChanges) - 2)));
           }
         } catch (err) {
           console.log(`pixelmatch error: ${(err as Error).message}, ${(err as Error).stack}`);

--- a/tests/testaro.js
+++ b/tests/testaro.js
@@ -314,17 +314,6 @@ const allRules = [
         defaultOn: true
     },
     {
-        id: 'motion',
-        what: 'motion without user request',
-        contaminates: false,
-        needsAccessibleName: false,
-        // The budget must cover a full-page screenshot (itself allowed 4 seconds in
-        // procs/shoot.js), decoding two full-page PNGs, and a pixel comparison; 5
-        // seconds made the rule time out whenever an initial image existed.
-        timeOut: 30,
-        defaultOn: true
-    },
-    {
         id: 'dupAtt',
         what: 'duplicate attribute values',
         contaminates: false,
@@ -346,6 +335,17 @@ const allRules = [
         contaminates: false,
         needsAccessibleName: true,
         timeOut: 5,
+        defaultOn: true
+    },
+    {
+        id: 'motion',
+        what: 'motion without user request',
+        contaminates: true,
+        needsAccessibleName: false,
+        // The budget must cover a full-page screenshot (itself allowed 4 seconds in
+        // procs/shoot.js), decoding two full-page PNGs, and a pixel comparison; 5
+        // seconds made the rule time out whenever an initial image existed.
+        timeOut: 30,
         defaultOn: true
     },
     {

--- a/tests/testaro.ts
+++ b/tests/testaro.ts
@@ -359,17 +359,6 @@ const allRules: RuleMeta[] = [
     defaultOn: true
   },
   {
-    id: 'motion',
-    what: 'motion without user request',
-    contaminates: false,
-    needsAccessibleName: false,
-    // The budget must cover a full-page screenshot (itself allowed 4 seconds in
-    // procs/shoot.js), decoding two full-page PNGs, and a pixel comparison; 5
-    // seconds made the rule time out whenever an initial image existed.
-    timeOut: 30,
-    defaultOn: true
-  },
-  {
     id: 'dupAtt',
     what: 'duplicate attribute values',
     contaminates: false,
@@ -391,6 +380,17 @@ const allRules: RuleMeta[] = [
     contaminates: false,
     needsAccessibleName: true,
     timeOut: 5,
+    defaultOn: true
+  },
+  {
+    id: 'motion',
+    what: 'motion without user request',
+    contaminates: true,
+    needsAccessibleName: false,
+    // The budget must cover a full-page screenshot (itself allowed 4 seconds in
+    // procs/shoot.js), decoding two full-page PNGs, and a pixel comparison; 5
+    // seconds made the rule time out whenever an initial image existed.
+    timeOut: 30,
     defaultOn: true
   },
   {


### PR DESCRIPTION
The test of the motion rule of the `testaro` rule engine delivers false positive results if the tested page contains `details` elements that are closed, because the test compares an image of the page as it exists with the catalog image, which was made only after all `details` elements were forced open.

This change corrects that error by opening all closed `details` elements before the motion image is made. If the expansion fails, the test is aborted with a relevant error message.

The same test also reports the fraction of all pixels that changed, but the denominator is the pixel count of the entire page. A typical page has a background of uniform color that is covered only fractionally by foreground content. If all of that content disappears or is replaced with other content in situ, the perceived change is probably about 100%, but the reported change may be about 2%. Pending a more sophisticated approximation of perceived change, the revised test reports the count of changed pixels instead of the fraction, and the ordinalSeverity computation is now based on that count.

Since the `motion` test now opens closed `details` elements, it is reclassified as contaminating in `tests/testaro.ts` and is moved to be adjacent to other contaminating tests.