### PR TITLE
fix: correct bugs in testaro targetsNear test

### DIFF
--- a/testaro/targetsNear.js
+++ b/testaro/targetsNear.js
@@ -140,14 +140,10 @@ const reporter = async (page, report, _, withItems) => {
         const { xPath } = instance;
         // If the instance has an XPath:
         if (xPath) {
-            // Get its catalog index.
-            const catalogIndex = (0, xPath_1.getXPathCatalogIndex)(report, xPath);
-            // If this succeeded:
-            if (catalogIndex) {
-                // Replace the XPath with the catalog index.
-                instance.catalogIndex = catalogIndex;
-                delete instance.xPath;
-            }
+            // Ensure the catalog index of the instance is that with the XPath.
+            instance.catalogIndex = (0, xPath_1.getXPathCatalogIndex)(report, xPath);
+            // Delete the XPath from the instance.
+            delete instance.xPath;
         }
         return instance;
     });

--- a/testaro/targetsNear.js
+++ b/testaro/targetsNear.js
@@ -114,7 +114,7 @@ const reporter = async (page, report, _, withItems) => {
                 protoInstances.push({
                     ruleID: 'targetsNear',
                     what: 'Pointer-target centerpoints are less than 24px from others',
-                    ordinalSeverity: 1,
+                    ordinalSeverity: 3,
                     count: violationCounts[1]
                 });
             }
@@ -124,26 +124,31 @@ const reporter = async (page, report, _, withItems) => {
                 protoInstances.push({
                     ruleID: 'targetsNear',
                     what: 'Pointer-target centerpoints are less than 44px from others',
-                    ordinalSeverity: 0,
+                    ordinalSeverity: 2,
                     count: violationCounts[0]
                 });
             }
         }
         return {
             data: {},
-            totals: [...violationCounts, 0, 0],
+            totals: [0, 0, ...violationCounts],
             standardInstances: protoInstances
         };
     }, withItems);
     // Convert the XPaths of the proto-instances to catalog indexes.
     protoResult.standardInstances = protoResult.standardInstances.map(instance => {
-        /*
-          Summary instances (withItems false) carry no xPath, so this passes undefined and
-          getXPathTagName throws, marking the rule prevented. Preserved verbatim from the
-          JavaScript original; flagged for a behavior-correcting follow-up.
-        */
-        instance.catalogIndex = (0, xPath_1.getXPathCatalogIndex)(report, instance.xPath);
-        delete instance.xPath;
+        const { xPath } = instance;
+        // If the instance has an XPath:
+        if (xPath) {
+            // Get its catalog index.
+            const catalogIndex = (0, xPath_1.getXPathCatalogIndex)(report, xPath);
+            // If this succeeded:
+            if (catalogIndex) {
+                // Replace the XPath with the catalog index.
+                instance.catalogIndex = catalogIndex;
+                delete instance.xPath;
+            }
+        }
         return instance;
     });
     // Return the result.

--- a/testaro/targetsNear.ts
+++ b/testaro/targetsNear.ts
@@ -151,14 +151,10 @@ export const reporter = async (page: Page, report: Report, _: unknown, withItems
     const {xPath} = instance;
     // If the instance has an XPath:
     if (xPath) {
-      // Get its catalog index.
-      const catalogIndex = getXPathCatalogIndex(report, xPath as string);
-      // If this succeeded:
-      if (catalogIndex) {
-        // Replace the XPath with the catalog index.
-        instance.catalogIndex = catalogIndex;
-        delete instance.xPath;
-      }
+      // Ensure the catalog index of the instance is that with the XPath.
+      instance.catalogIndex = getXPathCatalogIndex(report, xPath as string);
+      // Delete the XPath from the instance.
+      delete instance.xPath;
     }
     return instance;
   });

--- a/testaro/targetsNear.ts
+++ b/testaro/targetsNear.ts
@@ -125,7 +125,7 @@ export const reporter = async (page: Page, report: Report, _: unknown, withItems
         protoInstances.push({
           ruleID: 'targetsNear',
           what: 'Pointer-target centerpoints are less than 24px from others',
-          ordinalSeverity: 1,
+          ordinalSeverity: 3,
           count: violationCounts[1]
         });
       }
@@ -135,26 +135,31 @@ export const reporter = async (page: Page, report: Report, _: unknown, withItems
         protoInstances.push({
           ruleID: 'targetsNear',
           what: 'Pointer-target centerpoints are less than 44px from others',
-          ordinalSeverity: 0,
+          ordinalSeverity: 2,
           count: violationCounts[0]
         });
       }
     }
     return {
       data: {},
-      totals: [...violationCounts, 0, 0],
+      totals: [0, 0, ...violationCounts],
       standardInstances: protoInstances
     };
   }, withItems);
   // Convert the XPaths of the proto-instances to catalog indexes.
   protoResult.standardInstances = protoResult.standardInstances.map(instance => {
-    /*
-      Summary instances (withItems false) carry no xPath, so this passes undefined and
-      getXPathTagName throws, marking the rule prevented. Preserved verbatim from the
-      JavaScript original; flagged for a behavior-correcting follow-up.
-    */
-    instance.catalogIndex = getXPathCatalogIndex(report, instance.xPath as string);
-    delete instance.xPath;
+    const {xPath} = instance;
+    // If the instance has an XPath:
+    if (xPath) {
+      // Get its catalog index.
+      const catalogIndex = getXPathCatalogIndex(report, xPath as string);
+      // If this succeeded:
+      if (catalogIndex) {
+        // Replace the XPath with the catalog index.
+        instance.catalogIndex = catalogIndex;
+        delete instance.xPath;
+      }
+    }
     return instance;
   });
   // Return the result.


### PR DESCRIPTION
Correct bugs in the test of `targetsNear` rule of the `testaro` rule engine:

1. Reporting of incorrect ordinal severities.
2. Incrementing of totals of incorrect ordinal severities.
3. Attempts to read a property of undefined instance XPaths.

This revision resolves issue #108.