### PR TITLE
fix: correct typo in testaro buttonMenu test

### DIFF
--- a/testaro/buttonMenu.js
+++ b/testaro/buttonMenu.js
@@ -255,7 +255,7 @@ const reporter = async (page, report, _0, withItems, trialKeySpecs = []) => {
                                     trialKeys.push(extraData.orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp');
                                 }
                                 else if (spec === '+') {
-                                    trialKeys.push(extraData.orientation === 'horizontal' ? 'ArrowtRight' : 'ArrowDown');
+                                    trialKeys.push(extraData.orientation === 'horizontal' ? 'ArrowRight' : 'ArrowDown');
                                 }
                             });
                         }

--- a/testaro/buttonMenu.ts
+++ b/testaro/buttonMenu.ts
@@ -285,7 +285,7 @@ export const reporter = async (
                 }
                 else if (spec === '+') {
                   trialKeys.push(
-                    extraData.orientation === 'horizontal' ? 'ArrowtRight' : 'ArrowDown'
+                    extraData.orientation === 'horizontal' ? 'ArrowRight' : 'ArrowDown'
                   );
                 }
               });

--- a/validation/tests/jobProperties/buttonMenu.json
+++ b/validation/tests/jobProperties/buttonMenu.json
@@ -38,6 +38,41 @@
     },
     {
       "type": "url",
+      "which": "file://validation/tests/targets/buttonMenu/horizontalGood.html",
+      "what": "page with standard horizontal button menu navigation"
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": true,
+      "args": {
+        "buttonMenu": [["+"]]
+      },
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.totals.2",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.length",
+          "=",
+          0
+        ]
+      ],
+      "rules": [
+        "y",
+        "buttonMenu"
+      ]
+    },
+    {
+      "type": "url",
       "which": "file://validation/tests/targets/buttonMenu/bad.html",
       "what": "page with deviant menu navigation"
     },

--- a/validation/tests/targets/buttonMenu/horizontalGood.html
+++ b/validation/tests/targets/buttonMenu/horizontalGood.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<!--
+  © 2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+-->
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+    <title>Page with standard horizontal button menu navigation</title>
+    <meta name="description" content="tester">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="style.css">
+    <script src="horizontalGood.js" defer></script>
+  </head>
+  <body>
+    <main>
+      <h1>Page with standard horizontal button menu navigation</h1>
+      <button
+        id="hButton"
+        type="button"
+        tabindex="0"
+        aria-haspopup="true"
+        aria-expanded="false"
+        aria-controls="hMenu"
+      >
+        Open horizontal menu
+      </button>
+      <ul id="hMenu" role="menubar" class="shut" aria-labelledby="hButton">
+        <li role="none">
+          <button id="hOne" role="menuitem" type="button" tabindex="-1">
+            One
+          </button>
+        </li>
+        <li role="none">
+          <button id="hTwo" role="menuitem" type="button" tabindex="-1">
+            Two
+          </button>
+        </li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/validation/tests/targets/buttonMenu/horizontalGood.js
+++ b/validation/tests/targets/buttonMenu/horizontalGood.js
@@ -1,0 +1,61 @@
+/*
+  © 2026 Jonathan Robert Pool.
+
+  Licensed under the MIT License. See LICENSE file at the project root or
+  https://opensource.org/license/mit/ for details.
+
+  SPDX-License-Identifier: MIT
+*/
+
+/*
+  horizontalGood.js
+  Script for validation/tests/targets/buttonMenu/horizontalGood.html
+*/
+
+const button = document.getElementById('hButton');
+const menu = document.getElementById('hMenu');
+const items = Array.from(menu.querySelectorAll('[role=menuitem]'));
+
+const setActive = index => {
+  items.forEach((item, itemIndex) => {
+    item.tabIndex = itemIndex === index ? 0 : -1;
+  });
+  items[index].focus();
+};
+
+const openMenu = () => {
+  button.setAttribute('aria-expanded', 'true');
+  menu.className = 'open';
+  setActive(0);
+};
+
+button.addEventListener('keydown', event => {
+  if (event.key === 'ArrowRight') {
+    event.preventDefault();
+    openMenu();
+  }
+});
+
+menu.addEventListener('keydown', event => {
+  const oldIndex = items.indexOf(document.activeElement);
+  let newIndex = oldIndex;
+  if (event.key === 'ArrowRight') {
+    event.preventDefault();
+    newIndex = (oldIndex + 1) % items.length;
+  }
+  else if (event.key === 'ArrowLeft') {
+    event.preventDefault();
+    newIndex = (items.length + oldIndex - 1) % items.length;
+  }
+  else if (event.key === 'Home') {
+    event.preventDefault();
+    newIndex = 0;
+  }
+  else if (event.key === 'End') {
+    event.preventDefault();
+    newIndex = items.length - 1;
+  }
+  if (newIndex !== oldIndex) {
+    setActive(newIndex);
+  }
+});


### PR DESCRIPTION
Correct `ArrowtRight` to `ArrowRight`. Resolves issue #111.

A validation target and test for the ArrowRight keypress was added by Copilot. However, the existing validations are partly broken because they expect standard instances to have properties such as `tagName` that they no longer have. That is another bug, which may exist in the tests for multiple rules, and this pull request does not correct it.